### PR TITLE
feat(web): add members management UI

### DIFF
--- a/apps/web/src/features/members/MemberForm.tsx
+++ b/apps/web/src/features/members/MemberForm.tsx
@@ -1,0 +1,88 @@
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import type { components } from '../../api/types';
+
+const schema = z.object({
+  displayName: z.string().min(2, 'Display name must be at least 2 characters'),
+  instruments: z.string().optional(),
+});
+
+export type MemberFormValues = z.infer<typeof schema>;
+
+export function MemberForm({
+  defaultValues,
+  onSubmit,
+  onCancel,
+}: {
+  defaultValues?: MemberFormValues;
+  onSubmit: (values: components['schemas']['MemberRequest']) => void;
+  onCancel?: () => void;
+}) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<MemberFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues,
+  });
+
+  return (
+    <form
+      onSubmit={handleSubmit((vals) =>
+        onSubmit({
+          displayName: vals.displayName,
+          instruments: vals.instruments
+            ? vals.instruments.split(',').map((s) => s.trim()).filter(Boolean)
+            : [],
+        }),
+      )}
+      className="space-y-2"
+    >
+      <div>
+        <label htmlFor="displayName" className="block text-sm font-medium mb-1">
+          Display Name
+        </label>
+        <input
+          id="displayName"
+          {...register('displayName')}
+          className="border p-2 rounded w-full"
+        />
+        {errors.displayName && (
+          <p className="text-red-500 text-sm">{errors.displayName.message}</p>
+        )}
+      </div>
+      <div>
+        <label htmlFor="instruments" className="block text-sm font-medium mb-1">
+          Instruments (comma separated)
+        </label>
+        <input
+          id="instruments"
+          {...register('instruments')}
+          className="border p-2 rounded w-full"
+        />
+        {errors.instruments && (
+          <p className="text-red-500 text-sm">{errors.instruments.message}</p>
+        )}
+      </div>
+      <div className="flex gap-2">
+        <button type="submit" className="px-4 py-2 bg-blue-500 text-white rounded">
+          Save
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2 bg-gray-200 rounded"
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+    </form>
+  );
+}
+
+export default MemberForm;
+

--- a/apps/web/src/features/members/hooks.ts
+++ b/apps/web/src/features/members/hooks.ts
@@ -16,7 +16,10 @@ export function useCreateMember() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: createMember,
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['members'] }),
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: ['members'] });
+      await qc.refetchQueries({ queryKey: ['members'] });
+    },
   });
 }
 
@@ -25,7 +28,10 @@ export function useUpdateMember() {
   return useMutation({
     mutationFn: ({ id, body }: { id: string; body: Parameters<typeof updateMember>[1] }) =>
       updateMember(id, body),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['members'] }),
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: ['members'] });
+      await qc.refetchQueries({ queryKey: ['members'] });
+    },
   });
 }
 
@@ -33,6 +39,9 @@ export function useDeleteMember() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: deleteMember,
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['members'] }),
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: ['members'] });
+      await qc.refetchQueries({ queryKey: ['members'] });
+    },
   });
 }


### PR DESCRIPTION
## Summary
- implement members page with debounced search, pagination, and CRUD modals
- add MemberForm component and refetch members after mutations

## Testing
- `yarn build`
- `yarn typecheck`

## 12) PR Checklist (agents copy this into PR body)
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [x] Web: Loading/error states; basic a11y; responsive layout
- [x] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68c77902b5848330b55a33d152d9bb16