### PR TITLE
feat(api): add initial JPA domain models

### DIFF
--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/arrangement/Arrangement.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/arrangement/Arrangement.java
@@ -1,0 +1,90 @@
+package com.homeputers.ebal2.api.domain.arrangement;
+
+import com.homeputers.ebal2.api.domain.song.Song;
+import jakarta.persistence.*;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity
+@Table(name = "arrangements")
+public class Arrangement {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "song_id")
+    private Song song;
+
+    private String key;
+
+    private Integer bpm;
+
+    private String meter;
+
+    @Column(name = "lyrics_chordpro")
+    private String lyricsChordpro;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public Song getSong() {
+        return song;
+    }
+
+    public void setSong(Song song) {
+        this.song = song;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public Integer getBpm() {
+        return bpm;
+    }
+
+    public void setBpm(Integer bpm) {
+        this.bpm = bpm;
+    }
+
+    public String getMeter() {
+        return meter;
+    }
+
+    public void setMeter(String meter) {
+        this.meter = meter;
+    }
+
+    public String getLyricsChordpro() {
+        return lyricsChordpro;
+    }
+
+    public void setLyricsChordpro(String lyricsChordpro) {
+        this.lyricsChordpro = lyricsChordpro;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Arrangement that = (Arrangement) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/arrangement/Arrangement.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/arrangement/Arrangement.java
@@ -1,78 +1,39 @@
 package com.homeputers.ebal2.api.domain.arrangement;
 
 import com.homeputers.ebal2.api.domain.song.Song;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 
 import java.util.Objects;
 import java.util.UUID;
 
 @Entity
 @Table(name = "arrangements")
-public class Arrangement {
+public record Arrangement(
+        @Id
+        @GeneratedValue
+        UUID id,
 
-    @Id
-    @GeneratedValue
-    private UUID id;
+        @ManyToOne
+        @JoinColumn(name = "song_id")
+        Song song,
 
-    @ManyToOne
-    @JoinColumn(name = "song_id")
-    private Song song;
+        String key,
+        Integer bpm,
+        String meter,
 
-    private String key;
-
-    private Integer bpm;
-
-    private String meter;
-
-    @Column(name = "lyrics_chordpro")
-    private String lyricsChordpro;
-
-    public UUID getId() {
-        return id;
-    }
-
-    public void setId(UUID id) {
-        this.id = id;
-    }
-
-    public Song getSong() {
-        return song;
-    }
-
-    public void setSong(Song song) {
-        this.song = song;
-    }
-
-    public String getKey() {
-        return key;
-    }
-
-    public void setKey(String key) {
-        this.key = key;
-    }
-
-    public Integer getBpm() {
-        return bpm;
-    }
-
-    public void setBpm(Integer bpm) {
-        this.bpm = bpm;
-    }
-
-    public String getMeter() {
-        return meter;
-    }
-
-    public void setMeter(String meter) {
-        this.meter = meter;
-    }
-
-    public String getLyricsChordpro() {
-        return lyricsChordpro;
-    }
-
-    public void setLyricsChordpro(String lyricsChordpro) {
-        this.lyricsChordpro = lyricsChordpro;
+        @Column(name = "lyrics_chordpro")
+        String lyricsChordpro
+) {
+    public Arrangement {
+        if (id == null) {
+            id = UUID.randomUUID();
+        }
     }
 
     @Override
@@ -88,3 +49,4 @@ public class Arrangement {
         return Objects.hash(id);
     }
 }
+

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/arrangement/ArrangementRepository.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/arrangement/ArrangementRepository.java
@@ -1,0 +1,8 @@
+package com.homeputers.ebal2.api.domain.arrangement;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ArrangementRepository extends JpaRepository<Arrangement, UUID> {
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/group/Group.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/group/Group.java
@@ -1,7 +1,12 @@
 package com.homeputers.ebal2.api.domain.group;
 
 import com.homeputers.ebal2.api.domain.groupmember.GroupMember;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 
 import java.util.HashSet;
 import java.util.Objects;
@@ -10,40 +15,24 @@ import java.util.UUID;
 
 @Entity
 @Table(name = "groups")
-public class Group {
+public record Group(
+        @Id
+        @GeneratedValue
+        UUID id,
 
-    @Id
-    @GeneratedValue
-    private UUID id;
+        @Column(unique = true)
+        String name,
 
-    @Column(unique = true)
-    private String name;
-
-    @OneToMany(mappedBy = "group")
-    private Set<GroupMember> members = new HashSet<>();
-
-    public UUID getId() {
-        return id;
-    }
-
-    public void setId(UUID id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public Set<GroupMember> getMembers() {
-        return members;
-    }
-
-    public void setMembers(Set<GroupMember> members) {
-        this.members = members;
+        @OneToMany(mappedBy = "group")
+        Set<GroupMember> members
+) {
+    public Group {
+        if (id == null) {
+            id = UUID.randomUUID();
+        }
+        if (members == null) {
+            members = new HashSet<>();
+        }
     }
 
     @Override
@@ -59,3 +48,4 @@ public class Group {
         return Objects.hash(id);
     }
 }
+

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/group/Group.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/group/Group.java
@@ -1,0 +1,61 @@
+package com.homeputers.ebal2.api.domain.group;
+
+import com.homeputers.ebal2.api.domain.groupmember.GroupMember;
+import jakarta.persistence.*;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+@Entity
+@Table(name = "groups")
+public class Group {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(unique = true)
+    private String name;
+
+    @OneToMany(mappedBy = "group")
+    private Set<GroupMember> members = new HashSet<>();
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Set<GroupMember> getMembers() {
+        return members;
+    }
+
+    public void setMembers(Set<GroupMember> members) {
+        this.members = members;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Group group = (Group) o;
+        return Objects.equals(id, group.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/group/GroupRepository.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/group/GroupRepository.java
@@ -1,0 +1,8 @@
+package com.homeputers.ebal2.api.domain.group;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface GroupRepository extends JpaRepository<Group, UUID> {
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/groupmember/GroupMember.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/groupmember/GroupMember.java
@@ -2,49 +2,38 @@ package com.homeputers.ebal2.api.domain.groupmember;
 
 import com.homeputers.ebal2.api.domain.group.Group;
 import com.homeputers.ebal2.api.domain.member.Member;
-import jakarta.persistence.*;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
 
 import java.util.Objects;
 
 @Entity
 @Table(name = "group_members")
-public class GroupMember {
+public record GroupMember(
+        @EmbeddedId
+        GroupMemberId id,
 
-    @EmbeddedId
-    private GroupMemberId id = new GroupMemberId();
+        @ManyToOne
+        @MapsId("groupId")
+        @JoinColumn(name = "group_id")
+        Group group,
 
-    @ManyToOne
-    @MapsId("groupId")
-    @JoinColumn(name = "group_id")
-    private Group group;
-
-    @ManyToOne
-    @MapsId("memberId")
-    @JoinColumn(name = "member_id")
-    private Member member;
-
-    public GroupMemberId getId() {
-        return id;
-    }
-
-    public void setId(GroupMemberId id) {
-        this.id = id;
-    }
-
-    public Group getGroup() {
-        return group;
-    }
-
-    public void setGroup(Group group) {
-        this.group = group;
-    }
-
-    public Member getMember() {
-        return member;
-    }
-
-    public void setMember(Member member) {
-        this.member = member;
+        @ManyToOne
+        @MapsId("memberId")
+        @JoinColumn(name = "member_id")
+        Member member
+) {
+    public GroupMember {
+        if (id == null) {
+            id = new GroupMemberId(
+                    group != null ? group.id() : null,
+                    member != null ? member.id() : null
+            );
+        }
     }
 
     @Override
@@ -60,3 +49,4 @@ public class GroupMember {
         return Objects.hash(id);
     }
 }
+

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/groupmember/GroupMember.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/groupmember/GroupMember.java
@@ -1,0 +1,62 @@
+package com.homeputers.ebal2.api.domain.groupmember;
+
+import com.homeputers.ebal2.api.domain.group.Group;
+import com.homeputers.ebal2.api.domain.member.Member;
+import jakarta.persistence.*;
+
+import java.util.Objects;
+
+@Entity
+@Table(name = "group_members")
+public class GroupMember {
+
+    @EmbeddedId
+    private GroupMemberId id = new GroupMemberId();
+
+    @ManyToOne
+    @MapsId("groupId")
+    @JoinColumn(name = "group_id")
+    private Group group;
+
+    @ManyToOne
+    @MapsId("memberId")
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    public GroupMemberId getId() {
+        return id;
+    }
+
+    public void setId(GroupMemberId id) {
+        this.id = id;
+    }
+
+    public Group getGroup() {
+        return group;
+    }
+
+    public void setGroup(Group group) {
+        this.group = group;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public void setMember(Member member) {
+        this.member = member;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GroupMember that = (GroupMember) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/groupmember/GroupMemberId.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/groupmember/GroupMemberId.java
@@ -1,0 +1,43 @@
+package com.homeputers.ebal2.api.domain.groupmember;
+
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.UUID;
+
+@Embeddable
+public class GroupMemberId implements Serializable {
+
+    private UUID groupId;
+    private UUID memberId;
+
+    public UUID getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(UUID groupId) {
+        this.groupId = groupId;
+    }
+
+    public UUID getMemberId() {
+        return memberId;
+    }
+
+    public void setMemberId(UUID memberId) {
+        this.memberId = memberId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GroupMemberId that = (GroupMemberId) o;
+        return Objects.equals(groupId, that.groupId) && Objects.equals(memberId, that.memberId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(groupId, memberId);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/groupmember/GroupMemberId.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/groupmember/GroupMemberId.java
@@ -3,41 +3,9 @@ package com.homeputers.ebal2.api.domain.groupmember;
 import jakarta.persistence.Embeddable;
 
 import java.io.Serializable;
-import java.util.Objects;
 import java.util.UUID;
 
 @Embeddable
-public class GroupMemberId implements Serializable {
-
-    private UUID groupId;
-    private UUID memberId;
-
-    public UUID getGroupId() {
-        return groupId;
-    }
-
-    public void setGroupId(UUID groupId) {
-        this.groupId = groupId;
-    }
-
-    public UUID getMemberId() {
-        return memberId;
-    }
-
-    public void setMemberId(UUID memberId) {
-        this.memberId = memberId;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        GroupMemberId that = (GroupMemberId) o;
-        return Objects.equals(groupId, that.groupId) && Objects.equals(memberId, that.memberId);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(groupId, memberId);
-    }
+public record GroupMemberId(UUID groupId, UUID memberId) implements Serializable {
 }
+

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/groupmember/GroupMemberRepository.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/groupmember/GroupMemberRepository.java
@@ -1,0 +1,6 @@
+package com.homeputers.ebal2.api.domain.groupmember;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupMemberRepository extends JpaRepository<GroupMember, GroupMemberId> {
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/member/Member.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/member/Member.java
@@ -1,6 +1,10 @@
 package com.homeputers.ebal2.api.domain.member;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
@@ -11,41 +15,25 @@ import java.util.UUID;
 
 @Entity
 @Table(name = "members")
-public class Member {
+public record Member(
+        @Id
+        @GeneratedValue
+        UUID id,
 
-    @Id
-    @GeneratedValue
-    private UUID id;
+        @Column(name = "display_name")
+        String displayName,
 
-    @Column(name = "display_name")
-    private String displayName;
-
-    @JdbcTypeCode(SqlTypes.ARRAY)
-    @Column(name = "instruments", columnDefinition = "text[]")
-    private List<String> instruments = new ArrayList<>();
-
-    public UUID getId() {
-        return id;
-    }
-
-    public void setId(UUID id) {
-        this.id = id;
-    }
-
-    public String getDisplayName() {
-        return displayName;
-    }
-
-    public void setDisplayName(String displayName) {
-        this.displayName = displayName;
-    }
-
-    public List<String> getInstruments() {
-        return instruments;
-    }
-
-    public void setInstruments(List<String> instruments) {
-        this.instruments = instruments;
+        @JdbcTypeCode(SqlTypes.ARRAY)
+        @Column(name = "instruments", columnDefinition = "text[]")
+        List<String> instruments
+) {
+    public Member {
+        if (id == null) {
+            id = UUID.randomUUID();
+        }
+        if (instruments == null) {
+            instruments = new ArrayList<>();
+        }
     }
 
     @Override
@@ -61,3 +49,4 @@ public class Member {
         return Objects.hash(id);
     }
 }
+

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/member/Member.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/member/Member.java
@@ -1,0 +1,63 @@
+package com.homeputers.ebal2.api.domain.member;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity
+@Table(name = "members")
+public class Member {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(name = "display_name")
+    private String displayName;
+
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    @Column(name = "instruments", columnDefinition = "text[]")
+    private List<String> instruments = new ArrayList<>();
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public List<String> getInstruments() {
+        return instruments;
+    }
+
+    public void setInstruments(List<String> instruments) {
+        this.instruments = instruments;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Member member = (Member) o;
+        return Objects.equals(id, member.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/member/MemberRepository.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/member/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.homeputers.ebal2.api.domain.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface MemberRepository extends JpaRepository<Member, UUID> {
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/service/Service.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/service/Service.java
@@ -1,0 +1,58 @@
+package com.homeputers.ebal2.api.domain.service;
+
+import jakarta.persistence.*;
+
+import java.time.OffsetDateTime;
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity
+@Table(name = "services")
+public class Service {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(name = "starts_at")
+    private OffsetDateTime startsAt;
+
+    private String location;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public OffsetDateTime getStartsAt() {
+        return startsAt;
+    }
+
+    public void setStartsAt(OffsetDateTime startsAt) {
+        this.startsAt = startsAt;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Service service = (Service) o;
+        return Objects.equals(id, service.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/service/Service.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/service/Service.java
@@ -1,6 +1,10 @@
 package com.homeputers.ebal2.api.domain.service;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 import java.time.OffsetDateTime;
 import java.util.Objects;
@@ -8,39 +12,20 @@ import java.util.UUID;
 
 @Entity
 @Table(name = "services")
-public class Service {
+public record Service(
+        @Id
+        @GeneratedValue
+        UUID id,
 
-    @Id
-    @GeneratedValue
-    private UUID id;
+        @Column(name = "starts_at")
+        OffsetDateTime startsAt,
 
-    @Column(name = "starts_at")
-    private OffsetDateTime startsAt;
-
-    private String location;
-
-    public UUID getId() {
-        return id;
-    }
-
-    public void setId(UUID id) {
-        this.id = id;
-    }
-
-    public OffsetDateTime getStartsAt() {
-        return startsAt;
-    }
-
-    public void setStartsAt(OffsetDateTime startsAt) {
-        this.startsAt = startsAt;
-    }
-
-    public String getLocation() {
-        return location;
-    }
-
-    public void setLocation(String location) {
-        this.location = location;
+        String location
+) {
+    public Service {
+        if (id == null) {
+            id = UUID.randomUUID();
+        }
     }
 
     @Override
@@ -56,3 +41,4 @@ public class Service {
         return Objects.hash(id);
     }
 }
+

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/service/ServiceRepository.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/service/ServiceRepository.java
@@ -1,0 +1,8 @@
+package com.homeputers.ebal2.api.domain.service;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ServiceRepository extends JpaRepository<Service, UUID> {
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/serviceplanitem/ServicePlanItem.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/serviceplanitem/ServicePlanItem.java
@@ -1,0 +1,91 @@
+package com.homeputers.ebal2.api.domain.serviceplanitem;
+
+import com.homeputers.ebal2.api.domain.service.Service;
+import jakarta.persistence.*;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity
+@Table(name = "service_plan_items")
+public class ServicePlanItem {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "service_id")
+    private Service service;
+
+    private String type;
+
+    @Column(name = "ref_id")
+    private UUID refId;
+
+    @Column(name = "\"order\"")
+    private Integer sortOrder;
+
+    private String notes;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public Service getService() {
+        return service;
+    }
+
+    public void setService(Service service) {
+        this.service = service;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public UUID getRefId() {
+        return refId;
+    }
+
+    public void setRefId(UUID refId) {
+        this.refId = refId;
+    }
+
+    public Integer getSortOrder() {
+        return sortOrder;
+    }
+
+    public void setSortOrder(Integer sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ServicePlanItem that = (ServicePlanItem) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/serviceplanitem/ServicePlanItem.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/serviceplanitem/ServicePlanItem.java
@@ -1,79 +1,42 @@
 package com.homeputers.ebal2.api.domain.serviceplanitem;
 
 import com.homeputers.ebal2.api.domain.service.Service;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 
 import java.util.Objects;
 import java.util.UUID;
 
 @Entity
 @Table(name = "service_plan_items")
-public class ServicePlanItem {
+public record ServicePlanItem(
+        @Id
+        @GeneratedValue
+        UUID id,
 
-    @Id
-    @GeneratedValue
-    private UUID id;
+        @ManyToOne
+        @JoinColumn(name = "service_id")
+        Service service,
 
-    @ManyToOne
-    @JoinColumn(name = "service_id")
-    private Service service;
+        String type,
 
-    private String type;
+        @Column(name = "ref_id")
+        UUID refId,
 
-    @Column(name = "ref_id")
-    private UUID refId;
+        @Column(name = "\"order\"")
+        Integer sortOrder,
 
-    @Column(name = "\"order\"")
-    private Integer sortOrder;
-
-    private String notes;
-
-    public UUID getId() {
-        return id;
-    }
-
-    public void setId(UUID id) {
-        this.id = id;
-    }
-
-    public Service getService() {
-        return service;
-    }
-
-    public void setService(Service service) {
-        this.service = service;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
-    }
-
-    public UUID getRefId() {
-        return refId;
-    }
-
-    public void setRefId(UUID refId) {
-        this.refId = refId;
-    }
-
-    public Integer getSortOrder() {
-        return sortOrder;
-    }
-
-    public void setSortOrder(Integer sortOrder) {
-        this.sortOrder = sortOrder;
-    }
-
-    public String getNotes() {
-        return notes;
-    }
-
-    public void setNotes(String notes) {
-        this.notes = notes;
+        String notes
+) {
+    public ServicePlanItem {
+        if (id == null) {
+            id = UUID.randomUUID();
+        }
     }
 
     @Override
@@ -89,3 +52,4 @@ public class ServicePlanItem {
         return Objects.hash(id);
     }
 }
+

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/serviceplanitem/ServicePlanItemRepository.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/serviceplanitem/ServicePlanItemRepository.java
@@ -1,0 +1,8 @@
+package com.homeputers.ebal2.api.domain.serviceplanitem;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ServicePlanItemRepository extends JpaRepository<ServicePlanItem, UUID> {
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/song/Song.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/song/Song.java
@@ -1,6 +1,10 @@
 package com.homeputers.ebal2.api.domain.song;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
@@ -11,69 +15,29 @@ import java.util.UUID;
 
 @Entity
 @Table(name = "songs")
-public class Song {
+public record Song(
+        @Id
+        @GeneratedValue
+        UUID id,
 
-    @Id
-    @GeneratedValue
-    private UUID id;
+        String title,
+        String ccli,
+        String author,
 
-    private String title;
-    private String ccli;
-    private String author;
+        @Column(name = "default_key")
+        String defaultKey,
 
-    @Column(name = "default_key")
-    private String defaultKey;
-
-    @JdbcTypeCode(SqlTypes.ARRAY)
-    @Column(name = "tags", columnDefinition = "text[]")
-    private List<String> tags = new ArrayList<>();
-
-    public UUID getId() {
-        return id;
-    }
-
-    public void setId(UUID id) {
-        this.id = id;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public String getCcli() {
-        return ccli;
-    }
-
-    public void setCcli(String ccli) {
-        this.ccli = ccli;
-    }
-
-    public String getAuthor() {
-        return author;
-    }
-
-    public void setAuthor(String author) {
-        this.author = author;
-    }
-
-    public String getDefaultKey() {
-        return defaultKey;
-    }
-
-    public void setDefaultKey(String defaultKey) {
-        this.defaultKey = defaultKey;
-    }
-
-    public List<String> getTags() {
-        return tags;
-    }
-
-    public void setTags(List<String> tags) {
-        this.tags = tags;
+        @JdbcTypeCode(SqlTypes.ARRAY)
+        @Column(name = "tags", columnDefinition = "text[]")
+        List<String> tags
+) {
+    public Song {
+        if (id == null) {
+            id = UUID.randomUUID();
+        }
+        if (tags == null) {
+            tags = new ArrayList<>();
+        }
     }
 
     @Override
@@ -89,3 +53,4 @@ public class Song {
         return Objects.hash(id);
     }
 }
+

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/song/Song.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/song/Song.java
@@ -1,0 +1,91 @@
+package com.homeputers.ebal2.api.domain.song;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity
+@Table(name = "songs")
+public class Song {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    private String title;
+    private String ccli;
+    private String author;
+
+    @Column(name = "default_key")
+    private String defaultKey;
+
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    @Column(name = "tags", columnDefinition = "text[]")
+    private List<String> tags = new ArrayList<>();
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getCcli() {
+        return ccli;
+    }
+
+    public void setCcli(String ccli) {
+        this.ccli = ccli;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    public String getDefaultKey() {
+        return defaultKey;
+    }
+
+    public void setDefaultKey(String defaultKey) {
+        this.defaultKey = defaultKey;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Song song = (Song) o;
+        return Objects.equals(id, song.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/song/SongRepository.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/song/SongRepository.java
@@ -1,0 +1,8 @@
+package com.homeputers.ebal2.api.domain.song;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface SongRepository extends JpaRepository<Song, UUID> {
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/songset/SongSet.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/songset/SongSet.java
@@ -1,34 +1,25 @@
 package com.homeputers.ebal2.api.domain.songset;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 import java.util.Objects;
 import java.util.UUID;
 
 @Entity
 @Table(name = "song_sets")
-public class SongSet {
-
-    @Id
-    @GeneratedValue
-    private UUID id;
-
-    private String name;
-
-    public UUID getId() {
-        return id;
-    }
-
-    public void setId(UUID id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
+public record SongSet(
+        @Id
+        @GeneratedValue
+        UUID id,
+        String name
+) {
+    public SongSet {
+        if (id == null) {
+            id = UUID.randomUUID();
+        }
     }
 
     @Override
@@ -44,3 +35,4 @@ public class SongSet {
         return Objects.hash(id);
     }
 }
+

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/songset/SongSet.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/songset/SongSet.java
@@ -1,0 +1,46 @@
+package com.homeputers.ebal2.api.domain.songset;
+
+import jakarta.persistence.*;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity
+@Table(name = "song_sets")
+public class SongSet {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    private String name;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SongSet songSet = (SongSet) o;
+        return Objects.equals(id, songSet.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/songset/SongSetRepository.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/songset/SongSetRepository.java
@@ -1,0 +1,8 @@
+package com.homeputers.ebal2.api.domain.songset;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface SongSetRepository extends JpaRepository<SongSet, UUID> {
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/songsetitem/SongSetItem.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/songsetitem/SongSetItem.java
@@ -1,0 +1,93 @@
+package com.homeputers.ebal2.api.domain.songsetitem;
+
+import com.homeputers.ebal2.api.domain.arrangement.Arrangement;
+import com.homeputers.ebal2.api.domain.songset.SongSet;
+import jakarta.persistence.*;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity
+@Table(name = "song_set_items")
+public class SongSetItem {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "song_set_id")
+    private SongSet songSet;
+
+    @ManyToOne
+    @JoinColumn(name = "arrangement_id")
+    private Arrangement arrangement;
+
+    @Column(name = "\"order\"")
+    private Integer sortOrder;
+
+    private Integer transpose;
+
+    private Integer capo;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public SongSet getSongSet() {
+        return songSet;
+    }
+
+    public void setSongSet(SongSet songSet) {
+        this.songSet = songSet;
+    }
+
+    public Arrangement getArrangement() {
+        return arrangement;
+    }
+
+    public void setArrangement(Arrangement arrangement) {
+        this.arrangement = arrangement;
+    }
+
+    public Integer getSortOrder() {
+        return sortOrder;
+    }
+
+    public void setSortOrder(Integer sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    public Integer getTranspose() {
+        return transpose;
+    }
+
+    public void setTranspose(Integer transpose) {
+        this.transpose = transpose;
+    }
+
+    public Integer getCapo() {
+        return capo;
+    }
+
+    public void setCapo(Integer capo) {
+        this.capo = capo;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SongSetItem that = (SongSetItem) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/songsetitem/SongSetItem.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/songsetitem/SongSetItem.java
@@ -2,80 +2,42 @@ package com.homeputers.ebal2.api.domain.songsetitem;
 
 import com.homeputers.ebal2.api.domain.arrangement.Arrangement;
 import com.homeputers.ebal2.api.domain.songset.SongSet;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 
 import java.util.Objects;
 import java.util.UUID;
 
 @Entity
 @Table(name = "song_set_items")
-public class SongSetItem {
+public record SongSetItem(
+        @Id
+        @GeneratedValue
+        UUID id,
 
-    @Id
-    @GeneratedValue
-    private UUID id;
+        @ManyToOne
+        @JoinColumn(name = "song_set_id")
+        SongSet songSet,
 
-    @ManyToOne
-    @JoinColumn(name = "song_set_id")
-    private SongSet songSet;
+        @ManyToOne
+        @JoinColumn(name = "arrangement_id")
+        Arrangement arrangement,
 
-    @ManyToOne
-    @JoinColumn(name = "arrangement_id")
-    private Arrangement arrangement;
+        @Column(name = "\"order\"")
+        Integer sortOrder,
 
-    @Column(name = "\"order\"")
-    private Integer sortOrder;
-
-    private Integer transpose;
-
-    private Integer capo;
-
-    public UUID getId() {
-        return id;
-    }
-
-    public void setId(UUID id) {
-        this.id = id;
-    }
-
-    public SongSet getSongSet() {
-        return songSet;
-    }
-
-    public void setSongSet(SongSet songSet) {
-        this.songSet = songSet;
-    }
-
-    public Arrangement getArrangement() {
-        return arrangement;
-    }
-
-    public void setArrangement(Arrangement arrangement) {
-        this.arrangement = arrangement;
-    }
-
-    public Integer getSortOrder() {
-        return sortOrder;
-    }
-
-    public void setSortOrder(Integer sortOrder) {
-        this.sortOrder = sortOrder;
-    }
-
-    public Integer getTranspose() {
-        return transpose;
-    }
-
-    public void setTranspose(Integer transpose) {
-        this.transpose = transpose;
-    }
-
-    public Integer getCapo() {
-        return capo;
-    }
-
-    public void setCapo(Integer capo) {
-        this.capo = capo;
+        Integer transpose,
+        Integer capo
+) {
+    public SongSetItem {
+        if (id == null) {
+            id = UUID.randomUUID();
+        }
     }
 
     @Override
@@ -91,3 +53,4 @@ public class SongSetItem {
         return Objects.hash(id);
     }
 }
+

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/songsetitem/SongSetItemRepository.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/songsetitem/SongSetItemRepository.java
@@ -1,0 +1,8 @@
+package com.homeputers.ebal2.api.domain.songsetitem;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface SongSetItemRepository extends JpaRepository<SongSetItem, UUID> {
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/User.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/User.java
@@ -1,0 +1,58 @@
+package com.homeputers.ebal2.api.domain.user;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    private String email;
+
+    private String role;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        User user = (User) o;
+        return Objects.equals(id, user.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/User.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/User.java
@@ -4,43 +4,23 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+
 import java.util.Objects;
 import java.util.UUID;
 
 @Entity
 @Table(name = "users")
-public class User {
-
-    @Id
-    @GeneratedValue
-    private UUID id;
-
-    private String email;
-
-    private String role;
-
-    public UUID getId() {
-        return id;
-    }
-
-    public void setId(UUID id) {
-        this.id = id;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getRole() {
-        return role;
-    }
-
-    public void setRole(String role) {
-        this.role = role;
+public record User(
+        @Id
+        @GeneratedValue
+        UUID id,
+        String email,
+        String role
+) {
+    public User {
+        if (id == null) {
+            id = UUID.randomUUID();
+        }
     }
 
     @Override
@@ -56,3 +36,4 @@ public class User {
         return Objects.hash(id);
     }
 }
+

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/UserRepository.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/UserRepository.java
@@ -1,0 +1,8 @@
+package com.homeputers.ebal2.api.domain.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+}


### PR DESCRIPTION
## Summary
- add entity classes for users, members, groups, songs, arrangements, song sets, services and related tables
- create Spring Data repositories for each entity

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c86490948330a9375db8b4779a7d