### PR TITLE
feat(web): add async song/arrangement pickers

### DIFF
--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/serviceplanitem/ServicePlanItemService.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/serviceplanitem/ServicePlanItemService.java
@@ -31,10 +31,10 @@ public class ServicePlanItemService {
         ServicePlanItem updated = new ServicePlanItem(
                 existing.id(),
                 existing.service(),
-                request.getType(),
-                request.getRefId(),
-                request.getSortOrder(),
-                request.getNotes()
+                request.getType() != null ? request.getType() : existing.type(),
+                request.getRefId() != null ? request.getRefId() : existing.refId(),
+                request.getSortOrder() != null ? request.getSortOrder() : existing.sortOrder(),
+                request.getNotes() != null ? request.getNotes() : existing.notes()
         );
         mapper.update(updated);
         return updated;

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/song/SongController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/song/SongController.java
@@ -72,6 +72,12 @@ public class SongController implements SongsApi {
     }
 
     @Override
+    public ResponseEntity<ArrangementResponse> getArrangement(UUID arrangementId) {
+        Arrangement arrangement = service.getArrangement(arrangementId);
+        return ResponseEntity.ok(ArrangementDtoMapper.toResponse(arrangement));
+    }
+
+    @Override
     public ResponseEntity<ArrangementResponse> updateArrangement(UUID arrangementId, ArrangementRequest arrangementRequest) {
         Arrangement updated = service.updateArrangement(arrangementId, arrangementRequest);
         return ResponseEntity.ok(ArrangementDtoMapper.toResponse(updated));

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/song/SongService.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/song/SongService.java
@@ -84,6 +84,14 @@ public class SongService {
         songMapper.delete(id);
     }
 
+    public Arrangement getArrangement(UUID id) {
+        Arrangement arrangement = arrangementMapper.findById(id);
+        if (arrangement == null) {
+            throw new NoSuchElementException("Arrangement not found");
+        }
+        return arrangement;
+    }
+
     public List<Arrangement> listArrangements(UUID songId) {
         return arrangementMapper.findBySongId(songId);
     }

--- a/apps/api-java/src/main/resources/mappers/ArrangementMapper.xml
+++ b/apps/api-java/src/main/resources/mappers/ArrangementMapper.xml
@@ -2,12 +2,16 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.homeputers.ebal2.api.domain.arrangement.ArrangementMapper">
     <resultMap id="arrangementResult" type="com.homeputers.ebal2.api.domain.arrangement.Arrangement">
-        <id property="id" column="id" typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler"/>
-        <result property="key" column="key"/>
-        <result property="bpm" column="bpm"/>
-        <result property="meter" column="meter"/>
-        <result property="lyricsChordpro" column="lyrics_chordpro"/>
-        <association property="song" column="song_id" javaType="com.homeputers.ebal2.api.domain.song.Song" select="com.homeputers.ebal2.api.domain.song.SongMapper.findById"/>
+        <constructor>
+            <idArg column="id" javaType="java.util.UUID"
+                   typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler"/>
+            <arg column="song_id" javaType="com.homeputers.ebal2.api.domain.song.Song"
+                 select="com.homeputers.ebal2.api.domain.song.SongMapper.findById"/>
+            <arg column="key" javaType="java.lang.String"/>
+            <arg column="bpm" javaType="java.lang.Integer"/>
+            <arg column="meter" javaType="java.lang.String"/>
+            <arg column="lyrics_chordpro" javaType="java.lang.String"/>
+        </constructor>
     </resultMap>
 
     <select id="findById" resultMap="arrangementResult">
@@ -25,7 +29,7 @@
         insert into arrangements (id, song_id, key, bpm, meter, lyrics_chordpro)
         values (
             #{id, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler},
-            #{song.id, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler},
+            #{songId, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler},
             #{key},
             #{bpm},
             #{meter},

--- a/apps/api-java/src/main/resources/mappers/ServicePlanItemMapper.xml
+++ b/apps/api-java/src/main/resources/mappers/ServicePlanItemMapper.xml
@@ -2,12 +2,17 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.homeputers.ebal2.api.domain.serviceplanitem.ServicePlanItemMapper">
     <resultMap id="planItemResult" type="com.homeputers.ebal2.api.domain.serviceplanitem.ServicePlanItem">
-        <id property="id" column="id" typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler"/>
-        <result property="type" column="type"/>
-        <result property="refId" column="ref_id" typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler"/>
-        <result property="sortOrder" column="order"/>
-        <result property="notes" column="notes"/>
-        <association property="service" column="service_id" javaType="com.homeputers.ebal2.api.domain.service.Service" select="com.homeputers.ebal2.api.domain.service.ServiceMapper.findById"/>
+        <constructor>
+            <idArg column="id" javaType="java.util.UUID"
+                   typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler"/>
+            <arg column="service_id" javaType="com.homeputers.ebal2.api.domain.service.Service"
+                 select="com.homeputers.ebal2.api.domain.service.ServiceMapper.findById"/>
+            <arg column="type" javaType="java.lang.String"/>
+            <arg column="ref_id" javaType="java.util.UUID"
+                 typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler"/>
+            <arg column="order" javaType="java.lang.Integer"/>
+            <arg column="notes" javaType="java.lang.String"/>
+        </constructor>
     </resultMap>
 
     <select id="findById" resultMap="planItemResult">

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/serviceplanitem/ServicePlanItemServiceTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/serviceplanitem/ServicePlanItemServiceTest.java
@@ -1,0 +1,56 @@
+package com.homeputers.ebal2.api.serviceplanitem;
+
+import com.homeputers.ebal2.api.domain.service.Service;
+import com.homeputers.ebal2.api.domain.serviceplanitem.ServicePlanItem;
+import com.homeputers.ebal2.api.domain.serviceplanitem.ServicePlanItemMapper;
+import com.homeputers.ebal2.api.generated.model.ServicePlanItemRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ServicePlanItemServiceTest {
+
+    @Mock
+    private ServicePlanItemMapper mapper;
+
+    @InjectMocks
+    private ServicePlanItemService service;
+
+    @Test
+    void update_keeps_existing_fields_when_request_omits_them() {
+        UUID id = UUID.randomUUID();
+        Service serviceEntity = new Service(UUID.randomUUID(), OffsetDateTime.now(), "Main Hall");
+        ServicePlanItem existing = new ServicePlanItem(
+                id,
+                serviceEntity,
+                "song",
+                UUID.randomUUID(),
+                0,
+                "existing notes"
+        );
+
+        when(mapper.findById(id)).thenReturn(existing);
+
+        ServicePlanItemRequest request = new ServicePlanItemRequest();
+        request.setNotes("");
+
+        ServicePlanItem updated = service.update(id, request);
+
+        assertThat(updated.type()).isEqualTo(existing.type());
+        assertThat(updated.refId()).isEqualTo(existing.refId());
+        assertThat(updated.sortOrder()).isEqualTo(existing.sortOrder());
+        assertThat(updated.notes()).isEmpty();
+
+        verify(mapper).update(updated);
+    }
+}

--- a/apps/web/src/api/songs.ts
+++ b/apps/web/src/api/songs.ts
@@ -43,6 +43,8 @@ export type UpdateArrangementBody = RequestBodyOf<ArrangementPath, 'put'>;
 export type UpdateArrangementResponse = ResponseOf<ArrangementPath, 'put', 200>;
 
 export type DeleteArrangementParams = PathParamsOf<ArrangementPath, 'delete'>;
+export type GetArrangementParams = PathParamsOf<ArrangementPath, 'get'>;
+export type GetArrangementResponse = ResponseOf<ArrangementPath, 'get', 200>;
 
 export async function listSongs(params?: ListSongsParams) {
   const { data } = await apiClient.get<ListSongsResponse>('/songs', { params });
@@ -102,7 +104,7 @@ export async function deleteArrangement(arrangementId: string) {
 }
 
 export async function getArrangement(arrangementId: string) {
-  const { data } = await apiClient.get<components['schemas']['ArrangementResponse']>(
+  const { data } = await apiClient.get<GetArrangementResponse>(
     `/songs/arrangements/${arrangementId}`,
   );
   return data;

--- a/apps/web/src/api/songs.ts
+++ b/apps/web/src/api/songs.ts
@@ -1,5 +1,5 @@
 import apiClient from './client';
-import type { paths } from './types';
+import type { paths, components } from './types';
 import {
   QueryOf,
   ResponseOf,
@@ -99,4 +99,11 @@ export async function updateArrangement(
 
 export async function deleteArrangement(arrangementId: string) {
   await apiClient.delete<void>(`/songs/arrangements/${arrangementId}`);
+}
+
+export async function getArrangement(arrangementId: string) {
+  const { data } = await apiClient.get<components['schemas']['ArrangementResponse']>(
+    `/songs/arrangements/${arrangementId}`,
+  );
+  return data;
 }

--- a/apps/web/src/api/type-helpers.ts
+++ b/apps/web/src/api/type-helpers.ts
@@ -32,7 +32,7 @@ export type RequestBodyOf<
 export type QueryOf<
   TPath extends keyof paths,
   TMethod extends HttpMethod & keyof PathItem<TPath>
-> = Operation<TPath, TMethod>['parameters'] extends { query: infer T }
+> = Operation<TPath, TMethod>['parameters'] extends { query?: infer T }
   ? T
   : never;
 

--- a/apps/web/src/api/types.d.ts
+++ b/apps/web/src/api/types.d.ts
@@ -20,6 +20,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["search"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/groups": {
         parameters: {
             query?: never;
@@ -238,7 +254,7 @@ export interface paths {
             };
             cookie?: never;
         };
-        get?: never;
+        get: operations["getArrangement"];
         put: operations["updateArrangement"];
         post?: never;
         delete: operations["deleteArrangement"];
@@ -376,6 +392,14 @@ export interface components {
             totalPages?: number;
             number?: number;
             size?: number;
+        };
+        SearchResult: {
+            /** @enum {string} */
+            kind: "member" | "song" | "service";
+            /** Format: uuid */
+            id: string;
+            title: string;
+            subtitle?: string;
         };
         MemberRequest: {
             displayName: string;
@@ -528,6 +552,28 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Health"];
+                };
+            };
+        };
+    };
+    search: {
+        parameters: {
+            query: {
+                q: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SearchResult"][];
                 };
             };
         };
@@ -1170,6 +1216,28 @@ export interface operations {
         responses: {
             /** @description Created */
             201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ArrangementResponse"];
+                };
+            };
+        };
+    };
+    getArrangement: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                arrangementId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/apps/web/src/components/pickers/ArrangementPicker.tsx
+++ b/apps/web/src/components/pickers/ArrangementPicker.tsx
@@ -1,0 +1,109 @@
+import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { listArrangements } from '@/api/songs';
+import type { components } from '@/api/types';
+
+interface Props {
+  songId: string | undefined;
+  value: string | undefined;
+  onChange: (id: string | undefined) => void;
+}
+
+function formatLabel(a: components['schemas']['ArrangementResponse']) {
+  const parts = [`Key: ${a.key}`];
+  if (a.bpm) parts.push(`${a.bpm} BPM`);
+  if (a.meter) parts.push(a.meter);
+  return parts.join(' \u2022 ');
+}
+
+export function ArrangementPicker({ songId, value, onChange }: Props) {
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState(0);
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['arrangements', songId],
+    queryFn: () => listArrangements(songId!),
+    enabled: !!songId,
+  });
+
+  const options = data ?? [];
+  const selected = options.find((a) => a.id === value);
+
+  useEffect(() => {
+    if (!songId) {
+      onChange(undefined);
+    }
+  }, [songId, onChange]);
+
+  const handleSelect = (a: components['schemas']['ArrangementResponse']) => {
+    onChange(a.id);
+    setOpen(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setOpen(true);
+      setActive((p) => Math.min(p + 1, options.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActive((p) => Math.max(p - 1, 0));
+    } else if (e.key === 'Enter' && open && options[active]) {
+      e.preventDefault();
+      handleSelect(options[active]);
+    }
+  };
+
+  const closeLater = () => setTimeout(() => setOpen(false), 100);
+
+  if (!songId) {
+    return (
+      <input
+        disabled
+        placeholder="Select a song first"
+        className="border p-2 rounded w-full bg-gray-100"
+      />
+    );
+  }
+
+  return (
+    <div className="relative">
+      <input
+        value={selected ? formatLabel(selected) : ''}
+        readOnly
+        placeholder="Select arrangement"
+        onFocus={() => setOpen(true)}
+        onBlur={closeLater}
+        onKeyDown={handleKeyDown}
+        className="border p-2 rounded w-full"
+      />
+      {open && (
+        <ul
+          className="absolute z-10 mt-1 bg-white border rounded max-h-60 overflow-auto w-full"
+          role="listbox"
+        >
+          {isLoading && <li className="p-2 text-sm">Loading…</li>}
+          {isError && <li className="p-2 text-sm text-red-500">Failed to load</li>}
+          {!isLoading && !isError && options.length === 0 && (
+            <li className="p-2 text-sm">No arrangements</li>
+          )}
+          {options.map((a, idx) => (
+            <li
+              key={a.id}
+              role="option"
+              aria-selected={value === a.id}
+              className={`p-2 cursor-pointer ${
+                idx === active ? 'bg-blue-500 text-white' : ''
+              }`}
+              onMouseDown={() => handleSelect(a)}
+            >
+              {formatLabel(a)}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default ArrangementPicker;
+

--- a/apps/web/src/components/pickers/SongPicker.tsx
+++ b/apps/web/src/components/pickers/SongPicker.tsx
@@ -1,0 +1,122 @@
+import { useState, useEffect, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { listSongs } from '@/api/songs';
+import type { components } from '@/api/types';
+
+function useDebounce<T>(value: T, delay: number) {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const handler = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+  return debounced;
+}
+
+interface Props {
+  value: string | undefined;
+  onChange: (id: string | undefined) => void;
+  placeholder?: string;
+}
+
+export function SongPicker({ value, onChange, placeholder }: Props) {
+  const [search, setSearch] = useState('');
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState(0);
+  const debounced = useDebounce(search, 300);
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['songs', debounced],
+    queryFn: () => listSongs({ title: debounced, page: 0, size: 10 }),
+    enabled: open,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const options = data?.content ?? [];
+  const selected = options.find((s) => s.id === value);
+
+  useEffect(() => {
+    if (!value) {
+      setSearch('');
+    } else if (selected) {
+      setSearch(selected.title ?? '');
+    }
+  }, [value, selected]);
+
+  const handleSelect = (song: components['schemas']['SongResponse']) => {
+    onChange(song.id);
+    setOpen(false);
+    setSearch(song.title ?? '');
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setOpen(true);
+      setActive((p) => Math.min(p + 1, options.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActive((p) => Math.max(p - 1, 0));
+    } else if (e.key === 'Enter' && open && options[active]) {
+      e.preventDefault();
+      handleSelect(options[active]);
+    }
+  };
+
+  const closeLater = () => setTimeout(() => setOpen(false), 100);
+
+  return (
+    <div className="relative">
+      <input
+        value={search}
+        onChange={(e) => {
+          setSearch(e.target.value);
+          onChange(undefined);
+          if (!open) setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        onBlur={closeLater}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        className="border p-2 rounded w-full"
+        aria-autocomplete="list"
+        aria-expanded={open}
+      />
+      {open && (
+        <ul
+          className="absolute z-10 mt-1 bg-white border rounded max-h-60 overflow-auto w-full"
+          role="listbox"
+        >
+          {isLoading && <li className="p-2 text-sm">Loading…</li>}
+          {isError && <li className="p-2 text-sm text-red-500">Failed to load</li>}
+          {!isLoading && !isError && options.length === 0 && (
+            <li className="p-2 text-sm">No songs</li>
+          )}
+          {options.map((song, idx) => (
+            <li
+              key={song.id}
+              role="option"
+              aria-selected={value === song.id}
+              className={`p-2 cursor-pointer ${
+                idx === active ? 'bg-blue-500 text-white' : ''
+              }`}
+              onMouseDown={() => handleSelect(song)}
+            >
+              <div>
+                <span>{song.title}</span>{' '}
+                {song.defaultKey && (
+                  <span className="text-gray-500">({song.defaultKey})</span>
+                )}
+              </div>
+              {song.tags && song.tags.length > 0 && (
+                <div className="text-xs text-gray-500">{song.tags.join(', ')}</div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default SongPicker;
+

--- a/apps/web/src/features/services/usePlanArrangementInfo.ts
+++ b/apps/web/src/features/services/usePlanArrangementInfo.ts
@@ -1,0 +1,85 @@
+import { useEffect, useRef, useState } from 'react';
+import type { components } from '@/api/types';
+import { getArrangement, getSong } from '@/api/songs';
+
+export type ArrangementInfo = {
+  songTitle: string;
+  key?: string | null;
+  bpm?: number | null;
+  meter?: string | null;
+};
+
+type PlanItem = components['schemas']['ServicePlanItemResponse'];
+
+type ArrangementInfoMap = Record<string, ArrangementInfo>;
+
+export function usePlanArrangementInfo(planItems?: PlanItem[] | null) {
+  const [infoMap, setInfoMap] = useState<ArrangementInfoMap>({});
+  const inFlightRef = useRef(new Set<string>());
+
+  useEffect(() => {
+    if (!planItems || planItems.length === 0) return;
+
+    const candidateIds = Array.from(
+      new Set(
+        planItems
+          .filter((item) => item.type === 'song' && item.refId)
+          .map((item) => item.refId!)
+          .filter(Boolean),
+      ),
+    );
+
+    const missing = candidateIds.filter(
+      (arrangementId) => !infoMap[arrangementId] && !inFlightRef.current.has(arrangementId),
+    );
+
+    if (missing.length === 0) return;
+
+    let cancelled = false;
+
+    (async () => {
+      for (const arrangementId of missing) {
+        inFlightRef.current.add(arrangementId);
+        try {
+          const arrangement = await getArrangement(arrangementId);
+          const songTitle = arrangement.songId ? (await getSong(arrangement.songId))?.title : undefined;
+
+          if (!cancelled) {
+            setInfoMap((prev) => {
+              if (prev[arrangementId]) return prev;
+              return {
+                ...prev,
+                [arrangementId]: {
+                  songTitle: songTitle || 'Song',
+                  key: arrangement.key,
+                  bpm: arrangement.bpm,
+                  meter: arrangement.meter,
+                },
+              };
+            });
+          }
+        } catch {
+          if (!cancelled) {
+            setInfoMap((prev) => {
+              if (prev[arrangementId]) return prev;
+              return {
+                ...prev,
+                [arrangementId]: {
+                  songTitle: 'Song',
+                },
+              };
+            });
+          }
+        } finally {
+          inFlightRef.current.delete(arrangementId);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [planItems, infoMap]);
+
+  return infoMap;
+}

--- a/apps/web/src/pages/services/ServicePrintPage.tsx
+++ b/apps/web/src/pages/services/ServicePrintPage.tsx
@@ -1,10 +1,26 @@
 import { useParams } from 'react-router-dom';
 import { useService, usePlanItems } from '../../features/services/hooks';
+import { usePlanArrangementInfo, type ArrangementInfo } from '@/features/services/usePlanArrangementInfo';
 
 export default function ServicePrintPage() {
   const { id } = useParams();
   const { data: service } = useService(id);
   const { data: plan } = usePlanItems(id);
+  const arrangementInfo = usePlanArrangementInfo(plan);
+
+  const formatType = (type?: string | null) => {
+    if (!type) return 'Item';
+    return type.charAt(0).toUpperCase() + type.slice(1);
+  };
+
+  const formatArrangementDetails = (info?: ArrangementInfo) => {
+    if (!info) return '';
+    const parts: string[] = [];
+    if (info.key) parts.push(`Key ${info.key}`);
+    if (info.bpm != null) parts.push(`${info.bpm} BPM`);
+    if (info.meter) parts.push(info.meter);
+    return parts.join(' • ');
+  };
 
   const handlePrint = () => window.print();
 
@@ -25,9 +41,22 @@ export default function ServicePrintPage() {
       {plan && plan.length > 0 ? (
         <ol className="space-y-2 list-decimal list-inside">
           {plan.map((item) => (
-            <li key={item.id} className="capitalize">
-              <div>{item.type}</div>
-              {item.notes && <div className="text-sm whitespace-pre-line">{item.notes}</div>}
+            <li key={item.id}>
+              <div className="font-semibold">
+                {item.type === 'song' && item.refId
+                  ? arrangementInfo[item.refId]?.songTitle ?? 'Song'
+                  : formatType(item.type)}
+              </div>
+              {item.type === 'song' && item.refId && (
+                <div className="text-sm text-gray-600">
+                  {arrangementInfo[item.refId]
+                    ? formatArrangementDetails(arrangementInfo[item.refId]) || null
+                    : '…'}
+                </div>
+              )}
+              {item.notes && (
+                <div className="text-sm whitespace-pre-line mt-1">{item.notes}</div>
+              )}
             </li>
           ))}
         </ol>

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -499,6 +499,16 @@ paths:
         schema:
           type: string
           format: uuid
+    get:
+      tags: [Songs]
+      operationId: getArrangement
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArrangementResponse'
     put:
       tags: [Songs]
       operationId: updateArrangement


### PR DESCRIPTION
## Summary
- implement SongPicker and ArrangementPicker components for searching songs and arrangements
- require arrangement selection when adding song items and show arrangement summary
- show song labels in service plans using fetched arrangement metadata

## Testing
- `yarn typecheck`
- `yarn build`

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68c78b2f6b1883308ed4260793af2b10