### PR TITLE
feat: add search endpoint

### DIFF
--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/member/MemberMapper.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/member/MemberMapper.java
@@ -14,6 +14,9 @@ public interface MemberMapper {
                           @Param("offset") int offset,
                           @Param("limit") int limit);
 
+    List<Member> search(@Param("query") String query,
+                        @Param("limit") int limit);
+
     int count(@Param("query") String query);
 
     void insert(Member member);

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/service/ServiceMapper.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/service/ServiceMapper.java
@@ -3,6 +3,7 @@ package com.homeputers.ebal2.api.domain.service;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -12,6 +13,11 @@ public interface ServiceMapper {
 
     List<Service> findPage(@Param("offset") int offset,
                            @Param("limit") int limit);
+
+    List<Service> search(@Param("query") String query,
+                         @Param("start") OffsetDateTime start,
+                         @Param("end") OffsetDateTime end,
+                         @Param("limit") int limit);
 
     int count();
 

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/search/SearchController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/search/SearchController.java
@@ -1,0 +1,28 @@
+package com.homeputers.ebal2.api.search;
+
+import com.homeputers.ebal2.api.generated.SearchApi;
+import com.homeputers.ebal2.api.generated.model.SearchResult;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1")
+public class SearchController implements SearchApi {
+    private final SearchService service;
+
+    public SearchController(SearchService service) {
+        this.service = service;
+    }
+
+    @Override
+    public ResponseEntity<List<SearchResult>> search(String q) {
+        List<SearchResult> results = service.search(q).stream()
+                .map(SearchDtoMapper::toResponse)
+                .toList();
+        return ResponseEntity.ok(results);
+    }
+}
+

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/search/SearchDtoMapper.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/search/SearchDtoMapper.java
@@ -1,0 +1,18 @@
+package com.homeputers.ebal2.api.search;
+
+import com.homeputers.ebal2.api.generated.model.SearchResult;
+
+public final class SearchDtoMapper {
+    private SearchDtoMapper() {
+    }
+
+    public static SearchResult toResponse(SearchResultDto dto) {
+        SearchResult res = new SearchResult();
+        res.setKind(SearchResult.KindEnum.fromValue(dto.kind()));
+        res.setId(dto.id());
+        res.setTitle(dto.title());
+        res.setSubtitle(dto.subtitle());
+        return res;
+    }
+}
+

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/search/SearchResultDto.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/search/SearchResultDto.java
@@ -1,0 +1,11 @@
+package com.homeputers.ebal2.api.search;
+
+import java.util.UUID;
+
+public record SearchResultDto(
+        String kind,
+        UUID id,
+        String title,
+        String subtitle
+) {}
+

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/search/SearchService.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/search/SearchService.java
@@ -4,7 +4,6 @@ import com.homeputers.ebal2.api.domain.member.Member;
 import com.homeputers.ebal2.api.domain.member.MemberMapper;
 import com.homeputers.ebal2.api.domain.song.Song;
 import com.homeputers.ebal2.api.domain.song.SongMapper;
-import com.homeputers.ebal2.api.domain.service.Service;
 import com.homeputers.ebal2.api.domain.service.ServiceMapper;
 import org.springframework.stereotype.Service;
 
@@ -45,8 +44,9 @@ public class SearchService {
         }
 
         OffsetDateTime now = OffsetDateTime.now();
-        List<Service> services = serviceMapper.search(query, now.minusMonths(6), now.plusMonths(6), SERVICE_LIMIT);
-        for (Service svc : services) {
+        List<com.homeputers.ebal2.api.domain.service.Service> services =
+            serviceMapper.search(query, now.minusMonths(6), now.plusMonths(6), SERVICE_LIMIT);
+        for (com.homeputers.ebal2.api.domain.service.Service svc : services) {
             String title = svc.startsAt().toString();
             results.add(new SearchResultDto("service", svc.id(), title, svc.location()));
         }

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/search/SearchService.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/search/SearchService.java
@@ -1,0 +1,57 @@
+package com.homeputers.ebal2.api.search;
+
+import com.homeputers.ebal2.api.domain.member.Member;
+import com.homeputers.ebal2.api.domain.member.MemberMapper;
+import com.homeputers.ebal2.api.domain.song.Song;
+import com.homeputers.ebal2.api.domain.song.SongMapper;
+import com.homeputers.ebal2.api.domain.service.Service;
+import com.homeputers.ebal2.api.domain.service.ServiceMapper;
+import org.springframework.stereotype.Service;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class SearchService {
+    private static final int MEMBER_LIMIT = 5;
+    private static final int SONG_LIMIT = 5;
+    private static final int SERVICE_LIMIT = 5;
+
+    private final MemberMapper memberMapper;
+    private final SongMapper songMapper;
+    private final ServiceMapper serviceMapper;
+
+    public SearchService(MemberMapper memberMapper,
+                         SongMapper songMapper,
+                         ServiceMapper serviceMapper) {
+        this.memberMapper = memberMapper;
+        this.songMapper = songMapper;
+        this.serviceMapper = serviceMapper;
+    }
+
+    public List<SearchResultDto> search(String query) {
+        List<SearchResultDto> results = new ArrayList<>();
+
+        List<Member> members = memberMapper.search(query, MEMBER_LIMIT);
+        for (Member m : members) {
+            String subtitle = m.instruments() == null ? null : String.join(", ", m.instruments());
+            results.add(new SearchResultDto("member", m.id(), m.displayName(), subtitle));
+        }
+
+        List<Song> songs = songMapper.search(query, null, 0, SONG_LIMIT);
+        for (Song s : songs) {
+            results.add(new SearchResultDto("song", s.id(), s.title(), s.author()));
+        }
+
+        OffsetDateTime now = OffsetDateTime.now();
+        List<Service> services = serviceMapper.search(query, now.minusMonths(6), now.plusMonths(6), SERVICE_LIMIT);
+        for (Service svc : services) {
+            String title = svc.startsAt().toString();
+            results.add(new SearchResultDto("service", svc.id(), title, svc.location()));
+        }
+
+        return results;
+    }
+}
+

--- a/apps/api-java/src/main/resources/mappers/MemberMapper.xml
+++ b/apps/api-java/src/main/resources/mappers/MemberMapper.xml
@@ -2,9 +2,13 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.homeputers.ebal2.api.domain.member.MemberMapper">
     <resultMap id="memberResult" type="com.homeputers.ebal2.api.domain.member.Member">
-        <id property="id" column="id" typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler"/>
-        <result property="displayName" column="display_name"/>
-        <result property="instruments" column="instruments" typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.StringArrayTypeHandler"/>
+        <constructor>
+            <idArg column="id" javaType="java.util.UUID"
+                   typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler"/>
+            <arg column="display_name" javaType="java.lang.String"/>
+            <arg column="instruments" javaType="java.util.List"
+                 typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.StringArrayTypeHandler"/>
+        </constructor>
     </resultMap>
 
     <select id="findById" resultMap="memberResult">

--- a/apps/api-java/src/main/resources/mappers/MemberMapper.xml
+++ b/apps/api-java/src/main/resources/mappers/MemberMapper.xml
@@ -25,6 +25,18 @@
         limit #{limit} offset #{offset}
     </select>
 
+    <select id="search" resultMap="memberResult">
+        select id, display_name, instruments
+        from members
+        <where>
+            <if test="query != null and query != ''">
+                display_name ILIKE '%' || #{query} || '%'
+            </if>
+        </where>
+        order by display_name
+        limit #{limit}
+    </select>
+
     <select id="count" resultType="int">
         select count(*) from members
         <where>

--- a/apps/api-java/src/main/resources/mappers/ServiceMapper.xml
+++ b/apps/api-java/src/main/resources/mappers/ServiceMapper.xml
@@ -18,6 +18,20 @@
         limit #{limit} offset #{offset}
     </select>
 
+    <select id="search" resultMap="serviceResult">
+        select id, starts_at, location from services
+        <where>
+            <if test="query != null and query != ''">
+                location ILIKE '%' || #{query} || '%'
+            </if>
+            <if test="start != null">
+                starts_at between #{start} and #{end}
+            </if>
+        </where>
+        order by starts_at
+        limit #{limit}
+    </select>
+
     <select id="count" resultType="int">
         select count(*) from services
     </select>

--- a/apps/api-java/src/main/resources/mappers/ServiceMapper.xml
+++ b/apps/api-java/src/main/resources/mappers/ServiceMapper.xml
@@ -2,9 +2,12 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.homeputers.ebal2.api.domain.service.ServiceMapper">
     <resultMap id="serviceResult" type="com.homeputers.ebal2.api.domain.service.Service">
-        <id property="id" column="id" typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler"/>
-        <result property="startsAt" column="starts_at"/>
-        <result property="location" column="location"/>
+        <constructor>
+            <idArg column="id" javaType="java.util.UUID"
+                   typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler"/>
+            <arg column="starts_at" javaType="java.time.OffsetDateTime"/>
+            <arg column="location" javaType="java.lang.String"/>
+        </constructor>
     </resultMap>
 
     <select id="findById" resultMap="serviceResult">

--- a/apps/api-java/src/main/resources/mappers/SongMapper.xml
+++ b/apps/api-java/src/main/resources/mappers/SongMapper.xml
@@ -2,12 +2,16 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.homeputers.ebal2.api.domain.song.SongMapper">
     <resultMap id="songResult" type="com.homeputers.ebal2.api.domain.song.Song">
-        <id property="id" column="id" typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler"/>
-        <result property="title" column="title"/>
-        <result property="ccli" column="ccli"/>
-        <result property="author" column="author"/>
-        <result property="defaultKey" column="default_key"/>
-        <result property="tags" column="tags" typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.StringArrayTypeHandler"/>
+        <constructor>
+            <idArg column="id" javaType="java.util.UUID"
+                   typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler"/>
+            <arg column="title" javaType="java.lang.String"/>
+            <arg column="ccli" javaType="java.lang.String"/>
+            <arg column="author" javaType="java.lang.String"/>
+            <arg column="default_key" javaType="java.lang.String"/>
+            <arg column="tags" javaType="java.util.List"
+                 typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.StringArrayTypeHandler"/>
+        </constructor>
     </resultMap>
 
     <select id="findById" resultMap="songResult">

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/search/SearchControllerTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/search/SearchControllerTest.java
@@ -1,0 +1,56 @@
+package com.homeputers.ebal2.api.search;
+
+import com.homeputers.ebal2.api.AbstractIntegrationTest;
+import com.homeputers.ebal2.api.generated.model.MemberRequest;
+import com.homeputers.ebal2.api.generated.model.MemberResponse;
+import com.homeputers.ebal2.api.generated.model.SearchResult;
+import com.homeputers.ebal2.api.generated.model.ServiceRequest;
+import com.homeputers.ebal2.api.generated.model.ServiceResponse;
+import com.homeputers.ebal2.api.generated.model.SongRequest;
+import com.homeputers.ebal2.api.generated.model.SongResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class SearchControllerTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void searchAcrossEntities() {
+        MemberRequest mr = new MemberRequest();
+        mr.setDisplayName("Searchy Person");
+        restTemplate.postForEntity("/api/v1/members", mr, MemberResponse.class);
+
+        SongRequest sr = new SongRequest();
+        sr.setTitle("Searchy Song");
+        restTemplate.postForEntity("/api/v1/songs", sr, SongResponse.class);
+
+        ServiceRequest svcReq = new ServiceRequest();
+        svcReq.setStartsAt(OffsetDateTime.now().plusDays(1));
+        svcReq.setLocation("Search Hall");
+        restTemplate.postForEntity("/api/v1/services", svcReq, ServiceResponse.class);
+
+        ResponseEntity<SearchResult[]> response =
+                restTemplate.getForEntity("/api/v1/search?q=Search", SearchResult[].class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        List<SearchResult> results = List.of(response.getBody());
+        assertThat(results).extracting(SearchResult::getKind)
+                .contains(SearchResult.KindEnum.MEMBER,
+                        SearchResult.KindEnum.SONG,
+                        SearchResult.KindEnum.SERVICE);
+    }
+}
+

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -17,6 +17,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Health'
+  /search:
+    get:
+      tags: [Search]
+      operationId: search
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SearchResult'
   /groups:
     get:
       tags: [Groups]
@@ -730,6 +749,20 @@ components:
           type: integer
         size:
           type: integer
+    SearchResult:
+      type: object
+      required: [kind, id, title]
+      properties:
+        kind:
+          type: string
+          enum: [member, song, service]
+        id:
+          type: string
+          format: uuid
+        title:
+          type: string
+        subtitle:
+          type: string
     MemberRequest:
       type: object
       required: [displayName]


### PR DESCRIPTION
## Summary
- add `/api/v1/search` endpoint aggregating members, songs, and services
- expose simple `SearchResult` DTO with kind, id, title, subtitle
- include MyBatis queries for members and services and integration test

## Testing
- `mvn -q -DskipTests=false verify` *(fails: Non-resolvable parent POM - Network is unreachable)*
- `yarn build`
- `yarn tsc -p .`


------
https://chatgpt.com/codex/tasks/task_e_68c7350b16fc8330897553dfa6772514