### PR TITLE
Add basic CRUD API for core aggregates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ target/
 .vscode/
 *.iml
 
+# Environment files
+.env
+

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/ApiExceptionHandler.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/ApiExceptionHandler.java
@@ -1,0 +1,32 @@
+package com.homeputers.ebal2.api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ProblemDetail handleValidation(MethodArgumentNotValidException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+        Map<String, String> errors = ex.getBindingResult().getFieldErrors().stream()
+                .collect(Collectors.toMap(FieldError::getField, FieldError::getDefaultMessage));
+        pd.setProperty("errors", errors);
+        return pd;
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ProblemDetail handleNotFound(NoSuchElementException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/arrangement/ArrangementMapper.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/arrangement/ArrangementMapper.java
@@ -1,0 +1,15 @@
+package com.homeputers.ebal2.api.arrangement;
+
+import com.homeputers.ebal2.api.domain.arrangement.Arrangement;
+import com.homeputers.ebal2.api.domain.song.Song;
+
+public class ArrangementMapper {
+    public static Arrangement toEntity(Song song, ArrangementRequest request) {
+        return new Arrangement(null, song, request.key(), request.bpm(), request.meter(), request.lyricsChordpro());
+    }
+
+    public static ArrangementResponse toResponse(Arrangement arrangement) {
+        return new ArrangementResponse(arrangement.id(), arrangement.song() != null ? arrangement.song().id() : null,
+                arrangement.key(), arrangement.bpm(), arrangement.meter(), arrangement.lyricsChordpro());
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/arrangement/ArrangementRequest.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/arrangement/ArrangementRequest.java
@@ -1,0 +1,8 @@
+package com.homeputers.ebal2.api.arrangement;
+
+public record ArrangementRequest(
+        String key,
+        Integer bpm,
+        String meter,
+        String lyricsChordpro
+) {}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/arrangement/ArrangementResponse.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/arrangement/ArrangementResponse.java
@@ -1,0 +1,12 @@
+package com.homeputers.ebal2.api.arrangement;
+
+import java.util.UUID;
+
+public record ArrangementResponse(
+        UUID id,
+        UUID songId,
+        String key,
+        Integer bpm,
+        String meter,
+        String lyricsChordpro
+) {}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/arrangement/ArrangementRepository.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/arrangement/ArrangementRepository.java
@@ -2,7 +2,9 @@ package com.homeputers.ebal2.api.domain.arrangement;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface ArrangementRepository extends JpaRepository<Arrangement, UUID> {
+    List<Arrangement> findBySongId(UUID songId);
 }

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/member/MemberRepository.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/member/MemberRepository.java
@@ -1,8 +1,11 @@
 package com.homeputers.ebal2.api.domain.member;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
 public interface MemberRepository extends JpaRepository<Member, UUID> {
+    Page<Member> findByDisplayNameContainingIgnoreCase(String displayName, Pageable pageable);
 }

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/serviceplanitem/ServicePlanItemRepository.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/serviceplanitem/ServicePlanItemRepository.java
@@ -2,7 +2,9 @@ package com.homeputers.ebal2.api.domain.serviceplanitem;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface ServicePlanItemRepository extends JpaRepository<ServicePlanItem, UUID> {
+    List<ServicePlanItem> findByServiceIdOrderBySortOrder(UUID serviceId);
 }

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/song/SongRepository.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/song/SongRepository.java
@@ -1,8 +1,15 @@
 package com.homeputers.ebal2.api.domain.song;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.UUID;
 
 public interface SongRepository extends JpaRepository<Song, UUID> {
+
+    @Query("select s from Song s where (:title is null or lower(s.title) like lower(concat('%',:title,'%'))) and (:tag is null or :tag member of s.tags)")
+    Page<Song> search(@Param("title") String title, @Param("tag") String tag, Pageable pageable);
 }

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/songsetitem/SongSetItemRepository.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/songsetitem/SongSetItemRepository.java
@@ -2,7 +2,9 @@ package com.homeputers.ebal2.api.domain.songsetitem;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface SongSetItemRepository extends JpaRepository<SongSetItem, UUID> {
+    List<SongSetItem> findBySongSetIdOrderBySortOrder(UUID songSetId);
 }

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/group/GroupController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/group/GroupController.java
@@ -1,0 +1,61 @@
+package com.homeputers.ebal2.api.group;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/groups")
+@Tag(name = "Groups")
+public class GroupController {
+    private final GroupService service;
+
+    public GroupController(GroupService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public Page<GroupResponse> list(@RequestParam(defaultValue = "0") int page,
+                                    @RequestParam(defaultValue = "20") int size) {
+        return service.list(PageRequest.of(page, size)).map(GroupMapper::toResponse);
+    }
+
+    @GetMapping("/{id}")
+    public GroupResponse get(@PathVariable UUID id) {
+        return GroupMapper.toResponse(service.get(id));
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public GroupResponse create(@Valid @RequestBody GroupRequest request) {
+        return GroupMapper.toResponse(service.create(request));
+    }
+
+    @PutMapping("/{id}")
+    public GroupResponse update(@PathVariable UUID id, @Valid @RequestBody GroupRequest request) {
+        return GroupMapper.toResponse(service.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable UUID id) {
+        service.delete(id);
+    }
+
+    @PostMapping("/{id}/members/{memberId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void addMember(@PathVariable UUID id, @PathVariable UUID memberId) {
+        service.addMember(id, memberId);
+    }
+
+    @DeleteMapping("/{id}/members/{memberId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void removeMember(@PathVariable UUID id, @PathVariable UUID memberId) {
+        service.removeMember(id, memberId);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/group/GroupMapper.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/group/GroupMapper.java
@@ -1,0 +1,18 @@
+package com.homeputers.ebal2.api.group;
+
+import com.homeputers.ebal2.api.domain.group.Group;
+import java.util.stream.Collectors;
+
+public class GroupMapper {
+    public static Group toEntity(GroupRequest request) {
+        return new Group(null, request.name(), null);
+    }
+
+    public static GroupResponse toResponse(Group group) {
+        return new GroupResponse(
+                group.id(),
+                group.name(),
+                group.members().stream().map(m -> m.member().id()).collect(Collectors.toList())
+        );
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/group/GroupRequest.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/group/GroupRequest.java
@@ -1,0 +1,7 @@
+package com.homeputers.ebal2.api.group;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record GroupRequest(
+        @NotBlank String name
+) {}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/group/GroupResponse.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/group/GroupResponse.java
@@ -1,0 +1,10 @@
+package com.homeputers.ebal2.api.group;
+
+import java.util.List;
+import java.util.UUID;
+
+public record GroupResponse(
+        UUID id,
+        String name,
+        List<UUID> memberIds
+) {}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/group/GroupService.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/group/GroupService.java
@@ -1,0 +1,69 @@
+package com.homeputers.ebal2.api.group;
+
+import com.homeputers.ebal2.api.domain.group.Group;
+import com.homeputers.ebal2.api.domain.group.GroupRepository;
+import com.homeputers.ebal2.api.domain.groupmember.GroupMember;
+import com.homeputers.ebal2.api.domain.groupmember.GroupMemberId;
+import com.homeputers.ebal2.api.domain.groupmember.GroupMemberRepository;
+import com.homeputers.ebal2.api.domain.member.Member;
+import com.homeputers.ebal2.api.domain.member.MemberRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service
+public class GroupService {
+    private final GroupRepository repository;
+    private final MemberRepository memberRepository;
+    private final GroupMemberRepository groupMemberRepository;
+
+    public GroupService(GroupRepository repository, MemberRepository memberRepository, GroupMemberRepository groupMemberRepository) {
+        this.repository = repository;
+        this.memberRepository = memberRepository;
+        this.groupMemberRepository = groupMemberRepository;
+    }
+
+    public Page<Group> list(Pageable pageable) {
+        return repository.findAll(pageable);
+    }
+
+    public Group get(UUID id) {
+        return repository.findById(id).orElseThrow(() -> new NoSuchElementException("Group not found"));
+    }
+
+    @Transactional
+    public Group create(GroupRequest request) {
+        return repository.save(GroupMapper.toEntity(request));
+    }
+
+    @Transactional
+    public Group update(UUID id, GroupRequest request) {
+        Group existing = get(id);
+        Group updated = new Group(existing.id(), request.name(), existing.members());
+        return repository.save(updated);
+    }
+
+    @Transactional
+    public void delete(UUID id) {
+        repository.deleteById(id);
+    }
+
+    @Transactional
+    public void addMember(UUID groupId, UUID memberId) {
+        Group group = get(groupId);
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new NoSuchElementException("Member not found"));
+        GroupMemberId id = new GroupMemberId(groupId, memberId);
+        if (!groupMemberRepository.existsById(id)) {
+            groupMemberRepository.save(new GroupMember(id, group, member));
+        }
+    }
+
+    @Transactional
+    public void removeMember(UUID groupId, UUID memberId) {
+        groupMemberRepository.deleteById(new GroupMemberId(groupId, memberId));
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/member/MemberController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/member/MemberController.java
@@ -1,0 +1,52 @@
+package com.homeputers.ebal2.api.member;
+
+import com.homeputers.ebal2.api.domain.member.Member;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/members")
+@Tag(name = "Members")
+public class MemberController {
+    private final MemberService service;
+
+    public MemberController(MemberService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public Page<MemberResponse> list(@RequestParam(name = "q", required = false) String query,
+                                     @RequestParam(defaultValue = "0") int page,
+                                     @RequestParam(defaultValue = "20") int size) {
+        Page<Member> members = service.search(query, PageRequest.of(page, size));
+        return members.map(MemberMapper::toResponse);
+    }
+
+    @GetMapping("/{id}")
+    public MemberResponse get(@PathVariable UUID id) {
+        return MemberMapper.toResponse(service.get(id));
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public MemberResponse create(@Valid @RequestBody MemberRequest request) {
+        return MemberMapper.toResponse(service.create(request));
+    }
+
+    @PutMapping("/{id}")
+    public MemberResponse update(@PathVariable UUID id, @Valid @RequestBody MemberRequest request) {
+        return MemberMapper.toResponse(service.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable UUID id) {
+        service.delete(id);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/member/MemberMapper.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/member/MemberMapper.java
@@ -1,0 +1,13 @@
+package com.homeputers.ebal2.api.member;
+
+import com.homeputers.ebal2.api.domain.member.Member;
+
+public class MemberMapper {
+    public static Member toEntity(MemberRequest request) {
+        return new Member(null, request.displayName(), request.instruments());
+    }
+
+    public static MemberResponse toResponse(Member member) {
+        return new MemberResponse(member.id(), member.displayName(), member.instruments());
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/member/MemberRequest.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/member/MemberRequest.java
@@ -1,0 +1,9 @@
+package com.homeputers.ebal2.api.member;
+
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+public record MemberRequest(
+        @NotBlank String displayName,
+        List<String> instruments
+) {}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/member/MemberResponse.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/member/MemberResponse.java
@@ -1,0 +1,10 @@
+package com.homeputers.ebal2.api.member;
+
+import java.util.List;
+import java.util.UUID;
+
+public record MemberResponse(
+        UUID id,
+        String displayName,
+        List<String> instruments
+) {}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/member/MemberService.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/member/MemberService.java
@@ -1,0 +1,49 @@
+package com.homeputers.ebal2.api.member;
+
+import com.homeputers.ebal2.api.domain.member.Member;
+import com.homeputers.ebal2.api.domain.member.MemberRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service
+public class MemberService {
+    private final MemberRepository repository;
+
+    public MemberService(MemberRepository repository) {
+        this.repository = repository;
+    }
+
+    public Member get(UUID id) {
+        return repository.findById(id).orElseThrow(() -> new NoSuchElementException("Member not found"));
+    }
+
+    public Page<Member> search(String query, Pageable pageable) {
+        if (query != null && !query.isBlank()) {
+            return repository.findByDisplayNameContainingIgnoreCase(query, pageable);
+        }
+        return repository.findAll(pageable);
+    }
+
+    @Transactional
+    public Member create(MemberRequest request) {
+        return repository.save(MemberMapper.toEntity(request));
+    }
+
+    @Transactional
+    public Member update(UUID id, MemberRequest request) {
+        Member existing = get(id);
+        Member updated = new Member(existing.id(), request.displayName(), request.instruments());
+        return repository.save(updated);
+    }
+
+    @Transactional
+    public void delete(UUID id) {
+        repository.deleteById(id);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/service/ServiceController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/service/ServiceController.java
@@ -1,0 +1,64 @@
+package com.homeputers.ebal2.api.service;
+
+import com.homeputers.ebal2.api.serviceplanitem.ServicePlanItemMapper;
+import com.homeputers.ebal2.api.serviceplanitem.ServicePlanItemRequest;
+import com.homeputers.ebal2.api.serviceplanitem.ServicePlanItemResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/services")
+@Tag(name = "Services")
+public class ServiceController {
+    private final ServiceService service;
+
+    public ServiceController(ServiceService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public Page<ServiceResponse> list(@RequestParam(defaultValue = "0") int page,
+                                      @RequestParam(defaultValue = "20") int size) {
+        return service.list(PageRequest.of(page, size)).map(ServiceMapper::toResponse);
+    }
+
+    @GetMapping("/{id}")
+    public ServiceResponse get(@PathVariable UUID id) {
+        return ServiceMapper.toResponse(service.get(id));
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ServiceResponse create(@Valid @RequestBody ServiceRequest request) {
+        return ServiceMapper.toResponse(service.create(request));
+    }
+
+    @PutMapping("/{id}")
+    public ServiceResponse update(@PathVariable UUID id, @Valid @RequestBody ServiceRequest request) {
+        return ServiceMapper.toResponse(service.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable UUID id) {
+        service.delete(id);
+    }
+
+    @GetMapping("/{id}/plan-items")
+    public List<ServicePlanItemResponse> listPlanItems(@PathVariable UUID id) {
+        return service.listPlanItems(id).stream().map(ServicePlanItemMapper::toResponse).toList();
+    }
+
+    @PostMapping("/{id}/plan-items")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ServicePlanItemResponse addPlanItem(@PathVariable UUID id, @RequestBody ServicePlanItemRequest request) {
+        return ServicePlanItemMapper.toResponse(service.addPlanItem(id, request));
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/service/ServiceMapper.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/service/ServiceMapper.java
@@ -1,0 +1,13 @@
+package com.homeputers.ebal2.api.service;
+
+import com.homeputers.ebal2.api.domain.service.Service;
+
+public class ServiceMapper {
+    public static Service toEntity(ServiceRequest request) {
+        return new Service(null, request.startsAt(), request.location());
+    }
+
+    public static ServiceResponse toResponse(Service service) {
+        return new ServiceResponse(service.id(), service.startsAt(), service.location());
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/service/ServiceRequest.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/service/ServiceRequest.java
@@ -1,0 +1,9 @@
+package com.homeputers.ebal2.api.service;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.OffsetDateTime;
+
+public record ServiceRequest(
+        @NotNull OffsetDateTime startsAt,
+        String location
+) {}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/service/ServiceResponse.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/service/ServiceResponse.java
@@ -1,0 +1,10 @@
+package com.homeputers.ebal2.api.service;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record ServiceResponse(
+        UUID id,
+        OffsetDateTime startsAt,
+        String location
+) {}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/service/ServiceService.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/service/ServiceService.java
@@ -1,0 +1,61 @@
+package com.homeputers.ebal2.api.service;
+
+import com.homeputers.ebal2.api.domain.service.ServiceRepository;
+import com.homeputers.ebal2.api.domain.serviceplanitem.ServicePlanItem;
+import com.homeputers.ebal2.api.domain.serviceplanitem.ServicePlanItemRepository;
+import com.homeputers.ebal2.api.serviceplanitem.ServicePlanItemMapper;
+import com.homeputers.ebal2.api.serviceplanitem.ServicePlanItemRequest;
+import jakarta.transaction.Transactional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@org.springframework.stereotype.Service
+public class ServiceService {
+    private final ServiceRepository repository;
+    private final ServicePlanItemRepository planItemRepository;
+
+    public ServiceService(ServiceRepository repository, ServicePlanItemRepository planItemRepository) {
+        this.repository = repository;
+        this.planItemRepository = planItemRepository;
+    }
+
+    public Page<com.homeputers.ebal2.api.domain.service.Service> list(Pageable pageable) {
+        return repository.findAll(pageable);
+    }
+
+    public com.homeputers.ebal2.api.domain.service.Service get(UUID id) {
+        return repository.findById(id).orElseThrow(() -> new NoSuchElementException("Service not found"));
+    }
+
+    @Transactional
+    public com.homeputers.ebal2.api.domain.service.Service create(ServiceRequest request) {
+        return repository.save(ServiceMapper.toEntity(request));
+    }
+
+    @Transactional
+    public com.homeputers.ebal2.api.domain.service.Service update(UUID id, ServiceRequest request) {
+        com.homeputers.ebal2.api.domain.service.Service existing = get(id);
+        com.homeputers.ebal2.api.domain.service.Service updated = new com.homeputers.ebal2.api.domain.service.Service(existing.id(), request.startsAt(), request.location());
+        return repository.save(updated);
+    }
+
+    @Transactional
+    public void delete(UUID id) {
+        repository.deleteById(id);
+    }
+
+    public List<ServicePlanItem> listPlanItems(UUID serviceId) {
+        return planItemRepository.findByServiceIdOrderBySortOrder(serviceId);
+    }
+
+    @Transactional
+    public ServicePlanItem addPlanItem(UUID serviceId, ServicePlanItemRequest request) {
+        com.homeputers.ebal2.api.domain.service.Service service = get(serviceId);
+        ServicePlanItem item = ServicePlanItemMapper.toEntity(service, request);
+        return planItemRepository.save(item);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/serviceplanitem/ServicePlanItemController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/serviceplanitem/ServicePlanItemController.java
@@ -1,0 +1,30 @@
+package com.homeputers.ebal2.api.serviceplanitem;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/service-plan-items")
+@Tag(name = "Service Plan Items")
+public class ServicePlanItemController {
+    private final ServicePlanItemService service;
+
+    public ServicePlanItemController(ServicePlanItemService service) {
+        this.service = service;
+    }
+
+    @PutMapping("/{id}")
+    public ServicePlanItemResponse update(@PathVariable UUID id, @Valid @RequestBody ServicePlanItemRequest request) {
+        return ServicePlanItemMapper.toResponse(service.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable UUID id) {
+        service.delete(id);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/serviceplanitem/ServicePlanItemMapper.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/serviceplanitem/ServicePlanItemMapper.java
@@ -1,0 +1,14 @@
+package com.homeputers.ebal2.api.serviceplanitem;
+
+import com.homeputers.ebal2.api.domain.service.Service;
+import com.homeputers.ebal2.api.domain.serviceplanitem.ServicePlanItem;
+
+public class ServicePlanItemMapper {
+    public static ServicePlanItem toEntity(Service service, ServicePlanItemRequest request) {
+        return new ServicePlanItem(null, service, request.type(), request.refId(), request.sortOrder(), request.notes());
+    }
+
+    public static ServicePlanItemResponse toResponse(ServicePlanItem item) {
+        return new ServicePlanItemResponse(item.id(), item.service().id(), item.type(), item.refId(), item.sortOrder(), item.notes());
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/serviceplanitem/ServicePlanItemRequest.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/serviceplanitem/ServicePlanItemRequest.java
@@ -1,0 +1,10 @@
+package com.homeputers.ebal2.api.serviceplanitem;
+
+import java.util.UUID;
+
+public record ServicePlanItemRequest(
+        String type,
+        UUID refId,
+        Integer sortOrder,
+        String notes
+) {}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/serviceplanitem/ServicePlanItemResponse.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/serviceplanitem/ServicePlanItemResponse.java
@@ -1,0 +1,12 @@
+package com.homeputers.ebal2.api.serviceplanitem;
+
+import java.util.UUID;
+
+public record ServicePlanItemResponse(
+        UUID id,
+        UUID serviceId,
+        String type,
+        UUID refId,
+        Integer sortOrder,
+        String notes
+) {}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/serviceplanitem/ServicePlanItemService.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/serviceplanitem/ServicePlanItemService.java
@@ -1,0 +1,34 @@
+package com.homeputers.ebal2.api.serviceplanitem;
+
+import com.homeputers.ebal2.api.domain.serviceplanitem.ServicePlanItem;
+import com.homeputers.ebal2.api.domain.serviceplanitem.ServicePlanItemRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service
+public class ServicePlanItemService {
+    private final ServicePlanItemRepository repository;
+
+    public ServicePlanItemService(ServicePlanItemRepository repository) {
+        this.repository = repository;
+    }
+
+    public ServicePlanItem get(UUID id) {
+        return repository.findById(id).orElseThrow(() -> new NoSuchElementException("Plan item not found"));
+    }
+
+    @Transactional
+    public ServicePlanItem update(UUID id, ServicePlanItemRequest request) {
+        ServicePlanItem existing = get(id);
+        ServicePlanItem updated = new ServicePlanItem(existing.id(), existing.service(), request.type(), request.refId(), request.sortOrder(), request.notes());
+        return repository.save(updated);
+    }
+
+    @Transactional
+    public void delete(UUID id) {
+        repository.deleteById(id);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/song/SongController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/song/SongController.java
@@ -1,0 +1,77 @@
+package com.homeputers.ebal2.api.song;
+
+import com.homeputers.ebal2.api.arrangement.ArrangementMapper;
+import com.homeputers.ebal2.api.arrangement.ArrangementRequest;
+import com.homeputers.ebal2.api.arrangement.ArrangementResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/songs")
+@Tag(name = "Songs")
+public class SongController {
+    private final SongService service;
+
+    public SongController(SongService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public Page<SongResponse> list(@RequestParam(name = "title", required = false) String title,
+                                   @RequestParam(name = "tag", required = false) String tag,
+                                   @RequestParam(defaultValue = "0") int page,
+                                   @RequestParam(defaultValue = "20") int size) {
+        return service.search(title, tag, PageRequest.of(page, size)).map(SongMapper::toResponse);
+    }
+
+    @GetMapping("/{id}")
+    public SongResponse get(@PathVariable UUID id) {
+        return SongMapper.toResponse(service.get(id));
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public SongResponse create(@Valid @RequestBody SongRequest request) {
+        return SongMapper.toResponse(service.create(request));
+    }
+
+    @PutMapping("/{id}")
+    public SongResponse update(@PathVariable UUID id, @Valid @RequestBody SongRequest request) {
+        return SongMapper.toResponse(service.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable UUID id) {
+        service.delete(id);
+    }
+
+    @GetMapping("/{id}/arrangements")
+    public List<ArrangementResponse> listArrangements(@PathVariable UUID id) {
+        return service.listArrangements(id).stream().map(ArrangementMapper::toResponse).toList();
+    }
+
+    @PostMapping("/{id}/arrangements")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ArrangementResponse addArrangement(@PathVariable UUID id, @RequestBody ArrangementRequest request) {
+        return ArrangementMapper.toResponse(service.addArrangement(id, request));
+    }
+
+    @PutMapping("/arrangements/{arrangementId}")
+    public ArrangementResponse updateArrangement(@PathVariable UUID arrangementId, @RequestBody ArrangementRequest request) {
+        return ArrangementMapper.toResponse(service.updateArrangement(arrangementId, request));
+    }
+
+    @DeleteMapping("/arrangements/{arrangementId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteArrangement(@PathVariable UUID arrangementId) {
+        service.deleteArrangement(arrangementId);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/song/SongMapper.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/song/SongMapper.java
@@ -1,0 +1,13 @@
+package com.homeputers.ebal2.api.song;
+
+import com.homeputers.ebal2.api.domain.song.Song;
+
+public class SongMapper {
+    public static Song toEntity(SongRequest request) {
+        return new Song(null, request.title(), request.ccli(), request.author(), request.defaultKey(), request.tags());
+    }
+
+    public static SongResponse toResponse(Song song) {
+        return new SongResponse(song.id(), song.title(), song.ccli(), song.author(), song.defaultKey(), song.tags());
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/song/SongRequest.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/song/SongRequest.java
@@ -1,0 +1,12 @@
+package com.homeputers.ebal2.api.song;
+
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+public record SongRequest(
+        @NotBlank String title,
+        String ccli,
+        String author,
+        String defaultKey,
+        List<String> tags
+) {}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/song/SongResponse.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/song/SongResponse.java
@@ -1,0 +1,13 @@
+package com.homeputers.ebal2.api.song;
+
+import java.util.List;
+import java.util.UUID;
+
+public record SongResponse(
+        UUID id,
+        String title,
+        String ccli,
+        String author,
+        String defaultKey,
+        List<String> tags
+) {}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/song/SongService.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/song/SongService.java
@@ -1,0 +1,76 @@
+package com.homeputers.ebal2.api.song;
+
+import com.homeputers.ebal2.api.arrangement.ArrangementMapper;
+import com.homeputers.ebal2.api.arrangement.ArrangementRequest;
+import com.homeputers.ebal2.api.arrangement.ArrangementResponse;
+import com.homeputers.ebal2.api.domain.arrangement.Arrangement;
+import com.homeputers.ebal2.api.domain.arrangement.ArrangementRepository;
+import com.homeputers.ebal2.api.domain.song.Song;
+import com.homeputers.ebal2.api.domain.song.SongRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service
+public class SongService {
+    private final SongRepository songRepository;
+    private final ArrangementRepository arrangementRepository;
+
+    public SongService(SongRepository songRepository, ArrangementRepository arrangementRepository) {
+        this.songRepository = songRepository;
+        this.arrangementRepository = arrangementRepository;
+    }
+
+    public Song get(UUID id) {
+        return songRepository.findById(id).orElseThrow(() -> new NoSuchElementException("Song not found"));
+    }
+
+    public Page<Song> search(String title, String tag, Pageable pageable) {
+        return songRepository.search(title, tag, pageable);
+    }
+
+    @Transactional
+    public Song create(SongRequest request) {
+        return songRepository.save(SongMapper.toEntity(request));
+    }
+
+    @Transactional
+    public Song update(UUID id, SongRequest request) {
+        Song existing = get(id);
+        Song updated = new Song(existing.id(), request.title(), request.ccli(), request.author(), request.defaultKey(), request.tags());
+        return songRepository.save(updated);
+    }
+
+    @Transactional
+    public void delete(UUID id) {
+        songRepository.deleteById(id);
+    }
+
+    public List<Arrangement> listArrangements(UUID songId) {
+        return arrangementRepository.findBySongId(songId);
+    }
+
+    @Transactional
+    public Arrangement addArrangement(UUID songId, ArrangementRequest request) {
+        Song song = get(songId);
+        Arrangement arrangement = ArrangementMapper.toEntity(song, request);
+        return arrangementRepository.save(arrangement);
+    }
+
+    @Transactional
+    public Arrangement updateArrangement(UUID id, ArrangementRequest request) {
+        Arrangement existing = arrangementRepository.findById(id).orElseThrow(() -> new NoSuchElementException("Arrangement not found"));
+        Arrangement updated = new Arrangement(existing.id(), existing.song(), request.key(), request.bpm(), request.meter(), request.lyricsChordpro());
+        return arrangementRepository.save(updated);
+    }
+
+    @Transactional
+    public void deleteArrangement(UUID id) {
+        arrangementRepository.deleteById(id);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/songset/SongSetController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/songset/SongSetController.java
@@ -1,0 +1,76 @@
+package com.homeputers.ebal2.api.songset;
+
+import com.homeputers.ebal2.api.songsetitem.SongSetItemMapper;
+import com.homeputers.ebal2.api.songsetitem.SongSetItemRequest;
+import com.homeputers.ebal2.api.songsetitem.SongSetItemResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/song-sets")
+@Tag(name = "Song Sets")
+public class SongSetController {
+    private final SongSetService service;
+
+    public SongSetController(SongSetService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public Page<SongSetResponse> list(@RequestParam(defaultValue = "0") int page,
+                                      @RequestParam(defaultValue = "20") int size) {
+        return service.list(PageRequest.of(page, size)).map(SongSetMapper::toResponse);
+    }
+
+    @GetMapping("/{id}")
+    public SongSetResponse get(@PathVariable UUID id) {
+        return SongSetMapper.toResponse(service.get(id));
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public SongSetResponse create(@Valid @RequestBody SongSetRequest request) {
+        return SongSetMapper.toResponse(service.create(request));
+    }
+
+    @PutMapping("/{id}")
+    public SongSetResponse update(@PathVariable UUID id, @Valid @RequestBody SongSetRequest request) {
+        return SongSetMapper.toResponse(service.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable UUID id) {
+        service.delete(id);
+    }
+
+    @GetMapping("/{id}/items")
+    public List<SongSetItemResponse> listItems(@PathVariable UUID id) {
+        return service.listItems(id).stream().map(SongSetItemMapper::toResponse).toList();
+    }
+
+    @PostMapping("/{id}/items")
+    @ResponseStatus(HttpStatus.CREATED)
+    public SongSetItemResponse addItem(@PathVariable UUID id, @RequestBody SongSetItemRequest request) {
+        return SongSetItemMapper.toResponse(service.addItem(id, request));
+    }
+
+    @DeleteMapping("/{id}/items/{itemId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void removeItem(@PathVariable UUID id, @PathVariable UUID itemId) {
+        service.removeItem(id, itemId);
+    }
+
+    @PostMapping("/{id}/items/reorder")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void reorderItems(@PathVariable UUID id, @RequestBody List<UUID> order) {
+        service.reorderItems(id, order);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/songset/SongSetMapper.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/songset/SongSetMapper.java
@@ -1,0 +1,13 @@
+package com.homeputers.ebal2.api.songset;
+
+import com.homeputers.ebal2.api.domain.songset.SongSet;
+
+public class SongSetMapper {
+    public static SongSet toEntity(SongSetRequest request) {
+        return new SongSet(null, request.name());
+    }
+
+    public static SongSetResponse toResponse(SongSet songSet) {
+        return new SongSetResponse(songSet.id(), songSet.name());
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/songset/SongSetRequest.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/songset/SongSetRequest.java
@@ -1,0 +1,7 @@
+package com.homeputers.ebal2.api.songset;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SongSetRequest(
+        @NotBlank String name
+) {}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/songset/SongSetResponse.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/songset/SongSetResponse.java
@@ -1,0 +1,8 @@
+package com.homeputers.ebal2.api.songset;
+
+import java.util.UUID;
+
+public record SongSetResponse(
+        UUID id,
+        String name
+) {}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/songset/SongSetService.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/songset/SongSetService.java
@@ -1,0 +1,89 @@
+package com.homeputers.ebal2.api.songset;
+
+import com.homeputers.ebal2.api.domain.arrangement.Arrangement;
+import com.homeputers.ebal2.api.domain.arrangement.ArrangementRepository;
+import com.homeputers.ebal2.api.domain.songset.SongSet;
+import com.homeputers.ebal2.api.domain.songset.SongSetRepository;
+import com.homeputers.ebal2.api.domain.songsetitem.SongSetItem;
+import com.homeputers.ebal2.api.domain.songsetitem.SongSetItemRepository;
+import com.homeputers.ebal2.api.songsetitem.SongSetItemMapper;
+import com.homeputers.ebal2.api.songsetitem.SongSetItemRequest;
+import jakarta.transaction.Transactional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service
+public class SongSetService {
+    private final SongSetRepository repository;
+    private final SongSetItemRepository itemRepository;
+    private final ArrangementRepository arrangementRepository;
+
+    public SongSetService(SongSetRepository repository, SongSetItemRepository itemRepository, ArrangementRepository arrangementRepository) {
+        this.repository = repository;
+        this.itemRepository = itemRepository;
+        this.arrangementRepository = arrangementRepository;
+    }
+
+    public Page<SongSet> list(Pageable pageable) {
+        return repository.findAll(pageable);
+    }
+
+    public SongSet get(UUID id) {
+        return repository.findById(id).orElseThrow(() -> new NoSuchElementException("Song set not found"));
+    }
+
+    @Transactional
+    public SongSet create(SongSetRequest request) {
+        return repository.save(SongSetMapper.toEntity(request));
+    }
+
+    @Transactional
+    public SongSet update(UUID id, SongSetRequest request) {
+        SongSet existing = get(id);
+        SongSet updated = new SongSet(existing.id(), request.name());
+        return repository.save(updated);
+    }
+
+    @Transactional
+    public void delete(UUID id) {
+        repository.deleteById(id);
+    }
+
+    public List<SongSetItem> listItems(UUID songSetId) {
+        return itemRepository.findBySongSetIdOrderBySortOrder(songSetId);
+    }
+
+    @Transactional
+    public SongSetItem addItem(UUID songSetId, SongSetItemRequest request) {
+        SongSet songSet = get(songSetId);
+        Arrangement arrangement = arrangementRepository.findById(request.arrangementId()).orElseThrow(() -> new NoSuchElementException("Arrangement not found"));
+        SongSetItem item = SongSetItemMapper.toEntity(songSet, arrangement, request);
+        return itemRepository.save(item);
+    }
+
+    @Transactional
+    public void removeItem(UUID songSetId, UUID itemId) {
+        SongSetItem item = itemRepository.findById(itemId).orElseThrow(() -> new NoSuchElementException("Item not found"));
+        if (!item.songSet().id().equals(songSetId)) {
+            throw new NoSuchElementException("Item not part of song set");
+        }
+        itemRepository.delete(item);
+    }
+
+    @Transactional
+    public void reorderItems(UUID songSetId, List<UUID> order) {
+        List<SongSetItem> items = listItems(songSetId);
+        for (int i = 0; i < order.size(); i++) {
+            UUID id = order.get(i);
+            items.stream().filter(it -> it.id().equals(id)).findFirst().ifPresent(it -> {
+                SongSetItem updated = new SongSetItem(it.id(), it.songSet(), it.arrangement(), i, it.transpose(), it.capo());
+                itemRepository.save(updated);
+            });
+        }
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/songset/SongSetService.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/songset/SongSetService.java
@@ -80,10 +80,20 @@ public class SongSetService {
         List<SongSetItem> items = listItems(songSetId);
         for (int i = 0; i < order.size(); i++) {
             UUID id = order.get(i);
-            items.stream().filter(it -> it.id().equals(id)).findFirst().ifPresent(it -> {
-                SongSetItem updated = new SongSetItem(it.id(), it.songSet(), it.arrangement(), i, it.transpose(), it.capo());
-                itemRepository.save(updated);
-            });
+            final int sortOrder = i;
+            items.stream()
+                    .filter(it -> it.id().equals(id))
+                    .findFirst()
+                    .ifPresent(it -> {
+                        SongSetItem updated = new SongSetItem(
+                                it.id(),
+                                it.songSet(),
+                                it.arrangement(),
+                                sortOrder,
+                                it.transpose(),
+                                it.capo());
+                        itemRepository.save(updated);
+                    });
         }
     }
 }

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/songsetitem/SongSetItemController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/songsetitem/SongSetItemController.java
@@ -1,0 +1,30 @@
+package com.homeputers.ebal2.api.songsetitem;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/song-set-items")
+@Tag(name = "Song Set Items")
+public class SongSetItemController {
+    private final SongSetItemService service;
+
+    public SongSetItemController(SongSetItemService service) {
+        this.service = service;
+    }
+
+    @PutMapping("/{id}")
+    public SongSetItemResponse update(@PathVariable UUID id, @Valid @RequestBody SongSetItemRequest request) {
+        return SongSetItemMapper.toResponse(service.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable UUID id) {
+        service.delete(id);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/songsetitem/SongSetItemMapper.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/songsetitem/SongSetItemMapper.java
@@ -1,0 +1,15 @@
+package com.homeputers.ebal2.api.songsetitem;
+
+import com.homeputers.ebal2.api.domain.arrangement.Arrangement;
+import com.homeputers.ebal2.api.domain.songset.SongSet;
+import com.homeputers.ebal2.api.domain.songsetitem.SongSetItem;
+
+public class SongSetItemMapper {
+    public static SongSetItem toEntity(SongSet songSet, Arrangement arrangement, SongSetItemRequest request) {
+        return new SongSetItem(null, songSet, arrangement, request.sortOrder(), request.transpose(), request.capo());
+    }
+
+    public static SongSetItemResponse toResponse(SongSetItem item) {
+        return new SongSetItemResponse(item.id(), item.songSet().id(), item.arrangement().id(), item.sortOrder(), item.transpose(), item.capo());
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/songsetitem/SongSetItemRequest.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/songsetitem/SongSetItemRequest.java
@@ -1,0 +1,10 @@
+package com.homeputers.ebal2.api.songsetitem;
+
+import java.util.UUID;
+
+public record SongSetItemRequest(
+        UUID arrangementId,
+        Integer sortOrder,
+        Integer transpose,
+        Integer capo
+) {}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/songsetitem/SongSetItemResponse.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/songsetitem/SongSetItemResponse.java
@@ -1,0 +1,12 @@
+package com.homeputers.ebal2.api.songsetitem;
+
+import java.util.UUID;
+
+public record SongSetItemResponse(
+        UUID id,
+        UUID songSetId,
+        UUID arrangementId,
+        Integer sortOrder,
+        Integer transpose,
+        Integer capo
+) {}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/songsetitem/SongSetItemService.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/songsetitem/SongSetItemService.java
@@ -1,0 +1,34 @@
+package com.homeputers.ebal2.api.songsetitem;
+
+import com.homeputers.ebal2.api.domain.songsetitem.SongSetItem;
+import com.homeputers.ebal2.api.domain.songsetitem.SongSetItemRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service
+public class SongSetItemService {
+    private final SongSetItemRepository repository;
+
+    public SongSetItemService(SongSetItemRepository repository) {
+        this.repository = repository;
+    }
+
+    public SongSetItem get(UUID id) {
+        return repository.findById(id).orElseThrow(() -> new NoSuchElementException("Item not found"));
+    }
+
+    @Transactional
+    public SongSetItem update(UUID id, SongSetItemRequest request) {
+        SongSetItem existing = get(id);
+        SongSetItem updated = new SongSetItem(existing.id(), existing.songSet(), existing.arrangement(), request.sortOrder(), request.transpose(), request.capo());
+        return repository.save(updated);
+    }
+
+    @Transactional
+    public void delete(UUID id) {
+        repository.deleteById(id);
+    }
+}


### PR DESCRIPTION
## Summary
- add REST controllers, services, DTOs and mappers for members, groups, songs, arrangements, song sets, services and plan items
- provide search, pagination and nested item management
- centralize validation errors with ProblemDetail responses

## Testing
- `mvn -q -f apps/api-java/pom.xml test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to central - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4cb4c78f083308f87e184ce615efd