### PR TITLE
test: add testcontainers for songs

### DIFF
--- a/apps/api-java/pom.xml
+++ b/apps/api-java/pom.xml
@@ -60,6 +60,21 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/AbstractIntegrationTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/AbstractIntegrationTest.java
@@ -1,0 +1,24 @@
+package com.homeputers.ebal2.api;
+
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@ActiveProfiles("test")
+public abstract class AbstractIntegrationTest {
+
+    @Container
+    private static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine")
+            .withReuse(true);
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+}

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/song/SongControllerTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/song/SongControllerTest.java
@@ -1,0 +1,45 @@
+package com.homeputers.ebal2.api.song;
+
+import com.homeputers.ebal2.api.AbstractIntegrationTest;
+import com.homeputers.ebal2.api.generated.model.SongRequest;
+import com.homeputers.ebal2.api.generated.model.SongResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class SongControllerTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void createSong() {
+        SongRequest request = new SongRequest();
+        request.setTitle("Test Song");
+
+        ResponseEntity<SongResponse> response =
+                restTemplate.postForEntity("/api/v1/songs", request, SongResponse.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getId()).isNotNull();
+        assertThat(response.getBody().getTitle()).isEqualTo("Test Song");
+    }
+
+    @Test
+    void createSongValidationError() {
+        SongRequest request = new SongRequest();
+
+        ResponseEntity<String> response =
+                restTemplate.postForEntity("/api/v1/songs", request, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).contains("title");
+    }
+}

--- a/apps/api-java/src/test/resources/application-test.yaml
+++ b/apps/api-java/src/test/resources/application-test.yaml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    open-in-view: false
+  test:
+    database:
+      replace: none


### PR DESCRIPTION
## Summary
- add Postgres Testcontainers setup with reusable container and test profile
- cover SongController with integration tests for creation success and validation failure

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e5adbb908330b61969fb89b816ad