### PR TITLE
feat(web): add CRUD API helpers

### DIFF
--- a/apps/web/src/api/groups.ts
+++ b/apps/web/src/api/groups.ts
@@ -1,9 +1,31 @@
 import apiClient from './client';
-import type { QueryOf, ResponseOf } from './type-helpers';
+import type { paths } from './types';
+import {
+  QueryOf,
+  ResponseOf,
+  PathParamsOf,
+  RequestBodyOf,
+} from './type-helpers';
 
-type ListGroupsResponse = ResponseOf<'/groups', 'get', 200>;
-type ListGroupsParams = QueryOf<'/groups', 'get'>;
-type GetGroupResponse = ResponseOf<'/groups/{id}', 'get', 200>;
+// Path literals for clarity (must match your OpenAPI spec)
+type GroupsPath = keyof paths & '/groups';
+type GroupPath = keyof paths & '/groups/{id}';
+
+// Types
+export type ListGroupsParams = QueryOf<GroupsPath, 'get'>;
+export type ListGroupsResponse = ResponseOf<GroupsPath, 'get', 200>;
+
+export type GetGroupParams = PathParamsOf<GroupPath, 'get'>;
+export type GetGroupResponse = ResponseOf<GroupPath, 'get', 200>;
+
+export type CreateGroupBody = RequestBodyOf<GroupsPath, 'post'>;
+export type CreateGroupResponse = ResponseOf<GroupsPath, 'post', 201>;
+
+export type UpdateGroupParams = PathParamsOf<GroupPath, 'put'>;
+export type UpdateGroupBody = RequestBodyOf<GroupPath, 'put'>;
+export type UpdateGroupResponse = ResponseOf<GroupPath, 'put', 200>;
+
+export type DeleteGroupParams = PathParamsOf<GroupPath, 'delete'>;
 
 export async function listGroups(params?: ListGroupsParams) {
   const { data } = await apiClient.get<ListGroupsResponse>('/groups', { params });
@@ -13,4 +35,18 @@ export async function listGroups(params?: ListGroupsParams) {
 export async function getGroup(id: string) {
   const { data } = await apiClient.get<GetGroupResponse>(`/groups/${id}`);
   return data;
+}
+
+export async function createGroup(body: CreateGroupBody) {
+  const { data } = await apiClient.post<CreateGroupResponse>('/groups', body);
+  return data;
+}
+
+export async function updateGroup(id: string, body: UpdateGroupBody) {
+  const { data } = await apiClient.put<UpdateGroupResponse>(`/groups/${id}`, body);
+  return data;
+}
+
+export async function deleteGroup(id: string) {
+  await apiClient.delete<void>(`/groups/${id}`);
 }

--- a/apps/web/src/api/services.ts
+++ b/apps/web/src/api/services.ts
@@ -1,9 +1,31 @@
 import apiClient from './client';
-import type { QueryOf, ResponseOf } from './type-helpers';
+import type { paths } from './types';
+import {
+  QueryOf,
+  ResponseOf,
+  PathParamsOf,
+  RequestBodyOf,
+} from './type-helpers';
 
-type ListServicesResponse = ResponseOf<'/services', 'get', 200>;
-type ListServicesParams = QueryOf<'/services', 'get'>;
-type GetServiceResponse = ResponseOf<'/services/{id}', 'get', 200>;
+// Path literals for clarity (must match your OpenAPI spec)
+type ServicesPath = keyof paths & '/services';
+type ServicePath = keyof paths & '/services/{id}';
+
+// Types
+export type ListServicesParams = QueryOf<ServicesPath, 'get'>;
+export type ListServicesResponse = ResponseOf<ServicesPath, 'get', 200>;
+
+export type GetServiceParams = PathParamsOf<ServicePath, 'get'>;
+export type GetServiceResponse = ResponseOf<ServicePath, 'get', 200>;
+
+export type CreateServiceBody = RequestBodyOf<ServicesPath, 'post'>;
+export type CreateServiceResponse = ResponseOf<ServicesPath, 'post', 201>;
+
+export type UpdateServiceParams = PathParamsOf<ServicePath, 'put'>;
+export type UpdateServiceBody = RequestBodyOf<ServicePath, 'put'>;
+export type UpdateServiceResponse = ResponseOf<ServicePath, 'put', 200>;
+
+export type DeleteServiceParams = PathParamsOf<ServicePath, 'delete'>;
 
 export async function listServices(params?: ListServicesParams) {
   const { data } = await apiClient.get<ListServicesResponse>('/services', { params });
@@ -13,4 +35,18 @@ export async function listServices(params?: ListServicesParams) {
 export async function getService(id: string) {
   const { data } = await apiClient.get<GetServiceResponse>(`/services/${id}`);
   return data;
+}
+
+export async function createService(body: CreateServiceBody) {
+  const { data } = await apiClient.post<CreateServiceResponse>('/services', body);
+  return data;
+}
+
+export async function updateService(id: string, body: UpdateServiceBody) {
+  const { data } = await apiClient.put<UpdateServiceResponse>(`/services/${id}`, body);
+  return data;
+}
+
+export async function deleteService(id: string) {
+  await apiClient.delete<void>(`/services/${id}`);
 }

--- a/apps/web/src/api/sets.ts
+++ b/apps/web/src/api/sets.ts
@@ -1,9 +1,31 @@
 import apiClient from './client';
-import type { QueryOf, ResponseOf } from './type-helpers';
+import type { paths } from './types';
+import {
+  QueryOf,
+  ResponseOf,
+  PathParamsOf,
+  RequestBodyOf,
+} from './type-helpers';
 
-type ListSetsResponse = ResponseOf<'/song-sets', 'get', 200>;
-type ListSetsParams = QueryOf<'/song-sets', 'get'>;
-type GetSetResponse = ResponseOf<'/song-sets/{id}', 'get', 200>;
+// Path literals for clarity (must match your OpenAPI spec)
+type SongSetsPath = keyof paths & '/song-sets';
+type SongSetPath = keyof paths & '/song-sets/{id}';
+
+// Types
+export type ListSetsParams = QueryOf<SongSetsPath, 'get'>;
+export type ListSetsResponse = ResponseOf<SongSetsPath, 'get', 200>;
+
+export type GetSetParams = PathParamsOf<SongSetPath, 'get'>;
+export type GetSetResponse = ResponseOf<SongSetPath, 'get', 200>;
+
+export type CreateSetBody = RequestBodyOf<SongSetsPath, 'post'>;
+export type CreateSetResponse = ResponseOf<SongSetsPath, 'post', 201>;
+
+export type UpdateSetParams = PathParamsOf<SongSetPath, 'put'>;
+export type UpdateSetBody = RequestBodyOf<SongSetPath, 'put'>;
+export type UpdateSetResponse = ResponseOf<SongSetPath, 'put', 200>;
+
+export type DeleteSetParams = PathParamsOf<SongSetPath, 'delete'>;
 
 export async function listSets(params?: ListSetsParams) {
   const { data } = await apiClient.get<ListSetsResponse>('/song-sets', { params });
@@ -13,4 +35,18 @@ export async function listSets(params?: ListSetsParams) {
 export async function getSet(id: string) {
   const { data } = await apiClient.get<GetSetResponse>(`/song-sets/${id}`);
   return data;
+}
+
+export async function createSet(body: CreateSetBody) {
+  const { data } = await apiClient.post<CreateSetResponse>('/song-sets', body);
+  return data;
+}
+
+export async function updateSet(id: string, body: UpdateSetBody) {
+  const { data } = await apiClient.put<UpdateSetResponse>(`/song-sets/${id}`, body);
+  return data;
+}
+
+export async function deleteSet(id: string) {
+  await apiClient.delete<void>(`/song-sets/${id}`);
 }

--- a/apps/web/src/api/songs.ts
+++ b/apps/web/src/api/songs.ts
@@ -1,9 +1,31 @@
 import apiClient from './client';
-import type { QueryOf, ResponseOf } from './type-helpers';
+import type { paths } from './types';
+import {
+  QueryOf,
+  ResponseOf,
+  PathParamsOf,
+  RequestBodyOf,
+} from './type-helpers';
 
-type ListSongsResponse = ResponseOf<'/songs', 'get', 200>;
-type ListSongsParams = QueryOf<'/songs', 'get'>;
-type GetSongResponse = ResponseOf<'/songs/{id}', 'get', 200>;
+// Path literals for clarity (must match your OpenAPI spec)
+type SongsPath = keyof paths & '/songs';
+type SongPath = keyof paths & '/songs/{id}';
+
+// Types
+export type ListSongsParams = QueryOf<SongsPath, 'get'>;
+export type ListSongsResponse = ResponseOf<SongsPath, 'get', 200>;
+
+export type GetSongParams = PathParamsOf<SongPath, 'get'>;
+export type GetSongResponse = ResponseOf<SongPath, 'get', 200>;
+
+export type CreateSongBody = RequestBodyOf<SongsPath, 'post'>;
+export type CreateSongResponse = ResponseOf<SongsPath, 'post', 201>;
+
+export type UpdateSongParams = PathParamsOf<SongPath, 'put'>;
+export type UpdateSongBody = RequestBodyOf<SongPath, 'put'>;
+export type UpdateSongResponse = ResponseOf<SongPath, 'put', 200>;
+
+export type DeleteSongParams = PathParamsOf<SongPath, 'delete'>;
 
 export async function listSongs(params?: ListSongsParams) {
   const { data } = await apiClient.get<ListSongsResponse>('/songs', { params });
@@ -13,4 +35,18 @@ export async function listSongs(params?: ListSongsParams) {
 export async function getSong(id: string) {
   const { data } = await apiClient.get<GetSongResponse>(`/songs/${id}`);
   return data;
+}
+
+export async function createSong(body: CreateSongBody) {
+  const { data } = await apiClient.post<CreateSongResponse>('/songs', body);
+  return data;
+}
+
+export async function updateSong(id: string, body: UpdateSongBody) {
+  const { data } = await apiClient.put<UpdateSongResponse>(`/songs/${id}`, body);
+  return data;
+}
+
+export async function deleteSong(id: string) {
+  await apiClient.delete<void>(`/songs/${id}`);
 }


### PR DESCRIPTION
## Summary
- add typed CRUD helpers for groups, songs, song sets, and services

## Testing
- `yarn build`
- `yarn tsc -p .`

## PR Checklist
- [x] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68c5c92712108330a029ae2c6942b544