### PR TITLE
feat: add typed song set api helpers

### DIFF
--- a/apps/web/src/api/sets.ts
+++ b/apps/web/src/api/sets.ts
@@ -1,17 +1,19 @@
 import apiClient from './client';
 import type { paths } from './types';
 import {
-  QueryOf,
-  ResponseOf,
   PathParamsOf,
+  QueryOf,
   RequestBodyOf,
+  ResponseOf,
 } from './type-helpers';
 
 // Path literals for clarity (must match your OpenAPI spec)
 type SongSetsPath = keyof paths & '/song-sets';
 type SongSetPath = keyof paths & '/song-sets/{id}';
+type SongSetItemsPath = keyof paths & '/song-sets/{id}/items';
+type SongSetItemPath = keyof paths & '/song-set-items/{id}';
 
-// Types
+// Song set types
 export type ListSetsParams = QueryOf<SongSetsPath, 'get'>;
 export type ListSetsResponse = ResponseOf<SongSetsPath, 'get', 200>;
 
@@ -27,12 +29,29 @@ export type UpdateSetResponse = ResponseOf<SongSetPath, 'put', 200>;
 
 export type DeleteSetParams = PathParamsOf<SongSetPath, 'delete'>;
 
+// Song set item types
+export type ListSetItemsParams = PathParamsOf<SongSetItemsPath, 'get'>;
+export type ListSetItemsResponse = ResponseOf<SongSetItemsPath, 'get', 200>;
+
+export type AddSetItemParams = PathParamsOf<SongSetItemsPath, 'post'>;
+export type AddSetItemBody = RequestBodyOf<SongSetItemsPath, 'post'>;
+export type AddSetItemResponse = ResponseOf<SongSetItemsPath, 'post', 201>;
+
+export type UpdateSetItemParams = PathParamsOf<SongSetItemPath, 'put'>;
+export type UpdateSetItemBody = RequestBodyOf<SongSetItemPath, 'put'>;
+export type UpdateSetItemResponse = ResponseOf<SongSetItemPath, 'put', 200>;
+
+export type RemoveSetItemParams = PathParamsOf<SongSetItemPath, 'delete'>;
+
+type SetId = GetSetParams['id'];
+type SetItemId = UpdateSetItemParams['id'];
+
 export async function listSets(params?: ListSetsParams) {
   const { data } = await apiClient.get<ListSetsResponse>('/song-sets', { params });
   return data;
 }
 
-export async function getSet(id: string) {
+export async function getSet(id: SetId) {
   const { data } = await apiClient.get<GetSetResponse>(`/song-sets/${id}`);
   return data;
 }
@@ -42,11 +61,38 @@ export async function createSet(body: CreateSetBody) {
   return data;
 }
 
-export async function updateSet(id: string, body: UpdateSetBody) {
+export async function updateSet(id: SetId, body: UpdateSetBody) {
   const { data } = await apiClient.put<UpdateSetResponse>(`/song-sets/${id}`, body);
   return data;
 }
 
-export async function deleteSet(id: string) {
+export async function deleteSet(id: SetId) {
   await apiClient.delete<void>(`/song-sets/${id}`);
+}
+
+export async function listSetItems(setId: SetId) {
+  const { data } = await apiClient.get<ListSetItemsResponse>(
+    `/song-sets/${setId}/items`,
+  );
+  return data;
+}
+
+export async function addSetItem(setId: SetId, body: AddSetItemBody) {
+  const { data } = await apiClient.post<AddSetItemResponse>(
+    `/song-sets/${setId}/items`,
+    body,
+  );
+  return data;
+}
+
+export async function updateSetItem(itemId: SetItemId, body: UpdateSetItemBody) {
+  const { data } = await apiClient.put<UpdateSetItemResponse>(
+    `/song-set-items/${itemId}`,
+    body,
+  );
+  return data;
+}
+
+export async function removeSetItem(itemId: SetItemId) {
+  await apiClient.delete<void>(`/song-set-items/${itemId}`);
 }


### PR DESCRIPTION
## Summary
- add typed helper exports for song set CRUD operations
- implement typed item helpers for listing, creating, updating, and removing set items

## Testing
- yarn typecheck

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68c9f8ef045c833094587bea2b91c83b