### PR TITLE
build(api): replace JPA with MyBatis starter

### DIFF
--- a/apps/api-java/pom.xml
+++ b/apps/api-java/pom.xml
@@ -29,8 +29,9 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <groupId>org.mybatis.spring.boot</groupId>
+            <artifactId>mybatis-spring-boot-starter</artifactId>
+            <version>3.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/MyBatisConfig.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/MyBatisConfig.java
@@ -1,0 +1,10 @@
+package com.homeputers.ebal2.api.config;
+
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@MapperScan("com.homeputers.ebal2.api")
+public class MyBatisConfig {
+}
+

--- a/apps/api-java/src/main/resources/application.yaml
+++ b/apps/api-java/src/main/resources/application.yaml
@@ -3,9 +3,9 @@ spring:
     url: ${SPRING_DATASOURCE_URL}
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
-  jpa:
-    hibernate:
-      ddl-auto: validate
-    open-in-view: false
 server:
   port: 8080
+mybatis:
+  mapper-locations: classpath*:mappers/**/*.xml
+  configuration:
+    map-underscore-to-camel-case: true


### PR DESCRIPTION
## Summary
- replace Spring Data JPA with MyBatis starter
- add MyBatis configuration and mapper scanning

## Testing
- `mvn -q -DskipTests=false verify` *(fails: Network is unreachable)*

## PR Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68c6f1bc393883308fbed6cee729f0c6