### PR TITLE
feat(web): expand members API to full CRUD

### DIFF
--- a/apps/web/src/api/members.ts
+++ b/apps/web/src/api/members.ts
@@ -1,9 +1,26 @@
 import apiClient from './client';
-import type { QueryOf, ResponseOf } from './type-helpers';
+import type { paths } from './types';
+import { QueryOf, ResponseOf, PathParamsOf, RequestBodyOf } from './type-helpers';
 
-type ListMembersResponse = ResponseOf<'/members', 'get', 200>;
-type ListMembersParams = QueryOf<'/members', 'get'>;
-type GetMemberResponse = ResponseOf<'/members/{id}', 'get', 200>;
+// Path literals for clarity (must match your OpenAPI spec)
+type MembersPath = keyof paths & '/members';
+type MemberPath = keyof paths & '/members/{id}';
+
+// Types
+export type ListMembersParams = QueryOf<MembersPath, 'get'>;
+export type ListMembersResponse = ResponseOf<MembersPath, 'get', 200>;
+
+export type GetMemberParams = PathParamsOf<MemberPath, 'get'>;
+export type GetMemberResponse = ResponseOf<MemberPath, 'get', 200>;
+
+export type CreateMemberBody = RequestBodyOf<MembersPath, 'post'>;
+export type CreateMemberResponse = ResponseOf<MembersPath, 'post', 201>;
+
+export type UpdateMemberParams = PathParamsOf<MemberPath, 'put'>;
+export type UpdateMemberBody = RequestBodyOf<MemberPath, 'put'>;
+export type UpdateMemberResponse = ResponseOf<MemberPath, 'put', 200>;
+
+export type DeleteMemberParams = PathParamsOf<MemberPath, 'delete'>;
 
 export async function listMembers(params?: ListMembersParams) {
   const { data } = await apiClient.get<ListMembersResponse>('/members', { params });
@@ -13,4 +30,18 @@ export async function listMembers(params?: ListMembersParams) {
 export async function getMember(id: string) {
   const { data } = await apiClient.get<GetMemberResponse>(`/members/${id}`);
   return data;
+}
+
+export async function createMember(body: CreateMemberBody) {
+  const { data } = await apiClient.post<CreateMemberResponse>('/members', body);
+  return data;
+}
+
+export async function updateMember(id: string, body: UpdateMemberBody) {
+  const { data } = await apiClient.put<UpdateMemberResponse>(`/members/${id}`, body);
+  return data;
+}
+
+export async function deleteMember(id: string) {
+  await apiClient.delete<void>(`/members/${id}`);
 }


### PR DESCRIPTION
## Summary
- expand Members API client to support create, update, and delete endpoints using shared type helpers

## Testing
- `yarn lint`
- `yarn build`
- `yarn typecheck`
- `mvn -q verify` *(fails: Network is unreachable)*

## PR Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)

------
https://chatgpt.com/codex/tasks/task_e_68c5c39d42a08330bcdb631c0e782c9a