### PR TITLE
fix(api): prefix controllers with api base path

### DIFF
--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/HealthController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/HealthController.java
@@ -4,8 +4,10 @@ import com.homeputers.ebal2.api.generated.HealthApi;
 import com.homeputers.ebal2.api.generated.model.Health;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 @RestController
+@RequestMapping("/api/v1")
 public class HealthController implements HealthApi {
 
     @Override

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/group/GroupController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/group/GroupController.java
@@ -10,10 +10,12 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.UUID;
 
 @RestController
+@RequestMapping("/api/v1")
 public class GroupController implements GroupsApi {
     private final GroupService service;
 

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/member/MemberController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/member/MemberController.java
@@ -10,10 +10,12 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.UUID;
 
 @RestController
+@RequestMapping("/api/v1")
 public class MemberController implements MembersApi {
     private final MemberService service;
 

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/service/ServiceController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/service/ServiceController.java
@@ -12,11 +12,13 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.List;
 import java.util.UUID;
 
 @RestController
+@RequestMapping("/api/v1")
 public class ServiceController implements ServicesApi {
     private final ServiceService service;
 

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/serviceplanitem/ServicePlanItemController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/serviceplanitem/ServicePlanItemController.java
@@ -6,10 +6,12 @@ import com.homeputers.ebal2.api.generated.model.ServicePlanItemResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.UUID;
 
 @RestController
+@RequestMapping("/api/v1")
 public class ServicePlanItemController implements ServicePlanItemsApi {
     private final ServicePlanItemService service;
 

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/songset/SongSetController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/songset/SongSetController.java
@@ -13,11 +13,13 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.List;
 import java.util.UUID;
 
 @RestController
+@RequestMapping("/api/v1")
 public class SongSetController implements SongSetsApi {
     private final SongSetService service;
 

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/songsetitem/SongSetItemController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/songsetitem/SongSetItemController.java
@@ -6,10 +6,12 @@ import com.homeputers.ebal2.api.generated.model.SongSetItemResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.UUID;
 
 @RestController
+@RequestMapping("/api/v1")
 public class SongSetItemController implements SongSetItemsApi {
     private final SongSetItemService service;
 


### PR DESCRIPTION
## Summary
- apply `/api/v1` mapping to all controllers so every endpoint is versioned

## Testing
- `./mvnw -q -DskipTests=false verify` *(fails: Network is unreachable)*

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68c580b2a22083308e5fb88f08c2981f