### PR TITLE
chore: add docker setup for web and api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down logs
+.PHONY: up down logs build web-build web-up web-down web-logs api-build api-up api-down api-logs
 
-up down logs:
+up down logs build web-build web-up web-down web-logs api-build api-up api-down api-logs:
 	$(MAKE) -C infra $@

--- a/apps/api-java/Dockerfile
+++ b/apps/api-java/Dockerfile
@@ -1,12 +1,24 @@
 # syntax=docker/dockerfile:1
 
 FROM maven:3.9.6-eclipse-temurin-21 AS build
-WORKDIR /workspace
-COPY . .
-RUN ./mvnw -q -e -DskipTests package
+WORKDIR /workspace/apps/api-java
+
+# Copy Maven wrapper, pom, and configuration first for better caching
+COPY apps/api-java/mvnw ./mvnw
+COPY apps/api-java/.mvn ./.mvn
+COPY apps/api-java/pom.xml ./pom.xml
+COPY spec /workspace/spec
+
+RUN chmod +x mvnw
+RUN ./mvnw -B -ntp dependency:go-offline
+
+# Copy source after dependencies to leverage Docker layer caching
+COPY apps/api-java/src ./src
+
+RUN ./mvnw -B -ntp -DskipTests package
 
 FROM gcr.io/distroless/java21
 WORKDIR /app
-COPY --from=build /workspace/target/api-0.0.1-SNAPSHOT.jar app.jar
+COPY --from=build /workspace/apps/api-java/target/api-0.0.1-SNAPSHOT.jar app.jar
 EXPOSE 8080
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+# Enable Corepack to use the repo-managed Yarn version
+RUN corepack enable
+
+# Copy workspace manifests first for better caching
+COPY package.json yarn.lock ./
+COPY .yarn .yarn
+COPY apps/web ./apps/web
+COPY packages ./packages
+
+# Set the API base URL at build time with a sensible default
+ARG VITE_API_URL=http://localhost:8080
+ENV VITE_API_URL=${VITE_API_URL}
+
+RUN yarn install --immutable
+RUN yarn workspace web build
+
+FROM nginx:1.25-alpine AS runner
+COPY --from=builder /app/apps/web/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down logs
+.PHONY: up down logs build web-build web-up web-down web-logs api-build api-up api-down api-logs
 
 up:
 	docker compose up -d
@@ -8,3 +8,30 @@ down:
 
 logs:
 	docker compose logs -f
+
+build:
+	docker compose build
+
+web-build:
+	docker compose build web
+
+web-up:
+	docker compose up -d web
+
+web-down:
+	docker compose stop web
+
+web-logs:
+	docker compose logs -f web
+
+api-build:
+	docker compose build api
+
+api-up:
+	docker compose up -d api
+
+api-down:
+	docker compose stop api
+
+api-logs:
+	docker compose logs -f api

--- a/infra/docker-compose.yaml
+++ b/infra/docker-compose.yaml
@@ -12,5 +12,41 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
+  api:
+    build:
+      context: ..
+      dockerfile: apps/api-java/Dockerfile
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB}
+      SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
+      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
+    ports:
+      - "8080:8080"
+    depends_on:
+      - postgres
+
+  web:
+    build:
+      context: ..
+      dockerfile: apps/web/Dockerfile
+      args:
+        VITE_API_URL: http://localhost:8080
+    environment:
+      VITE_API_URL: http://localhost:8080
+    ports:
+      - "4173:80"
+    depends_on:
+      - api
+
+  # nginx:
+  #   image: nginx:1.25-alpine
+  #   volumes:
+  #     - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+  #   ports:
+  #     - "80:80"
+  #   depends_on:
+  #     - web
+  #     - api
+
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile for the Vite web app that installs with Yarn and serves the build through nginx
- restructure the Spring Boot Dockerfile to cache dependencies while keeping a distroless runtime image
- extend docker-compose and Makefile targets to build/run web and api services with optional reverse proxy scaffolding

## Testing
- docker compose config *(fails: Docker CLI not available in automation container)*

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68cb0dcd3ca08330bb1082d10d36ec2f