### PR TITLE
feat: add service calendar ical feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,11 @@ Lint the repository:
 yarn lint
 ```
 
+## Service calendar export
+
+The API provides a read-only iCalendar feed of upcoming services at
+`GET /api/v1/services/ical?token=...`. Tokens must exist in the
+`share_tokens` table with a `type` of `service_calendar`; this allows you
+to generate and distribute calendar links without granting write
+permissions.
+

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/service/ServiceMapper.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/service/ServiceMapper.java
@@ -19,6 +19,9 @@ public interface ServiceMapper {
                          @Param("end") OffsetDateTime end,
                          @Param("limit") int limit);
 
+    List<Service> findUpcoming(@Param("start") OffsetDateTime start,
+                               @Param("limit") int limit);
+
     int count();
 
     void insert(Service service);

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/token/ShareToken.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/token/ShareToken.java
@@ -1,0 +1,11 @@
+package com.homeputers.ebal2.api.domain.token;
+
+import java.time.OffsetDateTime;
+
+public record ShareToken(
+        String token,
+        String type,
+        String label,
+        OffsetDateTime createdAt
+) {
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/token/ShareTokenMapper.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/token/ShareTokenMapper.java
@@ -1,0 +1,11 @@
+package com.homeputers.ebal2.api.domain.token;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface ShareTokenMapper {
+    ShareToken findByTokenAndType(@Param("token") String token, @Param("type") String type);
+
+    void insert(ShareToken token);
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/service/ServiceCalendarService.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/service/ServiceCalendarService.java
@@ -1,0 +1,105 @@
+package com.homeputers.ebal2.api.service;
+
+import com.homeputers.ebal2.api.domain.service.Service;
+import com.homeputers.ebal2.api.domain.service.ServiceMapper;
+import com.homeputers.ebal2.api.domain.token.ShareToken;
+import com.homeputers.ebal2.api.domain.token.ShareTokenMapper;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+
+@org.springframework.stereotype.Service
+public class ServiceCalendarService {
+    static final String CALENDAR_TOKEN_TYPE = "service_calendar";
+    private static final DateTimeFormatter DATE_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'").withZone(ZoneOffset.UTC);
+    private static final int DEFAULT_LIMIT = 200;
+
+    private final ServiceMapper serviceMapper;
+    private final ShareTokenMapper shareTokenMapper;
+
+    public ServiceCalendarService(ServiceMapper serviceMapper, ShareTokenMapper shareTokenMapper) {
+        this.serviceMapper = serviceMapper;
+        this.shareTokenMapper = shareTokenMapper;
+    }
+
+    public String exportCalendar(String token) {
+        ShareToken shareToken = lookupToken(token);
+        if (shareToken == null) {
+            throw new NoSuchElementException("Calendar token not found");
+        }
+
+        List<Service> upcoming = serviceMapper.findUpcoming(OffsetDateTime.now(ZoneOffset.UTC), DEFAULT_LIMIT);
+        return buildCalendar(upcoming);
+    }
+
+    private ShareToken lookupToken(String token) {
+        if (token == null || token.isBlank()) {
+            return null;
+        }
+        return shareTokenMapper.findByTokenAndType(token, CALENDAR_TOKEN_TYPE);
+    }
+
+    private String buildCalendar(List<Service> services) {
+        StringBuilder sb = new StringBuilder();
+        appendLine(sb, "BEGIN:VCALENDAR");
+        appendLine(sb, "VERSION:2.0");
+        appendLine(sb, "PRODID:-//Every Breath And Life//Service Calendar//EN");
+        appendLine(sb, "CALSCALE:GREGORIAN");
+        appendLine(sb, "METHOD:PUBLISH");
+        appendLine(sb, "X-WR-CALNAME:Upcoming Services");
+
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+
+        for (Service service : services) {
+            if (service == null || service.startsAt() == null) {
+                continue;
+            }
+            appendLine(sb, "BEGIN:VEVENT");
+            appendLine(sb, "UID:" + service.id() + "@services.ebal");
+            appendLine(sb, "DTSTAMP:" + formatDateTime(now));
+            appendLine(sb, "DTSTART:" + formatDateTime(service.startsAt()));
+
+            String location = service.location();
+            String summary = location == null || location.isBlank()
+                    ? "Service"
+                    : "Service - " + location;
+            appendLine(sb, "SUMMARY:" + escape(summary));
+
+            if (location != null && !location.isBlank()) {
+                appendLine(sb, "LOCATION:" + escape(location));
+            }
+
+            appendLine(sb, "END:VEVENT");
+        }
+
+        appendLine(sb, "END:VCALENDAR");
+        return sb.toString();
+    }
+
+    private static String formatDateTime(OffsetDateTime value) {
+        return DATE_TIME_FORMATTER.format(value.toInstant());
+    }
+
+    private static void appendLine(StringBuilder sb, String line) {
+        sb.append(Objects.requireNonNullElse(line, ""));
+        sb.append("\r\n");
+    }
+
+    private static String escape(String input) {
+        if (input == null) {
+            return "";
+        }
+        return input
+                .replace("\\", "\\\\")
+                .replace("\r\n", "\\n")
+                .replace("\n", "\\n")
+                .replace("\r", "\\n")
+                .replace(",", "\\,")
+                .replace(";", "\\;");
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/service/ServiceController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/service/ServiceController.java
@@ -10,9 +10,10 @@ import com.homeputers.ebal2.api.generated.model.ServiceResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.UUID;
@@ -21,9 +22,11 @@ import java.util.UUID;
 @RequestMapping("/api/v1")
 public class ServiceController implements ServicesApi {
     private final ServiceService service;
+    private final ServiceCalendarService serviceCalendarService;
 
-    public ServiceController(ServiceService service) {
+    public ServiceController(ServiceService service, ServiceCalendarService serviceCalendarService) {
         this.service = service;
+        this.serviceCalendarService = serviceCalendarService;
     }
 
     @Override
@@ -65,5 +68,13 @@ public class ServiceController implements ServicesApi {
     public ResponseEntity<ServicePlanItemResponse> addServicePlanItem(UUID id, ServicePlanItemRequest servicePlanItemRequest) {
         ServicePlanItem item = service.addPlanItem(id, servicePlanItemRequest);
         return new ResponseEntity<>(com.homeputers.ebal2.api.serviceplanitem.ServicePlanItemDtoMapper.toResponse(item), HttpStatus.CREATED);
+    }
+
+    @Override
+    public ResponseEntity<String> exportServicesCalendar(String token) {
+        String calendar = serviceCalendarService.exportCalendar(token);
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType("text/calendar; charset=UTF-8"))
+                .body(calendar);
     }
 }

--- a/apps/api-java/src/main/resources/db/migration/V3__share_tokens.sql
+++ b/apps/api-java/src/main/resources/db/migration/V3__share_tokens.sql
@@ -1,0 +1,9 @@
+-- Share tokens for read-only access
+CREATE TABLE share_tokens (
+    token TEXT PRIMARY KEY,
+    type TEXT NOT NULL,
+    label TEXT,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_share_tokens_type ON share_tokens(type);

--- a/apps/api-java/src/main/resources/mappers/ServiceMapper.xml
+++ b/apps/api-java/src/main/resources/mappers/ServiceMapper.xml
@@ -35,6 +35,13 @@
         limit #{limit}
     </select>
 
+    <select id="findUpcoming" resultMap="serviceResult">
+        select id, starts_at, location from services
+        where starts_at >= #{start}
+        order by starts_at
+        limit #{limit}
+    </select>
+
     <select id="count" resultType="int">
         select count(*) from services
     </select>

--- a/apps/api-java/src/main/resources/mappers/ShareTokenMapper.xml
+++ b/apps/api-java/src/main/resources/mappers/ShareTokenMapper.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.homeputers.ebal2.api.domain.token.ShareTokenMapper">
+    <resultMap id="shareTokenResult" type="com.homeputers.ebal2.api.domain.token.ShareToken">
+        <constructor>
+            <idArg column="token" javaType="java.lang.String" />
+            <arg column="type" javaType="java.lang.String" />
+            <arg column="label" javaType="java.lang.String" />
+            <arg column="created_at" javaType="java.time.OffsetDateTime" />
+        </constructor>
+    </resultMap>
+
+    <select id="findByTokenAndType" resultMap="shareTokenResult">
+        select token, type, label, created_at
+        from share_tokens
+        where token = #{token}
+          and type = #{type}
+    </select>
+
+    <insert id="insert">
+        insert into share_tokens (token, type, label, created_at)
+        values (
+            #{token},
+            #{type},
+            #{label},
+            #{createdAt}
+        )
+    </insert>
+</mapper>

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/service/ServiceCalendarControllerTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/service/ServiceCalendarControllerTest.java
@@ -1,0 +1,63 @@
+package com.homeputers.ebal2.api.service;
+
+import com.homeputers.ebal2.api.AbstractIntegrationTest;
+import com.homeputers.ebal2.api.domain.service.Service;
+import com.homeputers.ebal2.api.domain.service.ServiceMapper;
+import com.homeputers.ebal2.api.domain.token.ShareToken;
+import com.homeputers.ebal2.api.domain.token.ShareTokenMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ServiceCalendarControllerTest extends AbstractIntegrationTest {
+
+    private static final DateTimeFormatter DATE_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'").withZone(ZoneOffset.UTC);
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private ServiceMapper serviceMapper;
+
+    @Autowired
+    private ShareTokenMapper shareTokenMapper;
+
+    @Test
+    void exportsCalendarForValidToken() {
+        String token = "calendar-token";
+        shareTokenMapper.insert(new ShareToken(token, ServiceCalendarService.CALENDAR_TOKEN_TYPE, "Calendar", OffsetDateTime.now(ZoneOffset.UTC)));
+
+        OffsetDateTime serviceStart = OffsetDateTime.now(ZoneOffset.UTC).plusDays(1).withNano(0);
+        Service service = new Service(UUID.randomUUID(), serviceStart, "Main Hall");
+        serviceMapper.insert(service);
+
+        ResponseEntity<String> response = restTemplate.getForEntity("/api/v1/services/ical?token=" + token, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders().getContentType()).isNotNull();
+        assertThat(response.getHeaders().getContentType().toString()).startsWith("text/calendar");
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody()).contains("BEGIN:VCALENDAR");
+        assertThat(response.getBody()).contains("SUMMARY:Service - Main Hall");
+        assertThat(response.getBody()).contains("DTSTART:" + DATE_TIME_FORMATTER.format(serviceStart.toInstant()));
+    }
+
+    @Test
+    void returnsNotFoundForUnknownToken() {
+        ResponseEntity<String> response = restTemplate.getForEntity("/api/v1/services/ical?token=missing", String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+}

--- a/apps/web/src/api/types.d.ts
+++ b/apps/web/src/api/types.d.ts
@@ -20,6 +20,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/storage/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Check storage module readiness
+         * @description Returns the current status of the storage subsystem when enabled.
+         */
+        get: operations["storageHealth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/me": {
         parameters: {
             query?: never;
@@ -27,6 +47,13 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /**
+         * Retrieve the current principal
+         * @description Returns information about the authenticated user making the request.
+         *     When the request is unauthenticated the API responds with an anonymous
+         *     placeholder user until session or OIDC login flows are enabled.
+         *
+         */
         get: operations["getCurrentUser"];
         put?: never;
         post?: never;
@@ -149,6 +176,23 @@ export interface paths {
         get: operations["listServices"];
         put?: never;
         post: operations["createService"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/services/ical": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Export upcoming services as iCal */
+        get: operations["exportServicesCalendar"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -393,11 +437,30 @@ export interface components {
         Health: {
             status?: string;
         };
+        /** @example {
+         *       "status": "enabled"
+         *     } */
+        StorageHealth: {
+            /** @description High level status string for the storage module. */
+            status: string;
+        };
+        /** @example {
+         *       "subject": "anonymous",
+         *       "displayName": "Anonymous",
+         *       "anonymous": true,
+         *       "roles": [],
+         *       "provider": null
+         *     } */
         CurrentUser: {
+            /** @description Unique identifier of the authenticated principal when available. */
             subject: string | null;
+            /** @description Human readable name for the current user. */
             displayName: string;
+            /** @description True when the request is unauthenticated or security is disabled. */
             anonymous: boolean;
+            /** @description Granted roles or authorities, empty when anonymous. */
             roles: string[];
+            /** @description Identity provider id used once OIDC is enabled. */
             provider?: string | null;
         };
         GroupRequest: {
@@ -575,6 +638,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Health"];
+                };
+            };
+        };
+    };
+    storageHealth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Storage module is available */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StorageHealth"];
                 };
             };
         };
@@ -938,6 +1021,35 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["ServiceResponse"];
                 };
+            };
+        };
+    };
+    exportServicesCalendar: {
+        parameters: {
+            query: {
+                token: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description iCalendar feed for upcoming services */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/calendar": string;
+                };
+            };
+            /** @description Calendar token not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -301,6 +301,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ServiceResponse'
+  /services/ical:
+    get:
+      tags: [Services]
+      summary: Export upcoming services as iCal
+      operationId: exportServicesCalendar
+      parameters:
+        - name: token
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: iCalendar feed for upcoming services
+          content:
+            text/calendar:
+              schema:
+                type: string
+        '404':
+          description: Calendar token not found
   /services/{id}:
     parameters:
       - name: id


### PR DESCRIPTION
## Summary
- add a read-only iCal export endpoint and service to render upcoming services behind share tokens
- persist calendar share tokens via a new mapper and flyway migration
- regenerate OpenAPI/TypeScript types and document the new feed in the README

## Testing
- `yarn build`
- `mvn -q verify` *(fails: unable to reach Maven Central from the environment)*

- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [x] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [x] Feature flags respected (`ebal.*`)
- [x] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68cc2fb90a2c833094f5fbd214d08ffd