### PR TITLE
Fix Docker build failure when Yarn directory is absent

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -6,9 +6,8 @@ WORKDIR /app
 # Enable Corepack to use the repo-managed Yarn version
 RUN corepack enable
 
-# Copy workspace manifests first for better caching
+# Copy workspace manifests first for better caching; Yarn metadata is generated during install
 COPY package.json yarn.lock ./
-COPY .yarn .yarn
 COPY apps/web ./apps/web
 COPY packages ./packages
 


### PR DESCRIPTION
## Summary
- stop copying the `.yarn` directory during the web image build so the release tag build succeeds
- note that Yarn metadata is generated at install time inside the container

## Testing
- yarn workspace web build

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68cc4c4a2ec08330b9a0e3833daf54a3