### PR TITLE
feat: add conditional storage module scaffolding

### DIFF
--- a/apps/api-java/pom.xml
+++ b/apps/api-java/pom.xml
@@ -65,6 +65,11 @@
             <artifactId>spring-data-commons</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.minio</groupId>
+            <artifactId>minio</artifactId>
+            <version>8.5.5</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/storage/MinioStorageService.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/storage/MinioStorageService.java
@@ -1,0 +1,101 @@
+package com.homeputers.ebal2.api.storage;
+
+import io.minio.GetObjectArgs;
+import io.minio.GetPresignedObjectUrlArgs;
+import io.minio.MinioClient;
+import io.minio.PutObjectArgs;
+import io.minio.http.Method;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@ConditionalOnProperty(prefix = "ebal.storage", name = "enabled", havingValue = "true")
+public class MinioStorageService implements StorageService {
+    private static final Duration MAX_EXPIRY = Duration.ofDays(7);
+    private final MinioClient minioClient;
+    private final String bucketName;
+
+    public MinioStorageService(
+            @Value("${ebal.storage.endpoint}") String endpoint,
+            @Value("${ebal.storage.access-key}") String accessKey,
+            @Value("${ebal.storage.secret-key}") String secretKey,
+            @Value("${ebal.storage.bucket}") String bucketName,
+            @Value("${ebal.storage.region:}") String region
+    ) {
+        Objects.requireNonNull(endpoint, "Storage endpoint must be provided");
+        Objects.requireNonNull(accessKey, "Storage access key must be provided");
+        Objects.requireNonNull(secretKey, "Storage secret key must be provided");
+        Objects.requireNonNull(bucketName, "Storage bucket must be provided");
+        this.bucketName = bucketName;
+        MinioClient.Builder builder = MinioClient.builder()
+                .endpoint(endpoint)
+                .credentials(accessKey, secretKey);
+        if (StringUtils.hasText(region)) {
+            builder.region(region);
+        }
+        this.minioClient = builder.build();
+    }
+
+    @Override
+    public void put(String objectName, InputStream data, long size, String contentType) {
+        Objects.requireNonNull(objectName, "Object name is required");
+        Objects.requireNonNull(data, "Input stream is required");
+        if (size < 0) {
+            throw new IllegalArgumentException("Object size must be non-negative");
+        }
+        try {
+            PutObjectArgs.Builder builder = PutObjectArgs.builder()
+                    .bucket(bucketName)
+                    .object(objectName)
+                    .stream(data, size, -1);
+            if (StringUtils.hasText(contentType)) {
+                builder.contentType(contentType);
+            }
+            minioClient.putObject(builder.build());
+        } catch (Exception ex) {
+            throw new StorageException("Failed to upload object '%s'".formatted(objectName), ex);
+        }
+    }
+
+    @Override
+    public InputStream get(String objectName) {
+        Objects.requireNonNull(objectName, "Object name is required");
+        try {
+            return minioClient.getObject(GetObjectArgs.builder()
+                    .bucket(bucketName)
+                    .object(objectName)
+                    .build());
+        } catch (Exception ex) {
+            throw new StorageException("Failed to download object '%s'".formatted(objectName), ex);
+        }
+    }
+
+    @Override
+    public String signedUrl(String objectName, Duration expiry) {
+        Objects.requireNonNull(objectName, "Object name is required");
+        Duration effectiveExpiry = expiry == null || expiry.isNegative() || expiry.isZero()
+                ? Duration.ofMinutes(15)
+                : expiry;
+        if (effectiveExpiry.compareTo(MAX_EXPIRY) > 0) {
+            effectiveExpiry = MAX_EXPIRY;
+        }
+        try {
+            int expirySeconds = Math.toIntExact(effectiveExpiry.getSeconds());
+            return minioClient.getPresignedObjectUrl(GetPresignedObjectUrlArgs.builder()
+                    .bucket(bucketName)
+                    .object(objectName)
+                    .method(Method.GET)
+                    .expiry(expirySeconds, TimeUnit.SECONDS)
+                    .build());
+        } catch (Exception ex) {
+            throw new StorageException("Failed to create signed URL for object '%s'".formatted(objectName), ex);
+        }
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/storage/StorageController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/storage/StorageController.java
@@ -1,25 +1,26 @@
 package com.homeputers.ebal2.api.storage;
 
+import com.homeputers.ebal2.api.generated.StorageApi;
+import com.homeputers.ebal2.api.generated.model.StorageHealth;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Map;
-
 @RestController
-@RequestMapping("/api/v1/storage")
+@RequestMapping("/api/v1")
 @ConditionalOnProperty(prefix = "ebal.storage", name = "enabled", havingValue = "true")
-public class StorageController {
+public class StorageController implements StorageApi {
     private final StorageService storageService;
 
     public StorageController(StorageService storageService) {
         this.storageService = storageService;
     }
 
-    @GetMapping("/health")
-    public ResponseEntity<Map<String, String>> health() {
-        return ResponseEntity.ok(Map.of("status", "enabled"));
+    @Override
+    public ResponseEntity<StorageHealth> storageHealth() {
+        StorageHealth health = new StorageHealth();
+        health.setStatus(storageService != null ? "enabled" : "unavailable");
+        return ResponseEntity.ok(health);
     }
 }

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/storage/StorageController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/storage/StorageController.java
@@ -1,0 +1,25 @@
+package com.homeputers.ebal2.api.storage;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/storage")
+@ConditionalOnProperty(prefix = "ebal.storage", name = "enabled", havingValue = "true")
+public class StorageController {
+    private final StorageService storageService;
+
+    public StorageController(StorageService storageService) {
+        this.storageService = storageService;
+    }
+
+    @GetMapping("/health")
+    public ResponseEntity<Map<String, String>> health() {
+        return ResponseEntity.ok(Map.of("status", "enabled"));
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/storage/StorageException.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/storage/StorageException.java
@@ -1,0 +1,7 @@
+package com.homeputers.ebal2.api.storage;
+
+public class StorageException extends RuntimeException {
+    public StorageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/storage/StorageService.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/storage/StorageService.java
@@ -1,0 +1,12 @@
+package com.homeputers.ebal2.api.storage;
+
+import java.io.InputStream;
+import java.time.Duration;
+
+public interface StorageService {
+    void put(String objectName, InputStream data, long size, String contentType);
+
+    InputStream get(String objectName);
+
+    String signedUrl(String objectName, Duration expiry);
+}

--- a/apps/api-java/src/main/resources/application.yaml
+++ b/apps/api-java/src/main/resources/application.yaml
@@ -10,3 +10,12 @@ mybatis:
   type-handlers-package: com.homeputers.ebal2.api.mybatis.typehandler
   configuration:
     map-underscore-to-camel-case: true
+
+ebal:
+  storage:
+    enabled: ${EBAL_STORAGE_ENABLED:false}
+    endpoint: ${EBAL_STORAGE_ENDPOINT:}
+    access-key: ${EBAL_STORAGE_ACCESS_KEY:}
+    secret-key: ${EBAL_STORAGE_SECRET_KEY:}
+    bucket: ${EBAL_STORAGE_BUCKET:}
+    region: ${EBAL_STORAGE_REGION:}

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/storage/StorageFeatureFlagTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/storage/StorageFeatureFlagTest.java
@@ -1,0 +1,41 @@
+package com.homeputers.ebal2.api.storage;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StorageFeatureFlagTest {
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(StorageComponentConfig.class);
+
+    @Test
+    void storageBeansAreDisabledByDefault() {
+        contextRunner.run(context -> {
+            assertThat(context).doesNotHaveBean(StorageService.class);
+            assertThat(context).doesNotHaveBean(StorageController.class);
+        });
+    }
+
+    @Test
+    void storageBeansLoadWhenFeatureFlagEnabled() {
+        contextRunner.withPropertyValues(
+                        "ebal.storage.enabled=true",
+                        "ebal.storage.endpoint=http://localhost:9000",
+                        "ebal.storage.access-key=test",
+                        "ebal.storage.secret-key=test",
+                        "ebal.storage.bucket=attachments"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(StorageService.class);
+                    assertThat(context).hasSingleBean(StorageController.class);
+                });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ComponentScan(basePackageClasses = MinioStorageService.class)
+    static class StorageComponentConfig {
+    }
+}

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -17,6 +17,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Health'
+  /storage/health:
+    get:
+      tags:
+        - Storage
+      summary: Check storage module readiness
+      description: Returns the current status of the storage subsystem when enabled.
+      operationId: storageHealth
+      responses:
+        '200':
+          description: Storage module is available
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StorageHealth'
   /auth/me:
     get:
       tags:
@@ -751,6 +765,15 @@ components:
       properties:
         status:
           type: string
+    StorageHealth:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          description: High level status string for the storage module.
+      example:
+        status: enabled
     CurrentUser:
       type: object
       required: [subject, displayName, anonymous, roles]


### PR DESCRIPTION
## Summary
- introduce a storage package with a guarded Minio-backed StorageService and controller
- add configuration placeholders for storage credentials and bucket names
- cover the feature flag behaviour with context-runner tests

## Testing
- `mvn -q -DskipTests=false verify` *(fails: network is unreachable while downloading spring-boot-starter-parent)*

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [x] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68cb07be0c1c8330ac53a842602fb6a7