### PR TITLE
feat(web): add song set query hooks

### DIFF
--- a/apps/web/src/pages/sets/SetsPage.tsx
+++ b/apps/web/src/pages/sets/SetsPage.tsx
@@ -1,11 +1,11 @@
 import { useMemo, useState } from 'react';
-import { useSetsList, useCreateSet, useUpdateSet, useDeleteSet } from '../../features/sets/hooks';
+import { useSongSetsList, useCreateSet, useUpdateSet, useDeleteSet } from '../../features/sets/hooks';
 
 export default function SetsPage() {
   const [query, setQuery] = useState('');
   const params = useMemo(() => (query ? { query, page: 0, size: 20 } : { page: 0, size: 20 }), [query]);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data, isLoading, isError } = useSetsList(params as any);
+  const { data, isLoading, isError } = useSongSetsList(params as any);
 
   const createMut = useCreateSet();
   const updateMut = useUpdateSet();


### PR DESCRIPTION
## Summary
- add TanStack Query hooks for song sets and set items that invalidate related caches
- update the sets page to use the renamed song set list hook

## Testing
- yarn --cwd apps/web typecheck
- yarn --cwd apps/web build

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68c9fb0d553c83309f12ce081130946b