### PR TITLE
fix(ci): build docker images from repo root

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Exclude version control and local tooling metadata
+.git
+.gitignore
+.husky
+
+# Ignore CI/config folders that are not needed at build time
+.github
+infra
+spec/openapi-generated
+
+# Node and build artifacts
+**/node_modules
+**/.turbo
+**/.next
+**/dist
+**/build
+**/.cache
+**/coverage
+
+# Miscellaneous OS/editor cruft
+.DS_Store
+Thumbs.db

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build and push web image
         uses: docker/build-push-action@v5
         with:
-          context: ./apps/web
+          context: .
           file: ./apps/web/Dockerfile
           push: true
           tags: |
@@ -40,7 +40,7 @@ jobs:
       - name: Build and push API image
         uses: docker/build-push-action@v5
         with:
-          context: ./apps/api-java
+          context: .
           file: ./apps/api-java/Dockerfile
           push: true
           tags: |


### PR DESCRIPTION
## Summary
- update the Docker publish workflow to send the full repository as the build context so the Dockerfiles can access shared manifests
- add a root-level .dockerignore to keep the Docker build context lean while still including required workspaces

## Testing
- not run (CI-only change)

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68cc49dd8d9c8330b85b7524b1b92b33