### PR TITLE
build(web): proxy API requests

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -9,4 +9,14 @@ export default defineConfig({
       '@': path.resolve(__dirname, 'src'),
     },
   },
+  server: {
+    proxy: {
+      // Browser calls /api/...; Vite proxies to :8080
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- proxy `/api` web requests to the Java backend on `localhost:8080`

## Testing
- `yarn build` *(fails: Cannot find module 'react-router-dom')*
- `yarn tsc -p .` *(fails: Cannot find module 'react-router-dom')*

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68c5bc089bf08330bb5c627c6aa467f8