### PR TITLE
feat(web): add OpenAPI type helpers

### DIFF
--- a/apps/web/src/api/groups.ts
+++ b/apps/web/src/api/groups.ts
@@ -1,9 +1,9 @@
-import type { paths } from './types';
 import apiClient from './client';
+import type { QueryOf, ResponseOf } from './type-helpers';
 
-type ListGroupsResponse = paths['/groups']['get']['responses']['200']['content']['application/json'];
-type ListGroupsParams = paths['/groups']['get']['parameters']['query'];
-type GetGroupResponse = paths['/groups/{id}']['get']['responses']['200']['content']['application/json'];
+type ListGroupsResponse = ResponseOf<'/groups', 'get', 200>;
+type ListGroupsParams = QueryOf<'/groups', 'get'>;
+type GetGroupResponse = ResponseOf<'/groups/{id}', 'get', 200>;
 
 export async function listGroups(params?: ListGroupsParams) {
   const { data } = await apiClient.get<ListGroupsResponse>('/groups', { params });

--- a/apps/web/src/api/members.ts
+++ b/apps/web/src/api/members.ts
@@ -1,9 +1,9 @@
-import type { paths } from './types';
 import apiClient from './client';
+import type { QueryOf, ResponseOf } from './type-helpers';
 
-type ListMembersResponse = paths['/members']['get']['responses']['200']['content']['application/json'];
-type ListMembersParams = paths['/members']['get']['parameters']['query'];
-type GetMemberResponse = paths['/members/{id}']['get']['responses']['200']['content']['application/json'];
+type ListMembersResponse = ResponseOf<'/members', 'get', 200>;
+type ListMembersParams = QueryOf<'/members', 'get'>;
+type GetMemberResponse = ResponseOf<'/members/{id}', 'get', 200>;
 
 export async function listMembers(params?: ListMembersParams) {
   const { data } = await apiClient.get<ListMembersResponse>('/members', { params });

--- a/apps/web/src/api/services.ts
+++ b/apps/web/src/api/services.ts
@@ -1,9 +1,9 @@
-import type { paths } from './types';
 import apiClient from './client';
+import type { QueryOf, ResponseOf } from './type-helpers';
 
-type ListServicesResponse = paths['/services']['get']['responses']['200']['content']['application/json'];
-type ListServicesParams = paths['/services']['get']['parameters']['query'];
-type GetServiceResponse = paths['/services/{id}']['get']['responses']['200']['content']['application/json'];
+type ListServicesResponse = ResponseOf<'/services', 'get', 200>;
+type ListServicesParams = QueryOf<'/services', 'get'>;
+type GetServiceResponse = ResponseOf<'/services/{id}', 'get', 200>;
 
 export async function listServices(params?: ListServicesParams) {
   const { data } = await apiClient.get<ListServicesResponse>('/services', { params });

--- a/apps/web/src/api/sets.ts
+++ b/apps/web/src/api/sets.ts
@@ -1,9 +1,9 @@
-import type { paths } from './types';
 import apiClient from './client';
+import type { QueryOf, ResponseOf } from './type-helpers';
 
-type ListSetsResponse = paths['/song-sets']['get']['responses']['200']['content']['application/json'];
-type ListSetsParams = paths['/song-sets']['get']['parameters']['query'];
-type GetSetResponse = paths['/song-sets/{id}']['get']['responses']['200']['content']['application/json'];
+type ListSetsResponse = ResponseOf<'/song-sets', 'get', 200>;
+type ListSetsParams = QueryOf<'/song-sets', 'get'>;
+type GetSetResponse = ResponseOf<'/song-sets/{id}', 'get', 200>;
 
 export async function listSets(params?: ListSetsParams) {
   const { data } = await apiClient.get<ListSetsResponse>('/song-sets', { params });

--- a/apps/web/src/api/songs.ts
+++ b/apps/web/src/api/songs.ts
@@ -1,9 +1,9 @@
-import type { paths } from './types';
 import apiClient from './client';
+import type { QueryOf, ResponseOf } from './type-helpers';
 
-type ListSongsResponse = paths['/songs']['get']['responses']['200']['content']['application/json'];
-type ListSongsParams = paths['/songs']['get']['parameters']['query'];
-type GetSongResponse = paths['/songs/{id}']['get']['responses']['200']['content']['application/json'];
+type ListSongsResponse = ResponseOf<'/songs', 'get', 200>;
+type ListSongsParams = QueryOf<'/songs', 'get'>;
+type GetSongResponse = ResponseOf<'/songs/{id}', 'get', 200>;
 
 export async function listSongs(params?: ListSongsParams) {
   const { data } = await apiClient.get<ListSongsResponse>('/songs', { params });

--- a/apps/web/src/api/type-helpers.ts
+++ b/apps/web/src/api/type-helpers.ts
@@ -1,0 +1,45 @@
+import type { paths } from './types';
+
+type PathItem<TPath extends keyof paths> = paths[TPath];
+type HttpMethod = 'get' | 'put' | 'post' | 'delete' | 'options' | 'head' | 'patch' | 'trace';
+type Operation<
+  TPath extends keyof paths,
+  TMethod extends HttpMethod & keyof PathItem<TPath>
+> = NonNullable<PathItem<TPath>[TMethod]>;
+
+// Extract response body for a path+method+status
+export type ResponseOf<
+  TPath extends keyof paths,
+  TMethod extends HttpMethod & keyof PathItem<TPath>,
+  TStatus extends keyof Operation<TPath, TMethod>['responses']
+> = Operation<TPath, TMethod>['responses'][TStatus] extends {
+  content: { 'application/json': infer T };
+}
+  ? T
+  : never;
+
+// Extract request body
+export type RequestBodyOf<
+  TPath extends keyof paths,
+  TMethod extends HttpMethod & keyof PathItem<TPath>
+> = Operation<TPath, TMethod>['requestBody'] extends {
+  content: { 'application/json': infer T };
+}
+  ? T
+  : never;
+
+// Extract query params
+export type QueryOf<
+  TPath extends keyof paths,
+  TMethod extends HttpMethod & keyof PathItem<TPath>
+> = Operation<TPath, TMethod>['parameters'] extends { query: infer T }
+  ? T
+  : never;
+
+// Extract path params
+export type PathParamsOf<
+  TPath extends keyof paths,
+  TMethod extends HttpMethod & keyof PathItem<TPath>
+> = Operation<TPath, TMethod>['parameters'] extends { path: infer T }
+  ? T
+  : never;


### PR DESCRIPTION
## Summary
- add type utility helpers for OpenAPI generated paths
- refactor API modules to leverage reusable helpers

## Testing
- `yarn build`
- `tsc -p .`

## PR Checklist
- [x] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68c5c1e11f508330b127f311dfe6b086