### PR TITLE
feat(web): add chordpro preview

### DIFF
--- a/apps/web/src/components/chordpro/ChordAboveLyrics.tsx
+++ b/apps/web/src/components/chordpro/ChordAboveLyrics.tsx
@@ -1,0 +1,71 @@
+import { useMemo } from 'react';
+import { transposeChordToken } from '../../lib/chordpro/parse';
+import type { ChordProToken } from '../../lib/chordpro/types';
+
+type Props = {
+  tokens: ChordProToken[];
+  transpose: number;
+  useFlats?: boolean;
+};
+
+type BuiltLines = {
+  chordLine: string;
+  lyricLine: string;
+};
+
+function buildLines(tokens: ChordProToken[], transpose: number, useFlats?: boolean): BuiltLines {
+  let chordLine = '';
+  let lyricLine = '';
+  let previousTokenWasChord = false;
+
+  tokens.forEach((token) => {
+    if (token.kind === 'lyric') {
+      lyricLine += token.text;
+      if (chordLine.length < lyricLine.length) {
+        chordLine = chordLine.padEnd(lyricLine.length, ' ');
+      }
+      previousTokenWasChord = false;
+      return;
+    }
+
+    if (chordLine.length < lyricLine.length) {
+      chordLine = chordLine.padEnd(lyricLine.length, ' ');
+    } else if (chordLine.length > lyricLine.length) {
+      lyricLine = lyricLine.padEnd(chordLine.length, ' ');
+    }
+
+    if (previousTokenWasChord && chordLine.length > 0) {
+      chordLine += ' ';
+      lyricLine = lyricLine.padEnd(chordLine.length, ' ');
+    }
+
+    const transposed = transposeChordToken(token.text, transpose, useFlats);
+    chordLine += transposed;
+    previousTokenWasChord = transposed.trim().length > 0;
+  });
+
+  if (chordLine.length < lyricLine.length) {
+    chordLine = chordLine.padEnd(lyricLine.length, ' ');
+  } else if (lyricLine.length < chordLine.length) {
+    lyricLine = lyricLine.padEnd(chordLine.length, ' ');
+  }
+
+  return {
+    chordLine: chordLine.replace(/\s+$/, ''),
+    lyricLine: lyricLine.replace(/\s+$/, ''),
+  };
+}
+
+export function ChordAboveLyrics({ tokens, transpose, useFlats }: Props) {
+  const { chordLine, lyricLine } = useMemo(
+    () => buildLines(tokens, transpose, useFlats),
+    [tokens, transpose, useFlats],
+  );
+
+  return (
+    <div className="chordpro-line chordpro-line--stacked">
+      <div className="chord-line">{chordLine || ' '}</div>
+      <div className="lyric-line">{lyricLine || ' '}</div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chordpro/ChordProView.tsx
+++ b/apps/web/src/components/chordpro/ChordProView.tsx
@@ -1,0 +1,109 @@
+import { useMemo } from 'react';
+import { parseChordPro, transposeChordToken } from '../../lib/chordpro/parse';
+import type { ChordProLineNode, ChordProNode } from '../../lib/chordpro/types';
+import { ChordAboveLyrics } from './ChordAboveLyrics';
+
+type Layout = 'inline' | 'above';
+
+type Props = {
+  source: string;
+  transpose?: number;
+  useFlats?: boolean;
+  layout?: Layout;
+  className?: string;
+};
+
+function renderInlineLine(
+  line: ChordProLineNode,
+  transpose: number,
+  useFlats: boolean,
+  lineIndex: number,
+) {
+  return (
+    <div key={`line-${lineIndex}`} className="chordpro-line">
+      {line.tokens.map((token, tokenIndex) => {
+        if (token.kind === 'chord') {
+          const transposed = transposeChordToken(token.text, transpose, useFlats);
+          return (
+            <span key={`line-${lineIndex}-token-${tokenIndex}`} className="chord">
+              {transposed || ' '}
+            </span>
+          );
+        }
+
+        return (
+          <span key={`line-${lineIndex}-token-${tokenIndex}`}>
+            {token.text.length > 0 ? token.text : '​'}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+function renderDirective(node: ChordProNode, index: number) {
+  if (node.type !== 'directive') {
+    return null;
+  }
+
+  const name = node.name.trim().toLowerCase();
+  if (name === 'title') {
+    return (
+      <div key={`directive-${index}`} className="chordpro-title">
+        {node.value}
+      </div>
+    );
+  }
+
+  if (name === 'comment') {
+    return (
+      <div key={`directive-${index}`} className="chordpro-comment">
+        {node.value}
+      </div>
+    );
+  }
+
+  return null;
+}
+
+export function ChordProView({
+  source,
+  transpose = 0,
+  useFlats = false,
+  layout = 'inline',
+  className,
+}: Props) {
+  const parsed = useMemo(() => parseChordPro(source ?? ''), [source]);
+  const containerClassName = ['chordpro-view', className].filter(Boolean).join(' ');
+
+  return (
+    <div className={containerClassName}>
+      {parsed.map((node, index) => {
+        if (node.type === 'empty') {
+          return (
+            <div key={`empty-${index}`} className="chordpro-line chordpro-line--empty">
+              {' '}
+            </div>
+          );
+        }
+
+        if (node.type === 'directive') {
+          return renderDirective(node, index);
+        }
+
+        if (layout === 'above') {
+          return (
+            <ChordAboveLyrics
+              key={`line-${index}`}
+              tokens={node.tokens}
+              transpose={transpose}
+              useFlats={useFlats}
+            />
+          );
+        }
+
+        return renderInlineLine(node, transpose, useFlats, index);
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/features/songs/ArrangementForm.tsx
+++ b/apps/web/src/features/songs/ArrangementForm.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import type { components } from '../../api/types';
-import { transposeChordPro } from '../../lib/chords';
+import { ChordProView } from '../../components/chordpro/ChordProView';
 
 const schema = z.object({
   key: z.string().min(1, 'Key is required'),
@@ -39,9 +39,10 @@ export function ArrangementForm({
 
   const [transpose, setTranspose] = useState(0);
   const [useFlats, setUseFlats] = useState(false);
+  const [layout, setLayout] = useState<'inline' | 'above'>('inline');
 
   const lyrics = watch('lyricsChordpro') || '';
-  const preview = transposeChordPro(lyrics, transpose, useFlats);
+  const normalizedLyrics = lyrics.replace(/\r\n?/g, '\n');
 
   return (
     <form
@@ -118,7 +119,7 @@ export function ArrangementForm({
           </div>
         </div>
         <div className="flex-1 flex flex-col">
-          <div className="mb-2 flex gap-2">
+          <div className="mb-2 flex gap-2 items-center">
             <button
               type="button"
               className="px-2 py-1 border rounded"
@@ -140,10 +141,27 @@ export function ArrangementForm({
             >
               {useFlats ? 'Use sharps' : 'Use flats'}
             </button>
+            <label className="text-sm">
+              Layout
+              <select
+                value={layout}
+                onChange={(event) =>
+                  setLayout(event.target.value === 'above' ? 'above' : 'inline')
+                }
+                className="ml-1 border rounded px-2 py-1 text-sm"
+              >
+                <option value="inline">Inline</option>
+                <option value="above">Chords above</option>
+              </select>
+            </label>
           </div>
-          <pre className="whitespace-pre-wrap border p-2 rounded flex-1 overflow-auto">
-            {preview}
-          </pre>
+          <ChordProView
+            source={normalizedLyrics}
+            transpose={transpose}
+            useFlats={useFlats}
+            layout={layout}
+            className="flex-1 overflow-auto p-3 border rounded font-mono text-sm"
+          />
         </div>
       </div>
     </form>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,3 +1,46 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.chordpro-view {
+  white-space: pre-wrap;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}
+
+.chordpro-view .chordpro-line {
+  white-space: pre-wrap;
+}
+
+.chordpro-view .chordpro-line--empty {
+  min-height: 1.25rem;
+}
+
+.chordpro-view .chord {
+  font-weight: 600;
+}
+
+.chordpro-view .chordpro-title {
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.chordpro-view .chordpro-comment {
+  font-style: italic;
+  margin-bottom: 0.25rem;
+}
+
+.chordpro-view .chordpro-line--stacked {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 0.25rem;
+}
+
+.chordpro-view .chord-line,
+.chordpro-view .lyric-line {
+  white-space: pre;
+}
+
+.chordpro-view .chord-line {
+  font-weight: 600;
+  font-size: 0.875rem;
+}

--- a/apps/web/src/lib/chordpro/parse.ts
+++ b/apps/web/src/lib/chordpro/parse.ts
@@ -1,0 +1,113 @@
+import { transposeChord } from '../transpose';
+import type {
+  ChordProDirectiveNode,
+  ChordProLineNode,
+  ChordProToken,
+  ParsedChordPro,
+} from './types';
+
+const CHORD_REGEX = /\[([^\]]+)\]/g;
+
+function tokenizeLine(line: string): ChordProToken[] {
+  const tokens: ChordProToken[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  const regex = new RegExp(CHORD_REGEX);
+
+  while ((match = regex.exec(line)) !== null) {
+    const [fullMatch, chord] = match;
+    const preceding = line.slice(lastIndex, match.index);
+    if (preceding) {
+      tokens.push({ kind: 'lyric', text: preceding });
+    }
+    tokens.push({ kind: 'chord', text: chord });
+    lastIndex = match.index + fullMatch.length;
+  }
+
+  const rest = line.slice(lastIndex);
+  if (rest) {
+    tokens.push({ kind: 'lyric', text: rest });
+  }
+
+  if (tokens.length === 0) {
+    tokens.push({ kind: 'lyric', text: line });
+  }
+
+  return tokens;
+}
+
+function parseDirective(line: string): ChordProDirectiveNode | null {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) {
+    return null;
+  }
+
+  const body = trimmed.slice(1, -1).trim();
+  if (!body) {
+    return { type: 'directive', name: '' };
+  }
+
+  const colonIndex = body.indexOf(':');
+  if (colonIndex === -1) {
+    return { type: 'directive', name: body };
+  }
+
+  const name = body.slice(0, colonIndex).trim();
+  const value = body.slice(colonIndex + 1).trim();
+  return {
+    type: 'directive',
+    name,
+    value,
+  };
+}
+
+export function parseChordPro(input: string): ParsedChordPro {
+  const normalized = input.replace(/\r\n?/g, '\n');
+  const lines = normalized.split('\n');
+  const result: ParsedChordPro = [];
+
+  for (const line of lines) {
+    if (line.length === 0) {
+      result.push({ type: 'empty' });
+      continue;
+    }
+
+    const directive = parseDirective(line);
+    if (directive) {
+      result.push(directive);
+      continue;
+    }
+
+    const tokens = tokenizeLine(line);
+    const lineNode: ChordProLineNode = {
+      type: 'line',
+      tokens,
+    };
+    result.push(lineNode);
+  }
+
+  return result;
+}
+
+export function transposeChordToken(
+  chord: string,
+  semitones: number,
+  useFlats?: boolean,
+): string {
+  if (!chord) {
+    return chord;
+  }
+
+  const leadingWhitespaceMatch = chord.match(/^\s*/);
+  const trailingWhitespaceMatch = chord.match(/\s*$/);
+  const leadingWhitespace = leadingWhitespaceMatch ? leadingWhitespaceMatch[0] : '';
+  const trailingWhitespace = trailingWhitespaceMatch ? trailingWhitespaceMatch[0] : '';
+  const core = chord.trim();
+
+  if (!core) {
+    return chord;
+  }
+
+  const transposed = transposeChord(core, semitones, useFlats);
+  return `${leadingWhitespace}${transposed}${trailingWhitespace}`;
+}

--- a/apps/web/src/lib/chordpro/types.ts
+++ b/apps/web/src/lib/chordpro/types.ts
@@ -1,0 +1,26 @@
+export type ChordProToken = {
+  kind: 'chord' | 'lyric';
+  text: string;
+};
+
+export type ChordProLineNode = {
+  type: 'line';
+  tokens: ChordProToken[];
+};
+
+export type ChordProDirectiveNode = {
+  type: 'directive';
+  name: string;
+  value?: string;
+};
+
+export type ChordProEmptyNode = {
+  type: 'empty';
+};
+
+export type ChordProNode =
+  | ChordProLineNode
+  | ChordProDirectiveNode
+  | ChordProEmptyNode;
+
+export type ParsedChordPro = ChordProNode[];


### PR DESCRIPTION
## Summary
- add chordpro token types and parser with directive handling and transposition helper
- build chordpro preview components with inline and chords-above layouts plus styling hooks
- integrate the new preview into the arrangement form with transpose/flats/layout controls

## Testing
- `cd apps/web && yarn typecheck`

## PR Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68cae808c1fc8330923eb7fcfb231400