### PR TITLE
fix: clear Maven config for API docker build

### DIFF
--- a/apps/api-java/Dockerfile
+++ b/apps/api-java/Dockerfile
@@ -3,6 +3,11 @@
 FROM maven:3.9.6-eclipse-temurin-21 AS build
 WORKDIR /workspace/apps/api-java
 
+# The Maven base image exports MAVEN_CONFIG=/root/.m2 which the Maven Wrapper
+# treats as CLI arguments. Clearing it avoids passing an invalid lifecycle phase
+# to Maven when the wrapper runs.
+ENV MAVEN_CONFIG=""
+
 # Copy Maven wrapper, pom, and configuration first for better caching
 COPY apps/api-java/mvnw ./mvnw
 COPY apps/api-java/.mvn ./.mvn


### PR DESCRIPTION
## Summary
- clear the Maven-configured environment when running the API Maven wrapper in the Docker build stage
- document why the variable is reset to avoid Maven treating it as a lifecycle phase

## Testing
- MAVEN_CONFIG= ./mvnw -B -ntp dependency:go-offline *(fails: network unreachable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4febfeec83308eb31eb20df811d8