### PR TITLE
docs: document docker-based deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,55 @@ Lint the repository:
 yarn lint
 ```
 
+## Deployment
+
+The repository ships with a Docker Compose stack that runs PostgreSQL, the
+Spring Boot API, and the static build of the web client. The fastest way to
+deploy is to use the make targets that wrap the Compose commands.
+
+### 1. Prerequisites
+
+- [Docker](https://www.docker.com/) (20.10 or newer)
+- [Docker Compose V2](https://docs.docker.com/compose/)
+- [`make`](https://www.gnu.org/software/make/) (optional, but simplifies the
+  commands)
+
+### 2. Configure environment variables
+
+Create an `.env` file in `infra/` so Compose can provision the database and API
+with the correct credentials:
+
+```dotenv
+# infra/.env
+POSTGRES_DB=ebal
+POSTGRES_USER=ebal
+POSTGRES_PASSWORD=ebal
+```
+
+Adjust the values as needed for your environment. The API service automatically
+applies Flyway migrations on startup and connects to the database using these
+settings.
+
+### 3. Build and start the stack
+
+```bash
+cd infra
+make build   # builds the api and web images defined in docker-compose.yaml
+make up      # starts postgres, api, and web in the background
+```
+
+If you prefer to avoid `make`, run `docker compose build` followed by
+`docker compose up -d` from the same directory.
+
+### 4. Verify the deployment
+
+- API: http://localhost:8080 (OpenAPI docs at `/v3/api-docs` once the service
+  is healthy)
+- Web: http://localhost:4173 (served by the `web` container)
+
+Use `make logs` (or `docker compose logs -f`) from the `infra/` directory to
+monitor the containers. To stop everything, run `make down`.
+
 ## Service calendar export
 
 The API provides a read-only iCalendar feed of upcoming services at

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,1 +1,32 @@
-Infrastructure configuration (docker-compose, Kubernetes, Helm charts) will be added here.
+# Infrastructure
+
+This directory houses the Docker Compose configuration and convenience
+Makefile targets for running the full stack.
+
+## Quick start
+
+1. Create an `.env` file alongside this README so Docker Compose can seed the
+   database credentials:
+
+   ```dotenv
+   POSTGRES_DB=ebal
+   POSTGRES_USER=ebal
+   POSTGRES_PASSWORD=ebal
+   ```
+
+2. Build and start the services:
+
+   ```bash
+   make build
+   make up
+   ```
+
+   (You can also call `docker compose build` and `docker compose up -d`
+   directly.)
+
+3. Visit the applications:
+   - API: http://localhost:8080
+   - Web: http://localhost:4173
+
+The root [`README.md`](../README.md) contains additional context, including
+prerequisite tooling and tips for monitoring or shutting down the containers.


### PR DESCRIPTION
## Summary
- add a deployment section to the repository README covering Docker Compose setup and verification steps
- expand infra/README with a quick-start guide and link back to the main documentation

## Testing
- not run (docs only)

## PR Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [x] Docs updated (`README.md` or `/docs/*`)
- [ ] Feature flags respected (`ebal.*`)


------
https://chatgpt.com/codex/tasks/task_e_68cc3e6565cc8330bfc089a883f34707