### PR TITLE
fix(web): use Vite proxy for API client and log dev errors

### DIFF
--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -1,14 +1,28 @@
 import axios from 'axios';
 
 export const apiClient = axios.create({
-  baseURL: `${import.meta.env.VITE_API_URL}/api/v1`,
+  baseURL: '/api/v1',
+  withCredentials: false,
+  headers: {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  },
 });
 
+// request interceptor (placeholder for auth headers later)
 apiClient.interceptors.request.use((config) => config);
 
+// response interceptor with minimal dev logging
 apiClient.interceptors.response.use(
   (response) => response,
-  (error) => Promise.reject(error)
+  (error) => {
+    if (import.meta.env.DEV) {
+      const status = error?.response?.status;
+      // eslint-disable-next-line no-console
+      console.error('[API ERROR]', status, error?.response?.data);
+    }
+    return Promise.reject(error);
+  }
 );
 
 export default apiClient;


### PR DESCRIPTION
## Summary
- use relative `/api/v1` base URL in axios client
- log API errors to console in dev mode

## Testing
- `yarn workspace web lint`
- `yarn build`
- `npx tsc -p apps/web`

## 12) PR Checklist (agents copy this into PR body)
- [x] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68c5be5ed4808330ad403f902f4f4e58