### PR TITLE
feat(web): add language aware routing

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,8 +1,7 @@
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
-import { Suspense, lazy } from 'react';
+import { lazy } from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { Navbar } from '@/components/Navbar';
-import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { LanguageGuard } from '@/components/LanguageGuard';
 import { queryClient } from '@/lib/queryClient';
 import { Toaster } from 'sonner';
 
@@ -22,27 +21,25 @@ export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        <div className="min-h-screen flex flex-col">
-          <Navbar />
-          <ErrorBoundary>
-            <Suspense fallback={<div>Loading...</div>}>
-              <Routes>
-                <Route path="/" element={<Navigate to="/members" replace />} />
-                <Route path="/members" element={<Members />} />
-                <Route path="/groups" element={<Groups />} />
-                <Route path="/groups/:id" element={<GroupDetail />} />
-                <Route path="/songs" element={<Songs />} />
-                <Route path="/songs/:id" element={<SongDetail />} />
-                <Route path="/song-sets" element={<SongSets />} />
-                <Route path="/song-sets/:id" element={<SongSetDetail />} />
-                <Route path="/services" element={<Services />} />
-                <Route path="/services/:id" element={<ServiceDetail />} />
-                <Route path="/services/:id/print" element={<ServicePrint />} />
-                <Route path="/services/:id/plan" element={<ServicePlanView />} />
-              </Routes>
-            </Suspense>
-          </ErrorBoundary>
-        </div>
+        <Routes>
+          <Route element={<LanguageGuard />}>
+            <Route path=":lang">
+              <Route index element={<Navigate to="members" replace />} />
+              <Route path="members" element={<Members />} />
+              <Route path="groups" element={<Groups />} />
+              <Route path="groups/:id" element={<GroupDetail />} />
+              <Route path="songs" element={<Songs />} />
+              <Route path="songs/:id" element={<SongDetail />} />
+              <Route path="song-sets" element={<SongSets />} />
+              <Route path="song-sets/:id" element={<SongSetDetail />} />
+              <Route path="services" element={<Services />} />
+              <Route path="services/:id" element={<ServiceDetail />} />
+              <Route path="services/:id/print" element={<ServicePrint />} />
+              <Route path="services/:id/plan" element={<ServicePlanView />} />
+              <Route path="*" element={<Navigate to="members" replace />} />
+            </Route>
+          </Route>
+        </Routes>
       </BrowserRouter>
       <Toaster />
     </QueryClientProvider>

--- a/apps/web/src/components/LanguageGuard.tsx
+++ b/apps/web/src/components/LanguageGuard.tsx
@@ -1,0 +1,123 @@
+import { Suspense, useEffect, useMemo } from 'react';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
+
+import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { Navbar } from '@/components/Navbar';
+import {
+  DEFAULT_LANGUAGE,
+  SUPPORTED_LANGUAGES,
+  setAppLanguage,
+} from '@/i18n';
+
+const LANGUAGE_STORAGE_KEY = 'i18nextLng';
+
+const isPotentialLanguageSegment = (segment: string | undefined) =>
+  typeof segment === 'string' && /^[a-z]{2}(?:-[a-z]{2})?$/i.test(segment);
+
+const normalizeLanguage = (value: string | null | undefined) => {
+  if (!value) {
+    return null;
+  }
+
+  const base = value.toLowerCase().split('-')[0];
+
+  return SUPPORTED_LANGUAGES.includes(base) ? base : null;
+};
+
+const detectPreferredLanguage = () => {
+  if (typeof window === 'undefined') {
+    return DEFAULT_LANGUAGE;
+  }
+
+  try {
+    const stored = window.localStorage?.getItem(LANGUAGE_STORAGE_KEY);
+    const normalizedStored = normalizeLanguage(stored);
+
+    if (normalizedStored) {
+      return normalizedStored;
+    }
+  } catch {
+    // Ignore storage access issues and fall back to navigator detection.
+  }
+
+  const navigatorLanguages = Array.isArray(window.navigator?.languages)
+    ? window.navigator.languages
+    : [];
+
+  for (const candidate of navigatorLanguages) {
+    const normalized = normalizeLanguage(candidate);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  const singleNavigatorLanguage = window.navigator?.language;
+  const normalizedNavigator = normalizeLanguage(singleNavigatorLanguage);
+
+  return normalizedNavigator ?? DEFAULT_LANGUAGE;
+};
+
+export function LanguageGuard() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const segments = useMemo(
+    () => location.pathname.split('/').filter(Boolean),
+    [location.pathname],
+  );
+  const [firstSegment, ...restSegments] = segments;
+  const normalizedLang = normalizeLanguage(firstSegment);
+  const hasValidLanguage = Boolean(
+    normalizedLang && firstSegment === normalizedLang,
+  );
+
+  useEffect(() => {
+    if (hasValidLanguage || typeof window === 'undefined') {
+      return;
+    }
+
+    const fallbackLang = detectPreferredLanguage();
+    const remainder = isPotentialLanguageSegment(firstSegment)
+      ? restSegments
+      : segments;
+    const nextSegments = [fallbackLang, ...remainder];
+    const nextPath = `/${nextSegments.join('/')}`;
+    const nextLocation = `${nextPath}${location.search}${location.hash}`;
+    const currentLocation = `${location.pathname}${location.search}${location.hash}`;
+
+    if (nextLocation !== currentLocation) {
+      navigate(nextLocation, { replace: true });
+    }
+  }, [
+    firstSegment,
+    hasValidLanguage,
+    location.hash,
+    location.pathname,
+    location.search,
+    navigate,
+    restSegments,
+    segments,
+  ]);
+
+  useEffect(() => {
+    if (hasValidLanguage && normalizedLang) {
+      setAppLanguage(normalizedLang);
+    }
+  }, [hasValidLanguage, normalizedLang]);
+
+  if (!hasValidLanguage || !normalizedLang) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar currentLanguage={normalizedLang} />
+      <ErrorBoundary>
+        <Suspense fallback={<div>Loading...</div>}>
+          <Outlet />
+        </Suspense>
+      </ErrorBoundary>
+    </div>
+  );
+}
+

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -1,20 +1,30 @@
 import { Link } from 'react-router-dom';
 
 const links = [
-  { to: '/members', label: 'Members' },
-  { to: '/groups', label: 'Groups' },
-  { to: '/songs', label: 'Songs' },
-  { to: '/song-sets', label: 'Song Sets' },
-  { to: '/services', label: 'Services' },
+  { path: 'members', label: 'Members' },
+  { path: 'groups', label: 'Groups' },
+  { path: 'songs', label: 'Songs' },
+  { path: 'song-sets', label: 'Song Sets' },
+  { path: 'services', label: 'Services' },
 ];
 
-export function Navbar() {
+type NavbarProps = {
+  currentLanguage: string;
+};
+
+const makeHref = (language: string, path: string) =>
+  `/${language}${path.startsWith('/') ? path : `/${path}`}`;
+
+export function Navbar({ currentLanguage }: NavbarProps) {
   return (
     <nav className="bg-gray-800 text-white p-4 print:hidden">
       <ul className="flex gap-4">
         {links.map((link) => (
-          <li key={link.to}>
-            <Link to={link.to} className="hover:underline">
+          <li key={link.path}>
+            <Link
+              to={makeHref(currentLanguage, link.path)}
+              className="hover:underline"
+            >
               {link.label}
             </Link>
           </li>

--- a/apps/web/src/i18n/index.ts
+++ b/apps/web/src/i18n/index.ts
@@ -53,6 +53,8 @@ const supportedLngs = Array.from(
   new Set([...Object.keys(resources), DEFAULT_LANGUAGE]),
 );
 
+export const SUPPORTED_LANGUAGES = supportedLngs as readonly string[];
+
 void i18n
   .use(LanguageDetector)
   .use(initReactI18next)

--- a/apps/web/src/pages/groups/GroupsPage.tsx
+++ b/apps/web/src/pages/groups/GroupsPage.tsx
@@ -133,7 +133,7 @@ export default function GroupsPage() {
                         />
                       ) : (
                         <Link
-                          to={`/groups/${g.id}`}
+                          to={g.id ?? ''}
                           className="text-blue-600 hover:underline"
                         >
                           {g.name}

--- a/apps/web/src/pages/services/ServiceDetailPage.tsx
+++ b/apps/web/src/pages/services/ServiceDetailPage.tsx
@@ -158,7 +158,7 @@ export default function ServiceDetailPage() {
         </div>
         <div className="flex gap-2">
           <Link
-            to={`/services/${id}/plan?share=preview`}
+            to={`plan?share=preview`}
             className="px-2 py-1 text-sm bg-indigo-500 text-white rounded"
           >
             Plan View
@@ -170,7 +170,7 @@ export default function ServiceDetailPage() {
             Edit
           </button>
           <Link
-            to={`/services/${id}/print`}
+            to="print"
             className="px-2 py-1 text-sm bg-blue-500 text-white rounded"
           >
             Print

--- a/apps/web/src/pages/services/ServicesPage.tsx
+++ b/apps/web/src/pages/services/ServicesPage.tsx
@@ -141,7 +141,7 @@ export default function ServicesPage() {
                   <td className="p-2 text-right">
                     <div className="flex gap-2 justify-end">
                       <Link
-                        to={`/services/${s.id}`}
+                        to={s.id ?? ''}
                         className="px-2 py-1 text-sm bg-green-500 text-white rounded"
                       >
                         Open plan

--- a/apps/web/src/pages/sets/SongSetsPage.tsx
+++ b/apps/web/src/pages/sets/SongSetsPage.tsx
@@ -163,7 +163,7 @@ export default function SongSetsPage() {
                         <td className="p-2 text-right align-top">
                           <div className="flex gap-2 justify-end">
                             <Link
-                              to={`/song-sets/${setId}`}
+                              to={setId}
                               className="px-2 py-1 text-sm bg-gray-100 rounded hover:bg-gray-200"
                             >
                               Open

--- a/apps/web/src/pages/songs/SongsPage.tsx
+++ b/apps/web/src/pages/songs/SongsPage.tsx
@@ -156,7 +156,7 @@ export default function SongsPage() {
                     <tr key={s.id} className="border-t">
                       <td className="p-2">
                         <Link
-                          to={`/songs/${s.id}`}
+                          to={s.id ?? ''}
                           className="text-blue-600 hover:underline"
                         >
                           {s.title}


### PR DESCRIPTION
## Summary
- add a LanguageGuard layout that validates the /:lang segment, detects a preferred locale, and keeps i18n in sync
- nest application routes under /:lang and expose the supported locale list for guard validation
- update navbar and internal links to build language-scoped URLs so navigation preserves the active language

## Testing
- yarn build

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [x] Web: Loading/error states; basic a11y; responsive layout
- [x] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)

------
https://chatgpt.com/codex/tasks/task_e_68ccc04e69ec8330aee1d0c4893fed6c