### PR TITLE
feat(web): add song set detail management page

### DIFF
--- a/apps/api-java/src/main/resources/mappers/SongSetItemMapper.xml
+++ b/apps/api-java/src/main/resources/mappers/SongSetItemMapper.xml
@@ -2,21 +2,26 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.homeputers.ebal2.api.domain.songsetitem.SongSetItemMapper">
     <resultMap id="songSetItemResult" type="com.homeputers.ebal2.api.domain.songsetitem.SongSetItem">
-        <id property="id" column="id" typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler"/>
-        <result property="sortOrder" column="order"/>
-        <result property="transpose" column="transpose"/>
-        <result property="capo" column="capo"/>
-        <association property="songSet" column="song_set_id" javaType="com.homeputers.ebal2.api.domain.songset.SongSet" select="com.homeputers.ebal2.api.domain.songset.SongSetMapper.findById"/>
-        <association property="arrangement" column="arrangement_id" javaType="com.homeputers.ebal2.api.domain.arrangement.Arrangement" select="com.homeputers.ebal2.api.domain.arrangement.ArrangementMapper.findById"/>
+        <constructor>
+            <idArg column="id" javaType="java.util.UUID"
+                   typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler"/>
+            <arg column="song_set_id" javaType="com.homeputers.ebal2.api.domain.songset.SongSet"
+                 select="com.homeputers.ebal2.api.domain.songset.SongSetMapper.findById"/>
+            <arg column="arrangement_id" javaType="com.homeputers.ebal2.api.domain.arrangement.Arrangement"
+                 select="com.homeputers.ebal2.api.domain.arrangement.ArrangementMapper.findById"/>
+            <arg column="sort_order" javaType="java.lang.Integer"/>
+            <arg column="transpose" javaType="java.lang.Integer"/>
+            <arg column="capo" javaType="java.lang.Integer"/>
+        </constructor>
     </resultMap>
 
     <select id="findById" resultMap="songSetItemResult">
-        select id, song_set_id, arrangement_id, "order", transpose, capo from song_set_items
+        select id, song_set_id, arrangement_id, "order" as sort_order, transpose, capo from song_set_items
         where id = #{id, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler}
     </select>
 
     <select id="findBySongSetId" resultMap="songSetItemResult">
-        select id, song_set_id, arrangement_id, "order", transpose, capo from song_set_items
+        select id, song_set_id, arrangement_id, "order" as sort_order, transpose, capo from song_set_items
         where song_set_id = #{songSetId, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler}
         order by "order"
     </select>

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/songset/SongSetControllerTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/songset/SongSetControllerTest.java
@@ -1,0 +1,82 @@
+package com.homeputers.ebal2.api.songset;
+
+import com.homeputers.ebal2.api.AbstractIntegrationTest;
+import com.homeputers.ebal2.api.generated.model.ArrangementRequest;
+import com.homeputers.ebal2.api.generated.model.ArrangementResponse;
+import com.homeputers.ebal2.api.generated.model.SongRequest;
+import com.homeputers.ebal2.api.generated.model.SongResponse;
+import com.homeputers.ebal2.api.generated.model.SongSetItemRequest;
+import com.homeputers.ebal2.api.generated.model.SongSetItemResponse;
+import com.homeputers.ebal2.api.generated.model.SongSetRequest;
+import com.homeputers.ebal2.api.generated.model.SongSetResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class SongSetControllerTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void listSongSetItems_returnsPersistedItems() {
+        SongSetRequest setRequest = new SongSetRequest();
+        setRequest.setName("Integration Set");
+        ResponseEntity<SongSetResponse> setResponse =
+                restTemplate.postForEntity("/api/v1/song-sets", setRequest, SongSetResponse.class);
+        assertThat(setResponse.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        UUID songSetId = setResponse.getBody().getId();
+
+        SongRequest songRequest = new SongRequest();
+        songRequest.setTitle("Integration Song");
+        ResponseEntity<SongResponse> songResponse =
+                restTemplate.postForEntity("/api/v1/songs", songRequest, SongResponse.class);
+        assertThat(songResponse.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        UUID songId = songResponse.getBody().getId();
+
+        ArrangementRequest arrangementRequest = new ArrangementRequest();
+        arrangementRequest.setKey("C");
+        ResponseEntity<ArrangementResponse> arrangementResponse = restTemplate.postForEntity(
+                "/api/v1/songs/" + songId + "/arrangements",
+                arrangementRequest,
+                ArrangementResponse.class
+        );
+        assertThat(arrangementResponse.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        UUID arrangementId = arrangementResponse.getBody().getId();
+
+        SongSetItemRequest itemRequest = new SongSetItemRequest();
+        itemRequest.setArrangementId(arrangementId);
+        itemRequest.setSortOrder(0);
+        itemRequest.setTranspose(2);
+        itemRequest.setCapo(1);
+        ResponseEntity<SongSetItemResponse> createItemResponse = restTemplate.postForEntity(
+                "/api/v1/song-sets/" + songSetId + "/items",
+                itemRequest,
+                SongSetItemResponse.class
+        );
+        assertThat(createItemResponse.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+
+        ResponseEntity<SongSetItemResponse[]> itemsResponse = restTemplate.getForEntity(
+                "/api/v1/song-sets/" + songSetId + "/items",
+                SongSetItemResponse[].class
+        );
+
+        assertThat(itemsResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(itemsResponse.getBody()).isNotNull();
+        assertThat(itemsResponse.getBody()).hasSize(1);
+
+        SongSetItemResponse item = itemsResponse.getBody()[0];
+        assertThat(item.getArrangementId()).isEqualTo(arrangementId);
+        assertThat(item.getTranspose()).isEqualTo(2);
+        assertThat(item.getCapo()).isEqualTo(1);
+    }
+}
+

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,10 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.1.0",
+    "@dnd-kit/modifiers": "^6.0.1",
+    "@dnd-kit/sortable": "^7.0.0",
+    "@dnd-kit/utilities": "^3.2.0",
     "@hookform/resolvers": "^3.3.4",
     "@tanstack/react-query": "^5.0.0",
     "axios": "^1.6.7",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -12,6 +12,7 @@ const GroupDetail = lazy(() => import('@/routes/GroupDetail'));
 const Songs = lazy(() => import('@/routes/Songs'));
 const SongDetail = lazy(() => import('@/routes/SongDetail'));
 const SongSets = lazy(() => import('@/routes/SongSets'));
+const SongSetDetail = lazy(() => import('@/routes/SongSetDetail'));
 const Services = lazy(() => import('@/routes/Services'));
 const ServiceDetail = lazy(() => import('@/routes/ServiceDetail'));
 const ServicePrint = lazy(() => import('@/routes/ServicePrint'));
@@ -32,6 +33,7 @@ export default function App() {
                 <Route path="/songs" element={<Songs />} />
                 <Route path="/songs/:id" element={<SongDetail />} />
                 <Route path="/song-sets" element={<SongSets />} />
+                <Route path="/song-sets/:id" element={<SongSetDetail />} />
                 <Route path="/services" element={<Services />} />
                 <Route path="/services/:id" element={<ServiceDetail />} />
                 <Route path="/services/:id/print" element={<ServicePrint />} />

--- a/apps/web/src/api/sets.ts
+++ b/apps/web/src/api/sets.ts
@@ -11,6 +11,7 @@ import {
 type SongSetsPath = keyof paths & '/song-sets';
 type SongSetPath = keyof paths & '/song-sets/{id}';
 type SongSetItemsPath = keyof paths & '/song-sets/{id}/items';
+type SongSetItemsReorderPath = keyof paths & '/song-sets/{id}/items/reorder';
 type SongSetItemPath = keyof paths & '/song-set-items/{id}';
 
 // Song set types
@@ -42,6 +43,8 @@ export type UpdateSetItemBody = RequestBodyOf<SongSetItemPath, 'put'>;
 export type UpdateSetItemResponse = ResponseOf<SongSetItemPath, 'put', 200>;
 
 export type RemoveSetItemParams = PathParamsOf<SongSetItemPath, 'delete'>;
+
+export type ReorderSetItemsBody = RequestBodyOf<SongSetItemsReorderPath, 'post'>;
 
 type SetId = GetSetParams['id'];
 type SetItemId = UpdateSetItemParams['id'];
@@ -95,4 +98,8 @@ export async function updateSetItem(itemId: SetItemId, body: UpdateSetItemBody) 
 
 export async function removeSetItem(itemId: SetItemId) {
   await apiClient.delete<void>(`/song-set-items/${itemId}`);
+}
+
+export async function reorderSetItems(setId: SetId, body: ReorderSetItemsBody) {
+  await apiClient.post<void>(`/song-sets/${setId}/items/reorder`, body);
 }

--- a/apps/web/src/api/songs.ts
+++ b/apps/web/src/api/songs.ts
@@ -1,5 +1,5 @@
 import apiClient from './client';
-import type { paths, components } from './types';
+import type { paths } from './types';
 import {
   QueryOf,
   ResponseOf,

--- a/apps/web/src/components/pickers/SongPicker.tsx
+++ b/apps/web/src/components/pickers/SongPicker.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { listSongs } from '@/api/songs';
 import type { components } from '@/api/types';

--- a/apps/web/src/features/arrangements/useArrangementInfo.ts
+++ b/apps/web/src/features/arrangements/useArrangementInfo.ts
@@ -1,0 +1,87 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { getArrangement, getSong } from '@/api/songs';
+
+export type ArrangementInfo = {
+  songTitle: string;
+  key?: string | null;
+  bpm?: number | null;
+  meter?: string | null;
+};
+
+type ArrangementInfoMap = Record<string, ArrangementInfo>;
+
+type ArrangementIdInput = Array<string | null | undefined> | undefined;
+
+export function useArrangementInfo(arrangementIds: ArrangementIdInput) {
+  const [infoMap, setInfoMap] = useState<ArrangementInfoMap>({});
+  const inFlightRef = useRef(new Set<string>());
+
+  const normalizedIds = useMemo(() => {
+    if (!arrangementIds) return [] as string[];
+    return Array.from(
+      new Set(
+        arrangementIds.filter((id): id is string => typeof id === 'string' && id.length > 0),
+      ),
+    );
+  }, [arrangementIds]);
+
+  useEffect(() => {
+    if (normalizedIds.length === 0) return;
+
+    const missing = normalizedIds.filter(
+      (id) => !infoMap[id] && !inFlightRef.current.has(id),
+    );
+
+    if (missing.length === 0) return;
+
+    let cancelled = false;
+
+    (async () => {
+      for (const arrangementId of missing) {
+        inFlightRef.current.add(arrangementId);
+        try {
+          const arrangement = await getArrangement(arrangementId);
+          const songTitle =
+            arrangement?.songId && arrangement.songId.length > 0
+              ? (await getSong(arrangement.songId))?.title
+              : undefined;
+
+          if (!cancelled) {
+            setInfoMap((prev) => {
+              if (prev[arrangementId]) return prev;
+              return {
+                ...prev,
+                [arrangementId]: {
+                  songTitle: songTitle || 'Song',
+                  key: arrangement?.key,
+                  bpm: arrangement?.bpm,
+                  meter: arrangement?.meter,
+                },
+              };
+            });
+          }
+        } catch {
+          if (!cancelled) {
+            setInfoMap((prev) => {
+              if (prev[arrangementId]) return prev;
+              return {
+                ...prev,
+                [arrangementId]: {
+                  songTitle: 'Song',
+                },
+              };
+            });
+          }
+        } finally {
+          inFlightRef.current.delete(arrangementId);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [normalizedIds, infoMap]);
+
+  return infoMap;
+}

--- a/apps/web/src/features/services/usePlanArrangementInfo.ts
+++ b/apps/web/src/features/services/usePlanArrangementInfo.ts
@@ -1,85 +1,19 @@
-import { useEffect, useRef, useState } from 'react';
+import { useMemo } from 'react';
 import type { components } from '@/api/types';
-import { getArrangement, getSong } from '@/api/songs';
-
-export type ArrangementInfo = {
-  songTitle: string;
-  key?: string | null;
-  bpm?: number | null;
-  meter?: string | null;
-};
+import { useArrangementInfo } from '@/features/arrangements/useArrangementInfo';
 
 type PlanItem = components['schemas']['ServicePlanItemResponse'];
 
-type ArrangementInfoMap = Record<string, ArrangementInfo>;
+export type { ArrangementInfo } from '@/features/arrangements/useArrangementInfo';
 
 export function usePlanArrangementInfo(planItems?: PlanItem[] | null) {
-  const [infoMap, setInfoMap] = useState<ArrangementInfoMap>({});
-  const inFlightRef = useRef(new Set<string>());
+  const arrangementIds = useMemo(() => {
+    if (!planItems) return [] as string[];
+    return planItems
+      .filter((item) => item.type === 'song' && item.refId)
+      .map((item) => item.refId!)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0);
+  }, [planItems]);
 
-  useEffect(() => {
-    if (!planItems || planItems.length === 0) return;
-
-    const candidateIds = Array.from(
-      new Set(
-        planItems
-          .filter((item) => item.type === 'song' && item.refId)
-          .map((item) => item.refId!)
-          .filter(Boolean),
-      ),
-    );
-
-    const missing = candidateIds.filter(
-      (arrangementId) => !infoMap[arrangementId] && !inFlightRef.current.has(arrangementId),
-    );
-
-    if (missing.length === 0) return;
-
-    let cancelled = false;
-
-    (async () => {
-      for (const arrangementId of missing) {
-        inFlightRef.current.add(arrangementId);
-        try {
-          const arrangement = await getArrangement(arrangementId);
-          const songTitle = arrangement.songId ? (await getSong(arrangement.songId))?.title : undefined;
-
-          if (!cancelled) {
-            setInfoMap((prev) => {
-              if (prev[arrangementId]) return prev;
-              return {
-                ...prev,
-                [arrangementId]: {
-                  songTitle: songTitle || 'Song',
-                  key: arrangement.key,
-                  bpm: arrangement.bpm,
-                  meter: arrangement.meter,
-                },
-              };
-            });
-          }
-        } catch {
-          if (!cancelled) {
-            setInfoMap((prev) => {
-              if (prev[arrangementId]) return prev;
-              return {
-                ...prev,
-                [arrangementId]: {
-                  songTitle: 'Song',
-                },
-              };
-            });
-          }
-        } finally {
-          inFlightRef.current.delete(arrangementId);
-        }
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [planItems, infoMap]);
-
-  return infoMap;
+  return useArrangementInfo(arrangementIds);
 }

--- a/apps/web/src/features/sets/hooks.ts
+++ b/apps/web/src/features/sets/hooks.ts
@@ -9,9 +9,11 @@ import {
   addSetItem,
   updateSetItem,
   removeSetItem,
+  reorderSetItems,
   type ListSetsParams,
   type AddSetItemBody,
   type UpdateSetItemBody,
+  type ReorderSetItemsBody,
 } from '../../api/sets';
 
 export function useSongSetsList(params?: ListSetsParams) {
@@ -103,8 +105,7 @@ export function useUpdateSetItem() {
   const qc = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ setId, itemId, body }: UpdateSetItemVariables) =>
-      updateSetItem(itemId, body),
+    mutationFn: ({ itemId, body }: UpdateSetItemVariables) => updateSetItem(itemId, body),
     onSuccess: (_, { setId }) => {
       qc.invalidateQueries({ queryKey: ['songSetItems', setId] });
       qc.invalidateQueries({ queryKey: ['songSet', setId] });
@@ -124,6 +125,19 @@ export function useRemoveSetItem() {
   return useMutation({
     mutationFn: ({ itemId }: RemoveSetItemVariables) => removeSetItem(itemId),
     onSuccess: (_, { setId }) => {
+      qc.invalidateQueries({ queryKey: ['songSetItems', setId] });
+      qc.invalidateQueries({ queryKey: ['songSet', setId] });
+      qc.invalidateQueries({ queryKey: ['songSets'] });
+    },
+  });
+}
+
+export function useReorderSetItems(setId: string) {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: ReorderSetItemsBody) => reorderSetItems(setId, body),
+    onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['songSetItems', setId] });
       qc.invalidateQueries({ queryKey: ['songSet', setId] });
       qc.invalidateQueries({ queryKey: ['songSets'] });

--- a/apps/web/src/lib/chords.ts
+++ b/apps/web/src/lib/chords.ts
@@ -4,7 +4,7 @@ const NOTES_FLAT = ['C', 'Db', 'D', 'Eb', 'E', 'F', 'Gb', 'G', 'Ab', 'A', 'Bb', 
 function transposeNote(note: string, steps: number, useFlats: boolean): string {
   const indexSharp = NOTES_SHARP.indexOf(note);
   const indexFlat = NOTES_FLAT.indexOf(note);
-  let index = indexSharp !== -1 ? indexSharp : indexFlat;
+  const index = indexSharp !== -1 ? indexSharp : indexFlat;
   if (index === -1) return note;
   const newIndex = (index + steps + 12) % 12;
   return useFlats ? NOTES_FLAT[newIndex] : NOTES_SHARP[newIndex];

--- a/apps/web/src/pages/sets/SongSetDetailPage.tsx
+++ b/apps/web/src/pages/sets/SongSetDetailPage.tsx
@@ -1,0 +1,455 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { CSSProperties, FormEvent, ReactNode } from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  type DragEndEvent,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { toast } from 'sonner';
+import SongPicker from '@/components/pickers/SongPicker';
+import ArrangementPicker from '@/components/pickers/ArrangementPicker';
+import SetForm, { type SetFormValues } from '@/features/sets/SetForm';
+import {
+  useSongSet,
+  useSetItems,
+  useAddSetItem,
+  useUpdateSetItem,
+  useRemoveSetItem,
+  useUpdateSet,
+  useReorderSetItems,
+} from '@/features/sets/hooks';
+import type { ListSetItemsResponse } from '@/api/sets';
+import { useArrangementInfo, type ArrangementInfo } from '@/features/arrangements/useArrangementInfo';
+
+function Modal({
+  open,
+  onClose,
+  children,
+}: {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center" onClick={onClose}>
+      <div
+        className="bg-white p-4 rounded shadow max-w-md w-full"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+type SongSetItem = ListSetItemsResponse extends Array<infer Item> ? Item : never;
+type SongSetItemWithId = SongSetItem & { id: string };
+
+type SortableSetItemProps = {
+  item: SongSetItemWithId;
+  arrangement?: ArrangementInfo;
+  onTransposeChange: (itemId: string, next: number) => void;
+  onCapoChange: (itemId: string, next: number) => void;
+  onRemove: (itemId: string) => void;
+};
+
+function formatArrangementDetails(info?: ArrangementInfo) {
+  if (!info) return '…';
+  const parts: string[] = [`Key ${info.key ?? '—'}`];
+  if (info.bpm != null) parts.push(`${info.bpm} BPM`);
+  if (info.meter) parts.push(info.meter);
+  return parts.join(' • ');
+}
+
+function SortableSetItem({
+  item,
+  arrangement,
+  onTransposeChange,
+  onCapoChange,
+  onRemove,
+}: SortableSetItemProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: item.id,
+  });
+
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.6 : undefined,
+  };
+
+  const transpose = item.transpose ?? 0;
+  const capo = item.capo ?? 0;
+
+  const handleTranspose = (delta: number) => {
+    const next = Math.max(-6, Math.min(6, transpose + delta));
+    onTransposeChange(item.id, next);
+  };
+
+  const handleCapo = (value: number) => {
+    const next = Math.max(0, Math.min(7, value));
+    onCapoChange(item.id, next);
+  };
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className="border rounded p-3 bg-white shadow-sm"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="font-semibold">{arrangement?.songTitle ?? 'Song'}</div>
+          <div className="text-sm text-gray-600">{formatArrangementDetails(arrangement)}</div>
+        </div>
+        <button
+          type="button"
+          aria-label="Drag to reorder"
+          className="cursor-grab text-gray-500 hover:text-gray-700 px-2"
+          {...attributes}
+          {...listeners}
+        >
+          ☰
+        </button>
+      </div>
+      <div className="mt-3 flex flex-wrap items-center gap-4">
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-gray-600">Transpose</span>
+          <div className="flex items-center border rounded">
+            <button
+              type="button"
+              onClick={() => handleTranspose(-1)}
+              className="px-2 py-1 text-sm"
+              disabled={transpose <= -6}
+            >
+              −
+            </button>
+            <span className="px-3 w-12 text-center text-sm">
+              {transpose > 0 ? `+${transpose}` : transpose}
+            </span>
+            <button
+              type="button"
+              onClick={() => handleTranspose(1)}
+              className="px-2 py-1 text-sm"
+              disabled={transpose >= 6}
+            >
+              +
+            </button>
+          </div>
+        </div>
+        <label className="flex items-center gap-2 text-sm text-gray-600">
+          Capo
+          <input
+            type="number"
+            min={0}
+            max={7}
+            value={capo}
+            onChange={(e) => {
+              const numeric = Number(e.target.value);
+              if (!Number.isNaN(numeric)) {
+                handleCapo(numeric);
+              }
+            }}
+            className="w-16 border rounded px-2 py-1 text-sm"
+          />
+        </label>
+        <button
+          type="button"
+          onClick={() => onRemove(item.id)}
+          className="ml-auto px-3 py-1 text-sm bg-red-500 text-white rounded"
+        >
+          Delete
+        </button>
+      </div>
+    </li>
+  );
+}
+
+function clampTranspose(value: number) {
+  return Math.max(-6, Math.min(6, value));
+}
+
+function clampCapo(value: number) {
+  return Math.max(0, Math.min(7, value));
+}
+
+export default function SongSetDetailPage() {
+  const { id } = useParams();
+  const setId = id ?? '';
+
+  const { data: songSet, isLoading, isError } = useSongSet(id);
+  const { data: itemsData, isLoading: itemsLoading, isError: itemsError } = useSetItems(id ?? undefined);
+
+  const [orderedItems, setOrderedItems] = useState<SongSetItemWithId[]>([]);
+  const arrangementInfo = useArrangementInfo(orderedItems.map((item) => item.arrangementId));
+
+  const [editingSet, setEditingSet] = useState(false);
+  const [songId, setSongId] = useState<string | undefined>();
+  const [arrangementId, setArrangementId] = useState<string | undefined>();
+  const [transpose, setTranspose] = useState(0);
+  const [capo, setCapo] = useState(0);
+
+  const addItemMut = useAddSetItem(setId);
+  const updateItemMut = useUpdateSetItem();
+  const removeItemMut = useRemoveSetItem();
+  const updateSetMut = useUpdateSet();
+  const reorderMut = useReorderSetItems(setId);
+
+  useEffect(() => {
+    if (!itemsData) return;
+    const withIds = itemsData.filter((item): item is SongSetItemWithId => !!item?.id);
+    const sorted = [...withIds].sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
+    setOrderedItems(sorted);
+  }, [itemsData]);
+
+  const addArrangementInfo = useArrangementInfo(arrangementId ? [arrangementId] : []);
+  const selectedArrangementInfo = arrangementId ? addArrangementInfo[arrangementId] : undefined;
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 5,
+      },
+    }),
+  );
+
+  const sortableIds = useMemo(() => orderedItems.map((item) => item.id), [orderedItems]);
+
+  if (!id) {
+    return <div className="p-4">No song set selected.</div>;
+  }
+
+  if (isLoading) return <div className="p-4">Loading…</div>;
+  if (isError || !songSet) return <div className="p-4">Failed to load song set.</div>;
+
+  const handleAddItem = (e: FormEvent) => {
+    e.preventDefault();
+    if (!arrangementId) return;
+
+    const nextTranspose = clampTranspose(transpose);
+    const nextCapo = clampCapo(capo);
+
+    addItemMut.mutate(
+      {
+        arrangementId,
+        transpose: nextTranspose,
+        capo: nextCapo,
+        sortOrder: orderedItems.length,
+      },
+      {
+        onSuccess: () => {
+          toast('Item added');
+          setSongId(undefined);
+          setArrangementId(undefined);
+          setTranspose(0);
+          setCapo(0);
+        },
+        onError: () => toast('Failed to add item'),
+      },
+    );
+  };
+
+  const handleTransposeChange = (itemId: string, next: number) => {
+    const clamped = clampTranspose(next);
+    const previous = orderedItems;
+    const idx = previous.findIndex((item) => item.id === itemId);
+    if (idx === -1) return;
+    const updated = [...previous];
+    updated[idx] = { ...updated[idx], transpose: clamped };
+    setOrderedItems(updated);
+    updateItemMut.mutate(
+      { setId, itemId, body: { transpose: clamped } },
+      {
+        onError: () => setOrderedItems(previous),
+      },
+    );
+  };
+
+  const handleCapoChange = (itemId: string, next: number) => {
+    const clamped = clampCapo(next);
+    const previous = orderedItems;
+    const idx = previous.findIndex((item) => item.id === itemId);
+    if (idx === -1) return;
+    const updated = [...previous];
+    updated[idx] = { ...updated[idx], capo: clamped };
+    setOrderedItems(updated);
+    updateItemMut.mutate(
+      { setId, itemId, body: { capo: clamped } },
+      {
+        onError: () => setOrderedItems(previous),
+      },
+    );
+  };
+
+  const handleRemove = (itemId: string) => {
+    const previous = orderedItems;
+    setOrderedItems(previous.filter((item) => item.id !== itemId));
+    removeItemMut.mutate(
+      { setId, itemId },
+      {
+        onError: () => setOrderedItems(previous),
+      },
+    );
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = orderedItems.findIndex((item) => item.id === active.id);
+    const newIndex = orderedItems.findIndex((item) => item.id === over.id);
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const previous = orderedItems;
+    const newItems = arrayMove(orderedItems, oldIndex, newIndex);
+    setOrderedItems(newItems);
+    reorderMut.mutate(newItems.map((item) => item.id), {
+      onError: () => setOrderedItems(previous),
+    });
+  };
+
+  const handleSetUpdate = (values: SetFormValues) => {
+    updateSetMut.mutate(
+      { id: setId, body: values },
+      {
+        onSuccess: () => setEditingSet(false),
+      },
+    );
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-semibold">{songSet.name ?? 'Song Set'}</h1>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            className="px-2 py-1 text-sm bg-gray-200 rounded"
+            onClick={() => setEditingSet(true)}
+          >
+            Edit
+          </button>
+        </div>
+      </div>
+      <div className="flex flex-col md:flex-row gap-4">
+        <div className="md:w-1/3 space-y-3">
+          <h2 className="font-semibold">Add Item</h2>
+          <form onSubmit={handleAddItem} className="space-y-3">
+            <SongPicker
+              value={songId}
+              onChange={(value) => {
+                setSongId(value);
+                setArrangementId(undefined);
+              }}
+              placeholder="Search songs..."
+            />
+            <ArrangementPicker
+              songId={songId}
+              value={arrangementId}
+              onChange={(value) => setArrangementId(value)}
+            />
+            {arrangementId && (
+              <div className="text-xs text-gray-600">
+                {formatArrangementDetails(selectedArrangementInfo)}
+              </div>
+            )}
+            <div className="flex flex-col gap-2">
+              <label className="flex items-center justify-between text-sm text-gray-600">
+                Transpose
+                <input
+                  type="number"
+                  min={-6}
+                  max={6}
+                  value={transpose}
+                  onChange={(e) => {
+                    const numeric = Number(e.target.value);
+                    if (!Number.isNaN(numeric)) {
+                      setTranspose(clampTranspose(numeric));
+                    }
+                  }}
+                  className="w-20 border rounded px-2 py-1 text-sm"
+                />
+              </label>
+              <label className="flex items-center justify-between text-sm text-gray-600">
+                Capo
+                <input
+                  type="number"
+                  min={0}
+                  max={7}
+                  value={capo}
+                  onChange={(e) => {
+                    const numeric = Number(e.target.value);
+                    if (!Number.isNaN(numeric)) {
+                      setCapo(clampCapo(numeric));
+                    }
+                  }}
+                  className="w-20 border rounded px-2 py-1 text-sm"
+                />
+              </label>
+            </div>
+            <button
+              type="submit"
+              disabled={addItemMut.isPending || !arrangementId}
+              className="px-4 py-2 bg-green-500 text-white rounded disabled:opacity-50"
+            >
+              Add Item
+            </button>
+          </form>
+        </div>
+        <div className="flex-1 space-y-3">
+          <h2 className="font-semibold">Items</h2>
+          {itemsLoading && <div>Loading…</div>}
+          {itemsError && !itemsLoading && <div>Failed to load items.</div>}
+          {!itemsLoading && orderedItems.length === 0 && !itemsError && <div>No items</div>}
+          {!itemsLoading && orderedItems.length > 0 && (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              modifiers={[restrictToVerticalAxis]}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+                <ul className="space-y-2">
+                  {orderedItems.map((item) => (
+                    <SortableSetItem
+                      key={item.id}
+                      item={item}
+                      arrangement={item.arrangementId ? arrangementInfo[item.arrangementId] : undefined}
+                      onTransposeChange={handleTransposeChange}
+                      onCapoChange={handleCapoChange}
+                      onRemove={handleRemove}
+                    />
+                  ))}
+                </ul>
+              </SortableContext>
+            </DndContext>
+          )}
+          {reorderMut.isPending && <div className="text-sm text-gray-500">Saving order…</div>}
+        </div>
+      </div>
+      <Modal open={editingSet} onClose={() => setEditingSet(false)}>
+        <h2 className="text-lg font-semibold mb-2">Edit Set</h2>
+        <SetForm
+          defaultValues={{ name: songSet.name ?? '' }}
+          onSubmit={handleSetUpdate}
+          onCancel={() => setEditingSet(false)}
+        />
+      </Modal>
+    </div>
+  );
+}

--- a/apps/web/src/routes/SongSetDetail.tsx
+++ b/apps/web/src/routes/SongSetDetail.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/pages/sets/SongSetDetailPage';

--- a/yarn.lock
+++ b/yarn.lock
@@ -422,6 +422,68 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@dnd-kit/accessibility@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@dnd-kit/accessibility@npm:3.1.1"
+  dependencies:
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 10c0/be0bf41716dc58f9386bc36906ec1ce72b7b42b6d1d0e631d347afe9bd8714a829bd6f58a346dd089b1519e93918ae2f94497411a61a4f5e4d9247c6cfd1fef8
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/core@npm:^6.1.0":
+  version: 6.3.1
+  resolution: "@dnd-kit/core@npm:6.3.1"
+  dependencies:
+    "@dnd-kit/accessibility": "npm:^3.1.1"
+    "@dnd-kit/utilities": "npm:^3.2.2"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 10c0/196db95d81096d9dc248983533eab91ba83591770fa5c894b1ac776f42af0d99522b3fd5bb3923411470e4733fcfa103e6ee17adc17b9b7eb54c7fbec5ff7c52
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/modifiers@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "@dnd-kit/modifiers@npm:6.0.1"
+  dependencies:
+    "@dnd-kit/utilities": "npm:^3.2.1"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@dnd-kit/core": ^6.0.6
+    react: ">=16.8.0"
+  checksum: 10c0/cf2a68f4b0c35c87fa143bce0d980ec82067dc023673f27d842d185a15041b5ca19140795351d9a774d86b1a7e3df00a118c4ff61ae121696021ba5678d50363
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/sortable@npm:^7.0.0":
+  version: 7.0.2
+  resolution: "@dnd-kit/sortable@npm:7.0.2"
+  dependencies:
+    "@dnd-kit/utilities": "npm:^3.2.0"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@dnd-kit/core": ^6.0.7
+    react: ">=16.8.0"
+  checksum: 10c0/06aeb113eeeb470bb2443bf1c48d597157bb3a1caa9740e60c2fa73a3076e753cd083a2d381f0556bd7e9873e851a49ce8ea14796ac02e2d796eabea4e27196d
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/utilities@npm:^3.2.0, @dnd-kit/utilities@npm:^3.2.1, @dnd-kit/utilities@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@dnd-kit/utilities@npm:3.2.2"
+  dependencies:
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 10c0/9aa90526f3e3fd567b5acc1b625a63177b9e8d00e7e50b2bd0e08fa2bf4dba7e19529777e001fdb8f89a7ce69f30b190c8364d390212634e0afdfa8c395e85a0
+  languageName: node
+  linkType: hard
+
 "@ebal/config@npm:*, @ebal/config@workspace:packages/config":
   version: 0.0.0-use.local
   resolution: "@ebal/config@workspace:packages/config"
@@ -5813,6 +5875,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:^2.0.0":
+  version: 2.8.1
+  resolution: "tslib@npm:2.8.1"
+  checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
+  languageName: node
+  linkType: hard
+
 "type-check@npm:^0.4.0, type-check@npm:~0.4.0":
   version: 0.4.0
   resolution: "type-check@npm:0.4.0"
@@ -6068,6 +6137,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "web@workspace:apps/web"
   dependencies:
+    "@dnd-kit/core": "npm:^6.1.0"
+    "@dnd-kit/modifiers": "npm:^6.0.1"
+    "@dnd-kit/sortable": "npm:^7.0.0"
+    "@dnd-kit/utilities": "npm:^3.2.0"
     "@ebal/config": "npm:*"
     "@hookform/resolvers": "npm:^3.3.4"
     "@tanstack/react-query": "npm:^5.0.0"


### PR DESCRIPTION
## Summary
- add the Song Set detail screen with drag-and-drop ordering, inline transpose/capo controls, and an add-item form that reuses the existing song and arrangement pickers
- introduce a shared `useArrangementInfo` hook and update the services plan hook to reuse it for song/arrangement metadata
- wire up the reorder API client/hook, register the new route, and install the @dnd-kit dependencies needed for drag-and-drop interactions

## Testing
- yarn lint
- yarn typecheck
- yarn build
- ./mvnw -q -DskipTests=false verify *(fails: network is unreachable while downloading Maven wrapper)*

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68ca067906f8833094d3dd77e89620ed