### PR TITLE
feat(web): add member hooks and page skeleton

### DIFF
--- a/apps/web/src/features/members/hooks.ts
+++ b/apps/web/src/features/members/hooks.ts
@@ -1,0 +1,38 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  listMembers, createMember, updateMember, deleteMember,
+  type ListMembersParams
+} from '../../api/members';
+
+export function useMembersList(params: ListMembersParams | undefined) {
+  return useQuery({
+    queryKey: ['members', params],
+    queryFn: () => listMembers(params),
+    placeholderData: (prev) => prev,
+  });
+}
+
+export function useCreateMember() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: createMember,
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['members'] }),
+  });
+}
+
+export function useUpdateMember() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, body }: { id: string; body: Parameters<typeof updateMember>[1] }) =>
+      updateMember(id, body),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['members'] }),
+  });
+}
+
+export function useDeleteMember() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: deleteMember,
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['members'] }),
+  });
+}

--- a/apps/web/src/pages/members/MembersPage.tsx
+++ b/apps/web/src/pages/members/MembersPage.tsx
@@ -1,0 +1,37 @@
+import { useMemo, useState } from 'react';
+import { useMembersList, useCreateMember, useUpdateMember, useDeleteMember } from '../../features/members/hooks';
+
+export default function MembersPage() {
+  const [query, setQuery] = useState('');
+  const params = useMemo(() => (query ? { query, page: 0, size: 20 } : { page: 0, size: 20 }), [query]);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, isLoading, isError } = useMembersList(params as any);
+
+  const createMut = useCreateMember();
+  const updateMut = useUpdateMember();
+  const deleteMut = useDeleteMember();
+  void createMut;
+  void updateMut;
+  void deleteMut;
+
+  // TODO: render table with data?.content and controls to create/edit/delete
+  // show loading/error/empty states
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-semibold mb-4">Members</h1>
+      <input
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search by name..."
+        className="border p-2 rounded w-full max-w-sm"
+      />
+      {isLoading && <div>Loading…</div>}
+      {isError && <div>Failed to load</div>}
+      {!isLoading && data ? (
+        <div className="mt-4">
+          {/* Render table rows from data.content */}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/routes/Members.tsx
+++ b/apps/web/src/routes/Members.tsx
@@ -1,3 +1,1 @@
-export default function Members() {
-  return <div>Members</div>;
-}
+export { default } from '@/pages/members/MembersPage';


### PR DESCRIPTION
## Summary
- add TanStack Query hooks for members CRUD
- scaffold members page with search and loading states
- wire members route to page component

## Testing
- `mvnw -q -DskipTests=false verify` *(fails: Network is unreachable)*
- `yarn lint`
- `yarn build`
- `yarn typecheck`

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [x] Web: Loading/error states; basic a11y; responsive layout
- [x] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68c5c5fbe1e88330ba5d4b8f4b766109