### PR TITLE
feat: add OpenTelemetry tracing filter

### DIFF
--- a/apps/api-java/pom.xml
+++ b/apps/api-java/pom.xml
@@ -70,6 +70,18 @@
             <version>8.5.5</version>
         </dependency>
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-otel</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/OpenTelemetryConfig.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/OpenTelemetryConfig.java
@@ -1,0 +1,77 @@
+package com.homeputers.ebal2.api.config;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.util.StringUtils;
+
+@Configuration
+@ConditionalOnProperty(prefix = "ebal.otel", name = "enabled", havingValue = "true")
+public class OpenTelemetryConfig {
+
+    @Bean
+    OtlpGrpcSpanExporter otlpGrpcSpanExporter(
+            @Value("${ebal.otel.exporter.otlp.endpoint:}") String endpoint
+    ) {
+        var builder = OtlpGrpcSpanExporter.builder();
+        if (StringUtils.hasText(endpoint)) {
+            builder.setEndpoint(endpoint);
+        }
+        return builder.build();
+    }
+
+    @Bean(destroyMethod = "close")
+    OpenTelemetry openTelemetry(OtlpGrpcSpanExporter spanExporter) {
+        Resource resource = Resource.getDefault().merge(Resource.builder()
+                .put(AttributeKey.stringKey("service.name"), "ebal-api")
+                .build());
+
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+                .setResource(resource)
+                .addSpanProcessor(BatchSpanProcessor.builder(spanExporter).build())
+                .build();
+
+        TextMapPropagator propagator = TextMapPropagator.composite(
+                W3CTraceContextPropagator.getInstance(),
+                W3CBaggagePropagator.getInstance()
+        );
+
+        return OpenTelemetrySdk.builder()
+                .setTracerProvider(tracerProvider)
+                .setPropagators(ContextPropagators.create(propagator))
+                .build();
+    }
+
+    @Bean
+    Tracer tracer(OpenTelemetry openTelemetry) {
+        return openTelemetry.getTracer("com.homeputers.ebal2.api");
+    }
+
+    @Bean
+    WebMvcTracingFilter webMvcTracingFilter(Tracer tracer) {
+        return new WebMvcTracingFilter(tracer);
+    }
+
+    @Bean
+    FilterRegistrationBean<WebMvcTracingFilter> webMvcTracingFilterRegistration(WebMvcTracingFilter filter) {
+        FilterRegistrationBean<WebMvcTracingFilter> registration = new FilterRegistrationBean<>(filter);
+        registration.setName("otelWebMvcTracingFilter");
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE + 20);
+        return registration;
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/WebMvcTracingFilter.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/WebMvcTracingFilter.java
@@ -1,0 +1,87 @@
+package com.homeputers.ebal2.api.config;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.io.IOException;
+
+class WebMvcTracingFilter extends OncePerRequestFilter {
+
+    private static final AttributeKey<String> HTTP_METHOD = AttributeKey.stringKey("http.method");
+    private static final AttributeKey<String> HTTP_ROUTE = AttributeKey.stringKey("http.route");
+    private static final AttributeKey<String> URL_SCHEME = AttributeKey.stringKey("url.scheme");
+    private static final AttributeKey<String> HTTP_TARGET = AttributeKey.stringKey("http.target");
+    private static final AttributeKey<String> HTTP_HOST = AttributeKey.stringKey("http.host");
+    private static final AttributeKey<String> HTTP_USER_AGENT = AttributeKey.stringKey("http.user_agent");
+    private static final AttributeKey<Long> HTTP_STATUS_CODE = AttributeKey.longKey("http.status_code");
+
+    private final Tracer tracer;
+
+    WebMvcTracingFilter(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String spanName = "%s %s".formatted(request.getMethod(), request.getRequestURI());
+        Span span = tracer.spanBuilder(spanName)
+                .setSpanKind(SpanKind.SERVER)
+                .startSpan();
+
+        span.setAttribute(HTTP_METHOD, request.getMethod());
+        String target = request.getRequestURI();
+        String queryString = request.getQueryString();
+        if (queryString != null && !queryString.isBlank()) {
+            target = target + "?" + queryString;
+        }
+        span.setAttribute(HTTP_TARGET, target);
+        span.setAttribute(URL_SCHEME, request.getScheme());
+        String host = request.getHeader("Host");
+        if (host == null || host.isBlank()) {
+            host = request.getServerName();
+            int port = request.getServerPort();
+            if (port > 0) {
+                host = host + ":" + port;
+            }
+        }
+        span.setAttribute(HTTP_HOST, host);
+        String userAgent = request.getHeader("User-Agent");
+        if (userAgent != null && !userAgent.isBlank()) {
+            span.setAttribute(HTTP_USER_AGENT, userAgent);
+        }
+        try (Scope ignored = span.makeCurrent()) {
+            filterChain.doFilter(request, response);
+            span.setAttribute(HTTP_STATUS_CODE, (long) response.getStatus());
+            if (response.getStatus() >= 500) {
+                span.setStatus(StatusCode.ERROR);
+            } else {
+                span.setStatus(StatusCode.OK);
+            }
+        } catch (Exception ex) {
+            span.recordException(ex);
+            span.setStatus(StatusCode.ERROR);
+            span.setAttribute(HTTP_STATUS_CODE, 500L);
+            throw ex;
+        } finally {
+            String route = (String) request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+            if (route != null && !route.isBlank()) {
+                span.setAttribute(HTTP_ROUTE, route);
+            }
+            span.end();
+        }
+    }
+}

--- a/apps/api-java/src/main/resources/application.yaml
+++ b/apps/api-java/src/main/resources/application.yaml
@@ -12,6 +12,11 @@ mybatis:
     map-underscore-to-camel-case: true
 
 ebal:
+  otel:
+    enabled: ${EBAL_OTEL_ENABLED:false}
+    exporter:
+      otlp:
+        endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:}
   storage:
     enabled: ${EBAL_STORAGE_ENABLED:false}
     endpoint: ${EBAL_STORAGE_ENDPOINT:}


### PR DESCRIPTION
## Summary
- add OpenTelemetry SDK, OTLP exporter, and micrometer tracing bridge dependencies
- expose `ebal.otel.*` configuration with an OTLP endpoint placeholder
- register conditional OpenTelemetry beans and a WebMvc tracing filter when tracing is enabled

## Testing
- `mvn -DskipTests=false verify` *(fails: network is unreachable while resolving Spring Boot parent)*
- `./mvnw -q -DskipTests=false verify` *(fails: network is unreachable while downloading Maven wrapper distribution)*

## 12) PR Checklist (agents copy this into PR body)
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68cc2990a5f48330a2e032f9868a3b48