### PR TITLE
feat(web): add initial locale resources

### DIFF
--- a/apps/web/src/locales/en/arrangements.json
+++ b/apps/web/src/locales/en/arrangements.json
@@ -1,1 +1,10 @@
-{}
+{
+  "page": {
+    "title": "Arrangements",
+    "empty": "No arrangements available for this song."
+  },
+  "fields": {
+    "key": "Key",
+    "bpm": "Tempo (BPM)"
+  }
+}

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -1,1 +1,17 @@
-{}
+{
+  "app": {
+    "title": "Every Breath and Life"
+  },
+  "nav": {
+    "songs": "Songs",
+    "services": "Services",
+    "members": "Members"
+  },
+  "actions": {
+    "save": "Save",
+    "cancel": "Cancel",
+    "edit": "Edit",
+    "delete": "Delete",
+    "back": "Back"
+  }
+}

--- a/apps/web/src/locales/en/members.json
+++ b/apps/web/src/locales/en/members.json
@@ -1,1 +1,10 @@
-{}
+{
+  "page": {
+    "title": "Members",
+    "empty": "No members have been added yet."
+  },
+  "fields": {
+    "displayName": "Name",
+    "instruments": "Instruments"
+  }
+}

--- a/apps/web/src/locales/en/services.json
+++ b/apps/web/src/locales/en/services.json
@@ -1,1 +1,10 @@
-{}
+{
+  "page": {
+    "title": "Services",
+    "empty": "No services scheduled."
+  },
+  "fields": {
+    "startsAt": "Start Time",
+    "location": "Location"
+  }
+}

--- a/apps/web/src/locales/en/songSets.json
+++ b/apps/web/src/locales/en/songSets.json
@@ -1,1 +1,10 @@
-{}
+{
+  "page": {
+    "title": "Song Sets",
+    "empty": "No song sets prepared yet."
+  },
+  "fields": {
+    "name": "Set Name",
+    "serviceDate": "Service Date"
+  }
+}

--- a/apps/web/src/locales/en/songs.json
+++ b/apps/web/src/locales/en/songs.json
@@ -1,1 +1,10 @@
-{}
+{
+  "page": {
+    "title": "Songs",
+    "empty": "No songs found. Start by adding one."
+  },
+  "fields": {
+    "title": "Title",
+    "defaultKey": "Default Key"
+  }
+}

--- a/apps/web/src/locales/en/validation.json
+++ b/apps/web/src/locales/en/validation.json
@@ -1,1 +1,5 @@
-{}
+{
+  "required": "This field is required.",
+  "email": "Enter a valid email address.",
+  "minLength": "Must be at least {{count}} characters long."
+}

--- a/apps/web/src/locales/es/arrangements.json
+++ b/apps/web/src/locales/es/arrangements.json
@@ -1,0 +1,10 @@
+{
+  "page": {
+    "title": "Arreglos",
+    "empty": "No hay arreglos disponibles para esta canción."
+  },
+  "fields": {
+    "key": "Tonalidad",
+    "bpm": "Tempo (PPM)"
+  }
+}

--- a/apps/web/src/locales/es/common.json
+++ b/apps/web/src/locales/es/common.json
@@ -1,0 +1,17 @@
+{
+  "app": {
+    "title": "Cada Aliento y Vida"
+  },
+  "nav": {
+    "songs": "Canciones",
+    "services": "Servicios",
+    "members": "Miembros"
+  },
+  "actions": {
+    "save": "Guardar",
+    "cancel": "Cancelar",
+    "edit": "Editar",
+    "delete": "Eliminar",
+    "back": "Volver"
+  }
+}

--- a/apps/web/src/locales/es/members.json
+++ b/apps/web/src/locales/es/members.json
@@ -1,0 +1,10 @@
+{
+  "page": {
+    "title": "Miembros",
+    "empty": "Aún no se han agregado miembros."
+  },
+  "fields": {
+    "displayName": "Nombre",
+    "instruments": "Instrumentos"
+  }
+}

--- a/apps/web/src/locales/es/services.json
+++ b/apps/web/src/locales/es/services.json
@@ -1,0 +1,10 @@
+{
+  "page": {
+    "title": "Servicios",
+    "empty": "No hay servicios programados."
+  },
+  "fields": {
+    "startsAt": "Hora de inicio",
+    "location": "Ubicación"
+  }
+}

--- a/apps/web/src/locales/es/songSets.json
+++ b/apps/web/src/locales/es/songSets.json
@@ -1,0 +1,10 @@
+{
+  "page": {
+    "title": "Conjuntos de canciones",
+    "empty": "Todavía no se han preparado conjuntos de canciones."
+  },
+  "fields": {
+    "name": "Nombre del conjunto",
+    "serviceDate": "Fecha del servicio"
+  }
+}

--- a/apps/web/src/locales/es/songs.json
+++ b/apps/web/src/locales/es/songs.json
@@ -1,0 +1,10 @@
+{
+  "page": {
+    "title": "Canciones",
+    "empty": "No se encontraron canciones. Comienza agregando una."
+  },
+  "fields": {
+    "title": "Título",
+    "defaultKey": "Tonalidad predeterminada"
+  }
+}

--- a/apps/web/src/locales/es/validation.json
+++ b/apps/web/src/locales/es/validation.json
@@ -1,0 +1,5 @@
+{
+  "required": "Este campo es obligatorio.",
+  "email": "Ingresa una dirección de correo válida.",
+  "minLength": "Debe tener al menos {{count}} caracteres."
+}


### PR DESCRIPTION
## Summary
- populate the initial English locale namespaces for common navigation and core resources
- add Spanish translations mirroring the English resource structure

## Testing
- not run (not requested)

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68ccbf2b391c8330827794f82a1dad9b