### PR TITLE
feat(web): add i18n coverage for key ui flows

### DIFF
--- a/apps/web/src/components/LanguageSwitcher.tsx
+++ b/apps/web/src/components/LanguageSwitcher.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
 import {
   LANGUAGE_STORAGE_KEY,
@@ -12,13 +13,10 @@ type LanguageSwitcherProps = {
   className?: string;
 };
 
-const LANGUAGE_LABELS: Record<string, string> = {
+const FALLBACK_LANGUAGE_LABELS: Record<string, string> = {
   en: 'English',
   es: 'Español',
 };
-
-const getLanguageLabel = (language: string) =>
-  LANGUAGE_LABELS[language] ?? language.toUpperCase();
 
 const isBrowser = typeof window !== 'undefined';
 
@@ -26,6 +24,7 @@ export function LanguageSwitcher({
   className,
   currentLanguage,
 }: LanguageSwitcherProps) {
+  const { t } = useTranslation('common');
   const [isOpen, setIsOpen] = useState(false);
   const location = useLocation();
   const navigate = useNavigate();
@@ -35,6 +34,15 @@ export function LanguageSwitcher({
   const languages = useMemo(
     () => Array.from(new Set(SUPPORTED_LANGUAGES)),
     [],
+  );
+
+  const getLanguageLabel = useCallback(
+    (language: string) =>
+      t(`language.labels.${language}`, {
+        defaultValue:
+          FALLBACK_LANGUAGE_LABELS[language] ?? language.toUpperCase(),
+      }),
+    [t],
   );
 
   useEffect(() => {
@@ -132,7 +140,7 @@ export function LanguageSwitcher({
         type="button"
         aria-haspopup="listbox"
         aria-expanded={isOpen}
-        aria-label="Change language"
+        aria-label={t('language.change')}
         className="inline-flex items-center gap-2 rounded-md border border-white/30 bg-white/10 px-3 py-1 text-sm font-medium text-white hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
         onClick={() => setIsOpen((value) => !value)}
       >
@@ -146,7 +154,7 @@ export function LanguageSwitcher({
       {isOpen ? (
         <ul
           role="listbox"
-          aria-label="Select language"
+          aria-label={t('language.select')}
           className="absolute right-0 z-50 mt-2 w-40 overflow-hidden rounded-md border border-gray-200 bg-white py-1 shadow-lg focus:outline-none"
         >
           {languages.map((language) => (

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -1,13 +1,14 @@
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 
 const links = [
-  { path: 'members', label: 'Members' },
-  { path: 'groups', label: 'Groups' },
-  { path: 'songs', label: 'Songs' },
-  { path: 'song-sets', label: 'Song Sets' },
-  { path: 'services', label: 'Services' },
+  { path: 'members', labelKey: 'nav.members' },
+  { path: 'groups', labelKey: 'nav.groups' },
+  { path: 'songs', labelKey: 'nav.songs' },
+  { path: 'song-sets', labelKey: 'nav.songSets' },
+  { path: 'services', labelKey: 'nav.services' },
 ];
 
 type NavbarProps = {
@@ -18,6 +19,8 @@ const makeHref = (language: string, path: string) =>
   `/${language}${path.startsWith('/') ? path : `/${path}`}`;
 
 export function Navbar({ currentLanguage }: NavbarProps) {
+  const { t } = useTranslation('common');
+
   return (
     <nav className="bg-gray-800 text-white p-4 print:hidden">
       <div className="mx-auto flex max-w-6xl items-center justify-between gap-4">
@@ -28,7 +31,7 @@ export function Navbar({ currentLanguage }: NavbarProps) {
                 to={makeHref(currentLanguage, link.path)}
                 className="hover:underline"
               >
-                {link.label}
+                {t(link.labelKey)}
               </Link>
             </li>
           ))}

--- a/apps/web/src/features/groups/GroupForm.tsx
+++ b/apps/web/src/features/groups/GroupForm.tsx
@@ -1,9 +1,10 @@
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
 const schema = z.object({
-  name: z.string().min(2, 'Name must be at least 2 characters'),
+  name: z.string().min(2, 'validation.nameMin'),
 });
 
 export type GroupFormValues = z.infer<typeof schema>;
@@ -17,6 +18,8 @@ export function GroupForm({
   onSubmit: (values: GroupFormValues) => void;
   onCancel?: () => void;
 }) {
+  const { t } = useTranslation('groups');
+  const { t: tCommon } = useTranslation('common');
   const {
     register,
     handleSubmit,
@@ -27,18 +30,24 @@ export function GroupForm({
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
       <div>
         <label htmlFor="name" className="block text-sm font-medium mb-1">
-          Name
+          {t('form.nameLabel')}
         </label>
         <input
           id="name"
           {...register('name')}
           className="border p-2 rounded w-full"
         />
-        {errors.name && <p className="text-red-500 text-sm">{errors.name.message}</p>}
+        {errors.name && (
+          <p className="text-red-500 text-sm">
+            {t(errors.name.message ?? '', {
+              defaultValue: errors.name.message ?? '',
+            })}
+          </p>
+        )}
       </div>
       <div className="flex gap-2">
         <button type="submit" className="px-4 py-2 bg-blue-500 text-white rounded">
-          Save
+          {tCommon('actions.save')}
         </button>
         {onCancel && (
           <button
@@ -46,7 +55,7 @@ export function GroupForm({
             onClick={onCancel}
             className="px-4 py-2 bg-gray-200 rounded"
           >
-            Cancel
+            {tCommon('actions.cancel')}
           </button>
         )}
       </div>

--- a/apps/web/src/features/members/MemberForm.tsx
+++ b/apps/web/src/features/members/MemberForm.tsx
@@ -1,10 +1,11 @@
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
+import { useTranslation } from 'react-i18next';
 import { zodResolver } from '@hookform/resolvers/zod';
 import type { components } from '../../api/types';
 
 const schema = z.object({
-  displayName: z.string().min(2, 'Display name must be at least 2 characters'),
+  displayName: z.string().min(2, 'validation.displayNameMin'),
   instruments: z.string().optional(),
 });
 
@@ -19,6 +20,9 @@ export function MemberForm({
   onSubmit: (values: components['schemas']['MemberRequest']) => void;
   onCancel?: () => void;
 }) {
+  const { t } = useTranslation('members');
+  const { t: tCommon } = useTranslation('common');
+
   const {
     register,
     handleSubmit,
@@ -42,7 +46,7 @@ export function MemberForm({
     >
       <div>
         <label htmlFor="displayName" className="block text-sm font-medium mb-1">
-          Display Name
+          {t('form.displayName')}
         </label>
         <input
           id="displayName"
@@ -50,12 +54,16 @@ export function MemberForm({
           className="border p-2 rounded w-full"
         />
         {errors.displayName && (
-          <p className="text-red-500 text-sm">{errors.displayName.message}</p>
+          <p className="text-red-500 text-sm">
+            {t(errors.displayName.message ?? '', {
+              defaultValue: errors.displayName.message ?? '',
+            })}
+          </p>
         )}
       </div>
       <div>
         <label htmlFor="instruments" className="block text-sm font-medium mb-1">
-          Instruments (comma separated)
+          {t('form.instrumentsLabel')}
         </label>
         <input
           id="instruments"
@@ -68,7 +76,7 @@ export function MemberForm({
       </div>
       <div className="flex gap-2">
         <button type="submit" className="px-4 py-2 bg-blue-500 text-white rounded">
-          Save
+          {tCommon('actions.save')}
         </button>
         {onCancel && (
           <button
@@ -76,7 +84,7 @@ export function MemberForm({
             onClick={onCancel}
             className="px-4 py-2 bg-gray-200 rounded"
           >
-            Cancel
+            {tCommon('actions.cancel')}
           </button>
         )}
       </div>

--- a/apps/web/src/features/services/ServiceForm.tsx
+++ b/apps/web/src/features/services/ServiceForm.tsx
@@ -1,5 +1,6 @@
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
+import { useTranslation } from 'react-i18next';
 import { zodResolver } from '@hookform/resolvers/zod';
 import type { components } from '../../api/types';
 
@@ -19,6 +20,9 @@ export function ServiceForm({
   onSubmit: (values: components['schemas']['ServiceRequest']) => void;
   onCancel?: () => void;
 }) {
+  const { t } = useTranslation('services');
+  const { t: tCommon } = useTranslation('common');
+
   const {
     register,
     handleSubmit,
@@ -34,7 +38,7 @@ export function ServiceForm({
     >
       <div>
         <label htmlFor="startsAt" className="block text-sm font-medium mb-1">
-          Starts At
+          {t('form.startsAtLabel')}
         </label>
         <input
           id="startsAt"
@@ -43,12 +47,16 @@ export function ServiceForm({
           className="border p-2 rounded w-full"
         />
         {errors.startsAt && (
-          <p className="text-red-500 text-sm">{errors.startsAt.message}</p>
+          <p className="text-red-500 text-sm">
+            {t(errors.startsAt.message ?? '', {
+              defaultValue: errors.startsAt.message ?? '',
+            })}
+          </p>
         )}
       </div>
       <div>
         <label htmlFor="location" className="block text-sm font-medium mb-1">
-          Location
+          {t('form.locationLabel')}
         </label>
         <input
           id="location"
@@ -56,12 +64,16 @@ export function ServiceForm({
           className="border p-2 rounded w-full"
         />
         {errors.location && (
-          <p className="text-red-500 text-sm">{errors.location.message}</p>
+          <p className="text-red-500 text-sm">
+            {t(errors.location.message ?? '', {
+              defaultValue: errors.location.message ?? '',
+            })}
+          </p>
         )}
       </div>
       <div className="flex gap-2">
         <button type="submit" className="px-4 py-2 bg-blue-500 text-white rounded">
-          Save
+          {tCommon('actions.save')}
         </button>
         {onCancel && (
           <button
@@ -69,7 +81,7 @@ export function ServiceForm({
             onClick={onCancel}
             className="px-4 py-2 bg-gray-200 rounded"
           >
-            Cancel
+            {tCommon('actions.cancel')}
           </button>
         )}
       </div>

--- a/apps/web/src/features/sets/SetForm.tsx
+++ b/apps/web/src/features/sets/SetForm.tsx
@@ -1,9 +1,10 @@
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
+import { useTranslation } from 'react-i18next';
 
 const schema = z.object({
-  name: z.string().min(2, 'Name must be at least 2 characters'),
+  name: z.string().min(2, 'validation.nameMin'),
 });
 
 export type SetFormValues = z.infer<typeof schema>;
@@ -15,6 +16,8 @@ type SetFormProps = {
 };
 
 export function SetForm({ defaultValues, onSubmit, onCancel }: SetFormProps) {
+  const { t } = useTranslation('songSets');
+  const { t: tCommon } = useTranslation('common');
   const {
     register,
     handleSubmit,
@@ -28,14 +31,20 @@ export function SetForm({ defaultValues, onSubmit, onCancel }: SetFormProps) {
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
       <div>
         <label htmlFor="name" className="block text-sm font-medium mb-1">
-          Name
+          {t('form.nameLabel')}
         </label>
         <input id="name" {...register('name')} className="border p-2 rounded w-full" />
-        {errors.name && <p className="text-red-500 text-sm">{errors.name.message}</p>}
+        {errors.name && (
+          <p className="text-red-500 text-sm">
+            {t(errors.name.message ?? '', {
+              defaultValue: errors.name.message ?? '',
+            })}
+          </p>
+        )}
       </div>
       <div className="flex gap-2">
         <button type="submit" className="px-4 py-2 bg-blue-500 text-white rounded">
-          Save
+          {tCommon('actions.save')}
         </button>
         {onCancel && (
           <button
@@ -43,7 +52,7 @@ export function SetForm({ defaultValues, onSubmit, onCancel }: SetFormProps) {
             onClick={onCancel}
             className="px-4 py-2 bg-gray-200 rounded"
           >
-            Cancel
+            {tCommon('actions.cancel')}
           </button>
         )}
       </div>

--- a/apps/web/src/features/songs/ArrangementForm.tsx
+++ b/apps/web/src/features/songs/ArrangementForm.tsx
@@ -1,19 +1,20 @@
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
+import { useTranslation } from 'react-i18next';
 import { zodResolver } from '@hookform/resolvers/zod';
 import type { components } from '../../api/types';
 import { ChordProView } from '../../components/chordpro/ChordProView';
 
 const schema = z.object({
-  key: z.string().min(1, 'Key is required'),
+  key: z.string().min(1, 'validation.keyRequired'),
   bpm: z
-    .number({ invalid_type_error: 'BPM must be a number' })
+    .number({ invalid_type_error: 'validation.bpmNumber' })
     .min(30)
     .max(300)
     .optional(),
   meter: z.string().optional(),
-  lyricsChordpro: z.string().min(1, 'Lyrics are required'),
+  lyricsChordpro: z.string().min(1, 'validation.lyricsRequired'),
 });
 
 export type ArrangementFormValues = z.infer<typeof schema>;
@@ -27,6 +28,9 @@ export function ArrangementForm({
   onSubmit: (values: components['schemas']['ArrangementRequest']) => void;
   onCancel?: () => void;
 }) {
+  const { t } = useTranslation('arrangements');
+  const { t: tCommon } = useTranslation('common');
+
   const {
     register,
     handleSubmit,
@@ -60,16 +64,20 @@ export function ArrangementForm({
         <div className="flex-1 space-y-2">
           <div>
             <label htmlFor="key" className="block text-sm font-medium mb-1">
-              Key
+              {t('form.keyLabel')}
             </label>
             <input id="key" {...register('key')} className="border p-2 rounded w-full" />
             {errors.key && (
-              <p className="text-red-500 text-sm">{errors.key.message}</p>
+              <p className="text-red-500 text-sm">
+                {t(errors.key.message ?? '', {
+                  defaultValue: errors.key.message ?? '',
+                })}
+              </p>
             )}
           </div>
           <div>
             <label htmlFor="bpm" className="block text-sm font-medium mb-1">
-              BPM
+              {t('form.bpmLabel')}
             </label>
             <input
               id="bpm"
@@ -78,21 +86,29 @@ export function ArrangementForm({
               className="border p-2 rounded w-full"
             />
             {errors.bpm && (
-              <p className="text-red-500 text-sm">{errors.bpm.message}</p>
+              <p className="text-red-500 text-sm">
+                {t(errors.bpm.message ?? '', {
+                  defaultValue: errors.bpm.message ?? '',
+                })}
+              </p>
             )}
           </div>
           <div>
             <label htmlFor="meter" className="block text-sm font-medium mb-1">
-              Meter
+              {t('form.meterLabel')}
             </label>
             <input id="meter" {...register('meter')} className="border p-2 rounded w-full" />
             {errors.meter && (
-              <p className="text-red-500 text-sm">{errors.meter.message}</p>
+              <p className="text-red-500 text-sm">
+                {t(errors.meter.message ?? '', {
+                  defaultValue: errors.meter.message ?? '',
+                })}
+              </p>
             )}
           </div>
           <div>
             <label htmlFor="lyricsChordpro" className="block text-sm font-medium mb-1">
-              ChordPro
+              {t('form.chordProLabel')}
             </label>
             <textarea
               id="lyricsChordpro"
@@ -100,12 +116,16 @@ export function ArrangementForm({
               className="border p-2 rounded w-full h-48 font-mono"
             />
             {errors.lyricsChordpro && (
-              <p className="text-red-500 text-sm">{errors.lyricsChordpro.message}</p>
+              <p className="text-red-500 text-sm">
+                {t(errors.lyricsChordpro.message ?? '', {
+                  defaultValue: errors.lyricsChordpro.message ?? '',
+                })}
+              </p>
             )}
           </div>
           <div className="flex gap-2">
             <button type="submit" className="px-4 py-2 bg-blue-500 text-white rounded">
-              Save
+              {tCommon('actions.save')}
             </button>
             {onCancel && (
               <button
@@ -113,7 +133,7 @@ export function ArrangementForm({
                 onClick={onCancel}
                 className="px-4 py-2 bg-gray-200 rounded"
               >
-                Cancel
+                {tCommon('actions.cancel')}
               </button>
             )}
           </div>
@@ -125,24 +145,24 @@ export function ArrangementForm({
               className="px-2 py-1 border rounded"
               onClick={() => setTranspose((t) => t + 1)}
             >
-              +1
+              {t('controls.transposeUp')}
             </button>
             <button
               type="button"
               className="px-2 py-1 border rounded"
               onClick={() => setTranspose((t) => t - 1)}
             >
-              -1
+              {t('controls.transposeDown')}
             </button>
             <button
               type="button"
               className="px-2 py-1 border rounded"
               onClick={() => setUseFlats((f) => !f)}
             >
-              {useFlats ? 'Use sharps' : 'Use flats'}
+              {useFlats ? t('controls.useSharps') : t('controls.useFlats')}
             </button>
             <label className="text-sm">
-              Layout
+              {t('controls.layout')}
               <select
                 value={layout}
                 onChange={(event) =>
@@ -150,8 +170,8 @@ export function ArrangementForm({
                 }
                 className="ml-1 border rounded px-2 py-1 text-sm"
               >
-                <option value="above">Chords above</option>
-                <option value="inline">Inline</option>
+                <option value="above">{t('controls.layoutAbove')}</option>
+                <option value="inline">{t('controls.layoutInline')}</option>
               </select>
             </label>
           </div>

--- a/apps/web/src/features/songs/SongForm.tsx
+++ b/apps/web/src/features/songs/SongForm.tsx
@@ -1,10 +1,11 @@
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
+import { useTranslation } from 'react-i18next';
 import { zodResolver } from '@hookform/resolvers/zod';
 import type { components } from '../../api/types';
 
 const schema = z.object({
-  title: z.string().min(2, 'Title must be at least 2 characters'),
+  title: z.string().min(2, 'validation.titleMin'),
   ccli: z.string().optional(),
   author: z.string().optional(),
   defaultKey: z.string().optional(),
@@ -22,6 +23,9 @@ export function SongForm({
   onSubmit: (values: components['schemas']['SongRequest']) => void;
   onCancel?: () => void;
 }) {
+  const { t } = useTranslation('songs');
+  const { t: tCommon } = useTranslation('common');
+
   const {
     register,
     handleSubmit,
@@ -48,28 +52,32 @@ export function SongForm({
     >
       <div>
         <label htmlFor="title" className="block text-sm font-medium mb-1">
-          Title
+          {t('form.titleLabel')}
         </label>
         <input id="title" {...register('title')} className="border p-2 rounded w-full" />
         {errors.title && (
-          <p className="text-red-500 text-sm">{errors.title.message}</p>
+          <p className="text-red-500 text-sm">
+            {t(errors.title.message ?? '', {
+              defaultValue: errors.title.message ?? '',
+            })}
+          </p>
         )}
       </div>
       <div>
         <label htmlFor="ccli" className="block text-sm font-medium mb-1">
-          CCLI
+          {t('form.ccliLabel')}
         </label>
         <input id="ccli" {...register('ccli')} className="border p-2 rounded w-full" />
       </div>
       <div>
         <label htmlFor="author" className="block text-sm font-medium mb-1">
-          Author
+          {t('form.authorLabel')}
         </label>
         <input id="author" {...register('author')} className="border p-2 rounded w-full" />
       </div>
       <div>
         <label htmlFor="defaultKey" className="block text-sm font-medium mb-1">
-          Default Key
+          {t('form.defaultKeyLabel')}
         </label>
         <input
           id="defaultKey"
@@ -79,13 +87,13 @@ export function SongForm({
       </div>
       <div>
         <label htmlFor="tags" className="block text-sm font-medium mb-1">
-          Tags (comma separated)
+          {t('form.tagsLabel')}
         </label>
         <input id="tags" {...register('tags')} className="border p-2 rounded w-full" />
       </div>
       <div className="flex gap-2">
         <button type="submit" className="px-4 py-2 bg-blue-500 text-white rounded">
-          Save
+          {tCommon('actions.save')}
         </button>
         {onCancel && (
           <button
@@ -93,7 +101,7 @@ export function SongForm({
             onClick={onCancel}
             className="px-4 py-2 bg-gray-200 rounded"
           >
-            Cancel
+            {tCommon('actions.cancel')}
           </button>
         )}
       </div>

--- a/apps/web/src/i18n/index.ts
+++ b/apps/web/src/i18n/index.ts
@@ -72,7 +72,7 @@ void i18n
       order: ['localStorage', 'navigator', 'htmlTag', 'path', 'subdomain'],
       caches: ['localStorage'],
     },
-    keySeparator: false,
+    keySeparator: '.',
     returnNull: false,
   });
 

--- a/apps/web/src/i18n/index.ts
+++ b/apps/web/src/i18n/index.ts
@@ -11,6 +11,7 @@ export const NAMESPACES = [
   'arrangements',
   'services',
   'songSets',
+  'groups',
   'validation',
 ] as const;
 

--- a/apps/web/src/locales/en/arrangements.json
+++ b/apps/web/src/locales/en/arrangements.json
@@ -6,5 +6,43 @@
   "fields": {
     "key": "Key",
     "bpm": "Tempo (BPM)"
+  },
+  "form": {
+    "keyLabel": "Key",
+    "bpmLabel": "BPM",
+    "meterLabel": "Meter",
+    "chordProLabel": "ChordPro"
+  },
+  "controls": {
+    "transposeUp": "+1",
+    "transposeDown": "-1",
+    "useSharps": "Use sharps",
+    "useFlats": "Use flats",
+    "layout": "Layout",
+    "layoutAbove": "Chords above",
+    "layoutInline": "Inline"
+  },
+  "actions": {
+    "new": "New Arrangement"
+  },
+  "modals": {
+    "createTitle": "New Arrangement",
+    "editTitle": "Edit Arrangement"
+  },
+  "table": {
+    "key": "Key",
+    "bpm": "BPM",
+    "meter": "Meter"
+  },
+  "list": {
+    "empty": "No arrangements"
+  },
+  "labels": {
+    "fallback": "Arrangement {{id}}"
+  },
+  "validation": {
+    "keyRequired": "Key is required",
+    "bpmNumber": "BPM must be a number",
+    "lyricsRequired": "Lyrics are required"
   }
 }

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -5,7 +5,9 @@
   "nav": {
     "songs": "Songs",
     "services": "Services",
-    "members": "Members"
+    "members": "Members",
+    "groups": "Groups",
+    "songSets": "Song Sets"
   },
   "actions": {
     "save": "Save",
@@ -33,5 +35,13 @@
   },
   "labels": {
     "notAvailable": "N/A"
+  },
+  "language": {
+    "change": "Change language",
+    "select": "Select language",
+    "labels": {
+      "en": "English",
+      "es": "Spanish"
+    }
   }
 }

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -12,6 +12,26 @@
     "cancel": "Cancel",
     "edit": "Edit",
     "delete": "Delete",
-    "back": "Back"
+    "back": "Back",
+    "open": "Open",
+    "add": "Add",
+    "remove": "Remove",
+    "print": "Print",
+    "exportPdf": "Export PDF"
+  },
+  "status": {
+    "loading": "Loading…",
+    "loadFailed": "Failed to load"
+  },
+  "pagination": {
+    "previous": "Previous",
+    "next": "Next",
+    "pageOf": "Page {{page}} of {{total}}"
+  },
+  "table": {
+    "actions": "Actions"
+  },
+  "labels": {
+    "notAvailable": "N/A"
   }
 }

--- a/apps/web/src/locales/en/groups.json
+++ b/apps/web/src/locales/en/groups.json
@@ -1,0 +1,35 @@
+{
+  "page": {
+    "title": "Groups"
+  },
+  "actions": {
+    "new": "New Group"
+  },
+  "list": {
+    "searchPlaceholder": "Search by name...",
+    "empty": "No groups found"
+  },
+  "table": {
+    "name": "Name",
+    "members": "Members"
+  },
+  "modals": {
+    "createTitle": "New Group",
+    "editTitle": "Edit Group"
+  },
+  "form": {
+    "nameLabel": "Name"
+  },
+  "validation": {
+    "nameMin": "Name must be at least 2 characters"
+  },
+  "detail": {
+    "infoTitle": "Group Info",
+    "membersTitle": "Members",
+    "searchPlaceholder": "Search members...",
+    "selectMember": "Select member",
+    "emptyMembers": "No members",
+    "loadFailedMembers": "Failed to load members",
+    "removeMemberConfirm": "Remove member?"
+  }
+}

--- a/apps/web/src/locales/en/members.json
+++ b/apps/web/src/locales/en/members.json
@@ -6,5 +6,27 @@
   "fields": {
     "displayName": "Name",
     "instruments": "Instruments"
+  },
+  "form": {
+    "displayName": "Display Name",
+    "instrumentsLabel": "Instruments (comma separated)"
+  },
+  "actions": {
+    "new": "New Member"
+  },
+  "list": {
+    "searchPlaceholder": "Search by name...",
+    "empty": "No members found"
+  },
+  "table": {
+    "name": "Name",
+    "instruments": "Instruments"
+  },
+  "modals": {
+    "createTitle": "New Member",
+    "editTitle": "Edit Member"
+  },
+  "validation": {
+    "displayNameMin": "Display name must be at least 2 characters"
   }
 }

--- a/apps/web/src/locales/en/services.json
+++ b/apps/web/src/locales/en/services.json
@@ -16,6 +16,13 @@
     "searchPlaceholder": "Search...",
     "empty": "No services found"
   },
+  "table": {
+    "startsAt": "Starts At",
+    "location": "Location"
+  },
+  "status": {
+    "loadFailed": "Failed to load services."
+  },
   "modals": {
     "createTitle": "New Service",
     "editTitle": "Edit Service"

--- a/apps/web/src/locales/en/services.json
+++ b/apps/web/src/locales/en/services.json
@@ -6,5 +6,52 @@
   "fields": {
     "startsAt": "Start Time",
     "location": "Location"
+  },
+  "actions": {
+    "new": "New Service",
+    "openPlan": "Open plan",
+    "planView": "Plan View"
+  },
+  "list": {
+    "searchPlaceholder": "Search...",
+    "empty": "No services found"
+  },
+  "modals": {
+    "createTitle": "New Service",
+    "editTitle": "Edit Service"
+  },
+  "form": {
+    "startsAtLabel": "Starts At",
+    "locationLabel": "Location"
+  },
+  "fallback": {
+    "title": "Service"
+  },
+  "plan": {
+    "addItemTitle": "Add Item",
+    "itemTypes": {
+      "song": "Song",
+      "reading": "Reading",
+      "note": "Note",
+      "itemFallback": "Item"
+    },
+    "notesPlaceholder": "Notes",
+    "title": "Plan",
+    "empty": "No plan items",
+    "noItems": "No items",
+    "notifications": {
+      "itemAdded": "Item added",
+      "addFailed": "Failed to add item"
+    }
+  },
+  "planView": {
+    "title": "Service Plan",
+    "shareRequiredTitle": "Share token required",
+    "shareRequiredDescription": "A valid share link is required to view this service plan. Please check your link and try again.",
+    "loading": "Loading plan…",
+    "unavailableTitle": "Plan unavailable",
+    "unavailableDescription": "We were unable to load this service plan. Please try again later or contact the organizer.",
+    "shareTokenLabel": "Share Token:",
+    "empty": "No plan items have been scheduled yet."
   }
 }

--- a/apps/web/src/locales/en/songSets.json
+++ b/apps/web/src/locales/en/songSets.json
@@ -6,5 +6,52 @@
   "fields": {
     "name": "Set Name",
     "serviceDate": "Service Date"
+  },
+  "actions": {
+    "new": "New Set"
+  },
+  "modals": {
+    "createTitle": "New Set",
+    "editTitle": "Edit Set"
+  },
+  "list": {
+    "searchPlaceholder": "Search by name...",
+    "empty": "No song sets found"
+  },
+  "table": {
+    "name": "Name",
+    "items": "Items"
+  },
+  "status": {
+    "loadFailed": "Failed to load song sets.",
+    "noneSelected": "No song set selected.",
+    "savingOrder": "Saving order…"
+  },
+  "confirm": {
+    "delete": "Are you sure you want to delete this set?"
+  },
+  "items": {
+    "addTitle": "Add Item",
+    "transpose": "Transpose",
+    "capo": "Capo",
+    "addButton": "Add Item",
+    "title": "Items",
+    "loadFailed": "Failed to load items.",
+    "empty": "No items",
+    "dragHandle": "Drag to reorder"
+  },
+  "notifications": {
+    "itemAdded": "Item added",
+    "addFailed": "Failed to add item"
+  },
+  "fallback": {
+    "title": "Song Set"
+  },
+  "controls": {
+    "showSharps": "Show sharps (♯)",
+    "showFlats": "Show flats (♭)"
+  },
+  "validation": {
+    "nameMin": "Name must be at least 2 characters"
   }
 }

--- a/apps/web/src/locales/en/songs.json
+++ b/apps/web/src/locales/en/songs.json
@@ -5,6 +5,37 @@
   },
   "fields": {
     "title": "Title",
-    "defaultKey": "Default Key"
+    "defaultKey": "Default Key",
+    "tags": "Tags"
+  },
+  "form": {
+    "titleLabel": "Title",
+    "ccliLabel": "CCLI",
+    "authorLabel": "Author",
+    "defaultKeyLabel": "Default Key",
+    "tagsLabel": "Tags (comma separated)"
+  },
+  "actions": {
+    "new": "New Song"
+  },
+  "modals": {
+    "createTitle": "New Song",
+    "editTitle": "Edit Song"
+  },
+  "list": {
+    "searchPlaceholder": "Search by title...",
+    "empty": "No songs found"
+  },
+  "validation": {
+    "titleMin": "Title must be at least 2 characters"
+  },
+  "detail": {
+    "author": "Author",
+    "ccli": "CCLI",
+    "defaultKey": "Default Key",
+    "tags": "Tags"
+  },
+  "pickers": {
+    "searchPlaceholder": "Search songs..."
   }
 }

--- a/apps/web/src/locales/es/arrangements.json
+++ b/apps/web/src/locales/es/arrangements.json
@@ -6,5 +6,43 @@
   "fields": {
     "key": "Tonalidad",
     "bpm": "Tempo (PPM)"
+  },
+  "form": {
+    "keyLabel": "Tonalidad",
+    "bpmLabel": "PPM",
+    "meterLabel": "Compás",
+    "chordProLabel": "ChordPro"
+  },
+  "controls": {
+    "transposeUp": "+1",
+    "transposeDown": "-1",
+    "useSharps": "Usar sostenidos",
+    "useFlats": "Usar bemoles",
+    "layout": "Diseño",
+    "layoutAbove": "Acordes arriba",
+    "layoutInline": "En línea"
+  },
+  "actions": {
+    "new": "Nuevo arreglo"
+  },
+  "modals": {
+    "createTitle": "Nuevo arreglo",
+    "editTitle": "Editar arreglo"
+  },
+  "table": {
+    "key": "Tonalidad",
+    "bpm": "PPM",
+    "meter": "Compás"
+  },
+  "list": {
+    "empty": "No hay arreglos"
+  },
+  "labels": {
+    "fallback": "Arreglo {{id}}"
+  },
+  "validation": {
+    "keyRequired": "La tonalidad es obligatoria",
+    "bpmNumber": "Los PPM deben ser un número",
+    "lyricsRequired": "Las letras son obligatorias"
   }
 }

--- a/apps/web/src/locales/es/common.json
+++ b/apps/web/src/locales/es/common.json
@@ -5,7 +5,9 @@
   "nav": {
     "songs": "Canciones",
     "services": "Servicios",
-    "members": "Miembros"
+    "members": "Miembros",
+    "groups": "Grupos",
+    "songSets": "Listas de canciones"
   },
   "actions": {
     "save": "Guardar",
@@ -33,5 +35,13 @@
   },
   "labels": {
     "notAvailable": "N/D"
+  },
+  "language": {
+    "change": "Cambiar idioma",
+    "select": "Seleccionar idioma",
+    "labels": {
+      "en": "Inglés",
+      "es": "Español"
+    }
   }
 }

--- a/apps/web/src/locales/es/common.json
+++ b/apps/web/src/locales/es/common.json
@@ -12,6 +12,26 @@
     "cancel": "Cancelar",
     "edit": "Editar",
     "delete": "Eliminar",
-    "back": "Volver"
+    "back": "Volver",
+    "open": "Abrir",
+    "add": "Agregar",
+    "remove": "Quitar",
+    "print": "Imprimir",
+    "exportPdf": "Exportar PDF"
+  },
+  "status": {
+    "loading": "Cargando…",
+    "loadFailed": "No se pudo cargar"
+  },
+  "pagination": {
+    "previous": "Anterior",
+    "next": "Siguiente",
+    "pageOf": "Página {{page}} de {{total}}"
+  },
+  "table": {
+    "actions": "Acciones"
+  },
+  "labels": {
+    "notAvailable": "N/D"
   }
 }

--- a/apps/web/src/locales/es/groups.json
+++ b/apps/web/src/locales/es/groups.json
@@ -1,0 +1,35 @@
+{
+  "page": {
+    "title": "Grupos"
+  },
+  "actions": {
+    "new": "Nuevo grupo"
+  },
+  "list": {
+    "searchPlaceholder": "Buscar por nombre...",
+    "empty": "No se encontraron grupos"
+  },
+  "table": {
+    "name": "Nombre",
+    "members": "Miembros"
+  },
+  "modals": {
+    "createTitle": "Nuevo grupo",
+    "editTitle": "Editar grupo"
+  },
+  "form": {
+    "nameLabel": "Nombre"
+  },
+  "validation": {
+    "nameMin": "El nombre debe tener al menos 2 caracteres"
+  },
+  "detail": {
+    "infoTitle": "Información del grupo",
+    "membersTitle": "Miembros",
+    "searchPlaceholder": "Buscar miembros...",
+    "selectMember": "Seleccionar miembro",
+    "emptyMembers": "Sin miembros",
+    "loadFailedMembers": "No se pudieron cargar los miembros",
+    "removeMemberConfirm": "¿Quitar miembro?"
+  }
+}

--- a/apps/web/src/locales/es/members.json
+++ b/apps/web/src/locales/es/members.json
@@ -6,5 +6,27 @@
   "fields": {
     "displayName": "Nombre",
     "instruments": "Instrumentos"
+  },
+  "form": {
+    "displayName": "Nombre para mostrar",
+    "instrumentsLabel": "Instrumentos (separados por comas)"
+  },
+  "actions": {
+    "new": "Nuevo miembro"
+  },
+  "list": {
+    "searchPlaceholder": "Buscar por nombre...",
+    "empty": "No se encontraron miembros"
+  },
+  "table": {
+    "name": "Nombre",
+    "instruments": "Instrumentos"
+  },
+  "modals": {
+    "createTitle": "Nuevo miembro",
+    "editTitle": "Editar miembro"
+  },
+  "validation": {
+    "displayNameMin": "El nombre para mostrar debe tener al menos 2 caracteres"
   }
 }

--- a/apps/web/src/locales/es/services.json
+++ b/apps/web/src/locales/es/services.json
@@ -6,5 +6,52 @@
   "fields": {
     "startsAt": "Hora de inicio",
     "location": "Ubicación"
+  },
+  "actions": {
+    "new": "Nuevo servicio",
+    "openPlan": "Abrir plan",
+    "planView": "Vista del plan"
+  },
+  "list": {
+    "searchPlaceholder": "Buscar...",
+    "empty": "No se encontraron servicios"
+  },
+  "modals": {
+    "createTitle": "Nuevo servicio",
+    "editTitle": "Editar servicio"
+  },
+  "form": {
+    "startsAtLabel": "Hora de inicio",
+    "locationLabel": "Ubicación"
+  },
+  "fallback": {
+    "title": "Servicio"
+  },
+  "plan": {
+    "addItemTitle": "Agregar elemento",
+    "itemTypes": {
+      "song": "Canción",
+      "reading": "Lectura",
+      "note": "Nota",
+      "itemFallback": "Elemento"
+    },
+    "notesPlaceholder": "Notas",
+    "title": "Plan",
+    "empty": "Sin elementos del plan",
+    "noItems": "Sin elementos",
+    "notifications": {
+      "itemAdded": "Elemento agregado",
+      "addFailed": "No se pudo agregar el elemento"
+    }
+  },
+  "planView": {
+    "title": "Plan del servicio",
+    "shareRequiredTitle": "Se requiere un token para compartir",
+    "shareRequiredDescription": "Se necesita un enlace válido para ver este plan de servicio. Verifica el enlace e inténtalo de nuevo.",
+    "loading": "Cargando plan…",
+    "unavailableTitle": "Plan no disponible",
+    "unavailableDescription": "No pudimos cargar este plan de servicio. Vuelve a intentarlo más tarde o contacta al organizador.",
+    "shareTokenLabel": "Token de compartido:",
+    "empty": "Aún no se han programado elementos en el plan."
   }
 }

--- a/apps/web/src/locales/es/services.json
+++ b/apps/web/src/locales/es/services.json
@@ -16,6 +16,13 @@
     "searchPlaceholder": "Buscar...",
     "empty": "No se encontraron servicios"
   },
+  "table": {
+    "startsAt": "Hora de inicio",
+    "location": "Ubicación"
+  },
+  "status": {
+    "loadFailed": "No se pudieron cargar los servicios."
+  },
   "modals": {
     "createTitle": "Nuevo servicio",
     "editTitle": "Editar servicio"

--- a/apps/web/src/locales/es/songSets.json
+++ b/apps/web/src/locales/es/songSets.json
@@ -6,5 +6,52 @@
   "fields": {
     "name": "Nombre del conjunto",
     "serviceDate": "Fecha del servicio"
+  },
+  "actions": {
+    "new": "Nuevo conjunto"
+  },
+  "modals": {
+    "createTitle": "Nuevo conjunto",
+    "editTitle": "Editar conjunto"
+  },
+  "list": {
+    "searchPlaceholder": "Buscar por nombre...",
+    "empty": "No se encontraron conjuntos de canciones"
+  },
+  "table": {
+    "name": "Nombre",
+    "items": "Elementos"
+  },
+  "status": {
+    "loadFailed": "No se pudieron cargar los conjuntos de canciones.",
+    "noneSelected": "No se seleccionó ningún conjunto de canciones.",
+    "savingOrder": "Guardando el orden…"
+  },
+  "confirm": {
+    "delete": "¿Seguro que deseas eliminar este conjunto?"
+  },
+  "items": {
+    "addTitle": "Agregar elemento",
+    "transpose": "Transponer",
+    "capo": "Capotraste",
+    "addButton": "Agregar elemento",
+    "title": "Elementos",
+    "loadFailed": "No se pudieron cargar los elementos.",
+    "empty": "Sin elementos",
+    "dragHandle": "Arrastrar para reordenar"
+  },
+  "notifications": {
+    "itemAdded": "Elemento agregado",
+    "addFailed": "No se pudo agregar el elemento"
+  },
+  "fallback": {
+    "title": "Conjunto de canciones"
+  },
+  "controls": {
+    "showSharps": "Mostrar sostenidos (♯)",
+    "showFlats": "Mostrar bemoles (♭)"
+  },
+  "validation": {
+    "nameMin": "El nombre debe tener al menos 2 caracteres"
   }
 }

--- a/apps/web/src/locales/es/songs.json
+++ b/apps/web/src/locales/es/songs.json
@@ -5,6 +5,37 @@
   },
   "fields": {
     "title": "Título",
-    "defaultKey": "Tonalidad predeterminada"
+    "defaultKey": "Tonalidad predeterminada",
+    "tags": "Etiquetas"
+  },
+  "form": {
+    "titleLabel": "Título",
+    "ccliLabel": "CCLI",
+    "authorLabel": "Autor",
+    "defaultKeyLabel": "Tonalidad predeterminada",
+    "tagsLabel": "Etiquetas (separadas por comas)"
+  },
+  "actions": {
+    "new": "Nueva canción"
+  },
+  "modals": {
+    "createTitle": "Nueva canción",
+    "editTitle": "Editar canción"
+  },
+  "list": {
+    "searchPlaceholder": "Buscar por título...",
+    "empty": "No se encontraron canciones"
+  },
+  "validation": {
+    "titleMin": "El título debe tener al menos 2 caracteres"
+  },
+  "detail": {
+    "author": "Autor",
+    "ccli": "CCLI",
+    "defaultKey": "Tonalidad predeterminada",
+    "tags": "Etiquetas"
+  },
+  "pickers": {
+    "searchPlaceholder": "Buscar canciones..."
   }
 }

--- a/apps/web/src/pages/groups/GroupDetailPage.tsx
+++ b/apps/web/src/pages/groups/GroupDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom';
 import { useState, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import GroupForm from '../../features/groups/GroupForm';
 import {
   useGroup,
@@ -15,6 +16,8 @@ type Member = components['schemas']['MemberResponse'];
 
 export default function GroupDetailPage() {
   const { id = '' } = useParams<{ id: string }>();
+  const { t } = useTranslation('groups');
+  const { t: tCommon } = useTranslation('common');
   const groupQuery = useGroup(id);
   const updateGroup = useUpdateGroup();
   const membersQuery = useGroupMembers(id);
@@ -49,9 +52,9 @@ export default function GroupDetailPage() {
   return (
     <div className="p-4 flex flex-col md:flex-row gap-6">
       <div className="md:w-1/2">
-        <h1 className="text-xl font-semibold mb-4">Group Info</h1>
-        {groupQuery.isLoading && <div>Loading…</div>}
-        {groupQuery.isError && <div>Failed to load</div>}
+        <h1 className="text-xl font-semibold mb-4">{t('detail.infoTitle')}</h1>
+        {groupQuery.isLoading && <div>{tCommon('status.loading')}</div>}
+        {groupQuery.isError && <div>{tCommon('status.loadFailed')}</div>}
         {groupQuery.data && (
           <GroupForm
             defaultValues={{ name: groupQuery.data.name || '' }}
@@ -60,12 +63,12 @@ export default function GroupDetailPage() {
         )}
       </div>
       <div className="md:w-1/2">
-        <h2 className="text-xl font-semibold mb-4">Members</h2>
+        <h2 className="text-xl font-semibold mb-4">{t('detail.membersTitle')}</h2>
         <div className="flex flex-col gap-2 mb-2 md:flex-row">
           <input
             value={memberSearch}
             onChange={(e) => setMemberSearch(e.target.value)}
-            placeholder="Search members..."
+            placeholder={t('detail.searchPlaceholder')}
             className="border p-2 rounded flex-1"
           />
           <select
@@ -73,7 +76,7 @@ export default function GroupDetailPage() {
             onChange={(e) => setSelectedMemberId(e.target.value)}
             className="border p-2 rounded flex-1"
           >
-            <option value="">Select member</option>
+            <option value="">{t('detail.selectMember')}</option>
             {availableMembers.map((m) => (
               <option key={m.id} value={m.id}>
                 {m.displayName}
@@ -85,17 +88,17 @@ export default function GroupDetailPage() {
             disabled={!selectedMemberId}
             className="px-3 py-2 bg-blue-500 text-white rounded disabled:opacity-50"
           >
-            Add
+            {tCommon('actions.add')}
           </button>
         </div>
-        {membersQuery.isLoading && <div>Loading…</div>}
-        {membersQuery.isError && <div>Failed to load members</div>}
+        {membersQuery.isLoading && <div>{tCommon('status.loading')}</div>}
+        {membersQuery.isError && <div>{t('detail.loadFailedMembers')}</div>}
         {membersQuery.data && membersQuery.data.length > 0 ? (
           <table className="w-full border mt-2">
             <thead>
               <tr className="bg-gray-50">
-                <th className="text-left p-2">Name</th>
-                <th className="p-2 text-right">Actions</th>
+                <th className="text-left p-2">{t('table.name')}</th>
+                <th className="p-2 text-right">{tCommon('table.actions')}</th>
               </tr>
             </thead>
             <tbody>
@@ -106,12 +109,12 @@ export default function GroupDetailPage() {
                     <button
                       className="px-2 py-1 text-sm bg-red-500 text-white rounded"
                       onClick={() => {
-                        if (confirm('Remove member?')) {
+                        if (confirm(t('detail.removeMemberConfirm'))) {
                           removeMember.mutate(m.id as string);
                         }
                       }}
                     >
-                      Remove
+                      {tCommon('actions.remove')}
                     </button>
                   </td>
                 </tr>
@@ -119,7 +122,7 @@ export default function GroupDetailPage() {
             </tbody>
           </table>
         ) : (
-          <div className="mt-2">No members</div>
+          <div className="mt-2">{t('detail.emptyMembers')}</div>
         )}
       </div>
     </div>

--- a/apps/web/src/pages/groups/GroupsPage.tsx
+++ b/apps/web/src/pages/groups/GroupsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import {
   useGroupsList,
   useCreateGroup,
@@ -34,6 +35,8 @@ function Modal({
 }
 
 export default function GroupsPage() {
+  const { t } = useTranslation('groups');
+  const { t: tCommon } = useTranslation('common');
   const [searchParams, setSearchParams] = useSearchParams();
   const queryParam = searchParams.get('query') ?? '';
   const pageParam = Number(searchParams.get('page') ?? '0');
@@ -91,24 +94,24 @@ export default function GroupsPage() {
 
   return (
     <div className="p-4">
-      <h1 className="text-xl font-semibold mb-4">Groups</h1>
+      <h1 className="text-xl font-semibold mb-4">{t('page.title')}</h1>
       <div className="flex items-center gap-2 mb-4">
         <input
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search by name..."
+          placeholder={t('list.searchPlaceholder')}
           className="border p-2 rounded w-full max-w-sm"
         />
         <button
           onClick={() => setCreating(true)}
           className="px-4 py-2 bg-blue-500 text-white rounded"
         >
-          New Group
+          {t('actions.new')}
         </button>
       </div>
 
-      {isLoading && <div>Loading…</div>}
-      {isError && <div>Failed to load</div>}
+      {isLoading && <div>{tCommon('status.loading')}</div>}
+      {isError && <div>{tCommon('status.loadFailed')}</div>}
 
       {!isLoading && data ? (
         <div className="mt-4">
@@ -116,9 +119,9 @@ export default function GroupsPage() {
             <table className="w-full border">
               <thead>
                 <tr className="bg-gray-50">
-                  <th className="text-left p-2">Name</th>
-                  <th className="text-left p-2">Members</th>
-                  <th className="p-2 text-right">Actions</th>
+                  <th className="text-left p-2">{t('table.name')}</th>
+                  <th className="text-left p-2">{t('table.members')}</th>
+                  <th className="p-2 text-right">{tCommon('table.actions')}</th>
                 </tr>
               </thead>
               <tbody>
@@ -148,13 +151,13 @@ export default function GroupsPage() {
                             className="px-2 py-1 text-sm bg-gray-200 rounded"
                             onClick={() => setEditingId(g.id!)}
                           >
-                            Edit
+                            {tCommon('actions.edit')}
                           </button>
                           <button
                             className="px-2 py-1 text-sm bg-red-500 text-white rounded"
                             onClick={() => deleteMut.mutate(g.id!)}
                           >
-                            Delete
+                            {tCommon('actions.delete')}
                           </button>
                         </div>
                       )}
@@ -164,7 +167,7 @@ export default function GroupsPage() {
               </tbody>
             </table>
           ) : (
-            <div>No groups found</div>
+            <div>{t('list.empty')}</div>
           )}
 
           <div className="flex items-center gap-2 mt-4">
@@ -173,10 +176,13 @@ export default function GroupsPage() {
               disabled={pageParam === 0}
               onClick={() => goToPage(Math.max(0, pageParam - 1))}
             >
-              Previous
+              {tCommon('pagination.previous')}
             </button>
             <span>
-              Page {(data.number ?? 0) + 1} of {data.totalPages ?? 1}
+              {tCommon('pagination.pageOf', {
+                page: (data.number ?? 0) + 1,
+                total: data.totalPages ?? 1,
+              })}
             </span>
             <button
               className="px-3 py-1 border rounded disabled:opacity-50"
@@ -187,14 +193,14 @@ export default function GroupsPage() {
               }
               onClick={() => goToPage(pageParam + 1)}
             >
-              Next
+              {tCommon('pagination.next')}
             </button>
           </div>
         </div>
       ) : null}
 
       <Modal open={creating} onClose={() => setCreating(false)}>
-        <h2 className="text-lg font-semibold mb-2">New Group</h2>
+        <h2 className="text-lg font-semibold mb-2">{t('modals.createTitle')}</h2>
         <GroupForm onSubmit={handleCreate} onCancel={() => setCreating(false)} />
       </Modal>
     </div>

--- a/apps/web/src/pages/members/MembersPage.tsx
+++ b/apps/web/src/pages/members/MembersPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import type { components } from '../../api/types';
 import {
   useMembersList,
@@ -38,6 +39,8 @@ type Member = components['schemas']['MemberResponse'];
 type MemberRequest = components['schemas']['MemberRequest'];
 
 export default function MembersPage() {
+  const { t } = useTranslation('members');
+  const { t: tCommon } = useTranslation('common');
   const [searchParams, setSearchParams] = useSearchParams();
   const queryParam = searchParams.get('query') ?? '';
   const pageParam = Number(searchParams.get('page') ?? '0');
@@ -88,23 +91,23 @@ export default function MembersPage() {
 
   return (
     <div className="p-4">
-      <h1 className="text-xl font-semibold mb-4">Members</h1>
+      <h1 className="text-xl font-semibold mb-4">{t('page.title')}</h1>
       <div className="flex items-center gap-2 mb-4">
         <input
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search by name..."
+          placeholder={t('list.searchPlaceholder')}
           className="border p-2 rounded w-full max-w-sm"
         />
         <button
           onClick={() => setCreating(true)}
           className="px-4 py-2 bg-blue-500 text-white rounded"
         >
-          New Member
+          {t('actions.new')}
         </button>
       </div>
-      {isLoading && <div>Loading…</div>}
-      {isError && <div>Failed to load</div>}
+      {isLoading && <div>{tCommon('status.loading')}</div>}
+      {isError && <div>{tCommon('status.loadFailed')}</div>}
       {!isLoading && data ? (
         <div className="mt-4">
           {data.content && data.content.length > 0 ? (
@@ -112,9 +115,9 @@ export default function MembersPage() {
               <table className="w-full border">
                 <thead>
                   <tr className="bg-gray-50">
-                    <th className="text-left p-2">Name</th>
-                    <th className="text-left p-2">Instruments</th>
-                    <th className="p-2 text-right">Actions</th>
+                    <th className="text-left p-2">{t('table.name')}</th>
+                    <th className="text-left p-2">{t('table.instruments')}</th>
+                    <th className="p-2 text-right">{tCommon('table.actions')}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -128,13 +131,13 @@ export default function MembersPage() {
                             className="px-2 py-1 text-sm bg-gray-200 rounded"
                             onClick={() => setEditing(m)}
                           >
-                            Edit
+                            {tCommon('actions.edit')}
                           </button>
                           <button
                             className="px-2 py-1 text-sm bg-red-500 text-white rounded"
                             onClick={() => deleteMut.mutate(m.id!)}
                           >
-                            Delete
+                            {tCommon('actions.delete')}
                           </button>
                         </div>
                       </td>
@@ -148,10 +151,13 @@ export default function MembersPage() {
                   disabled={pageParam === 0}
                   onClick={() => goToPage(Math.max(0, pageParam - 1))}
                 >
-                  Previous
+                  {tCommon('pagination.previous')}
                 </button>
                 <span>
-                  Page {(data.number ?? 0) + 1} of {data.totalPages ?? 1}
+                  {tCommon('pagination.pageOf', {
+                    page: (data.number ?? 0) + 1,
+                    total: data.totalPages ?? 1,
+                  })}
                 </span>
                 <button
                   className="px-3 py-1 border rounded disabled:opacity-50"
@@ -162,21 +168,21 @@ export default function MembersPage() {
                   }
                   onClick={() => goToPage(pageParam + 1)}
                 >
-                  Next
+                  {tCommon('pagination.next')}
                 </button>
               </div>
             </>
           ) : (
-            <div>No members found</div>
+            <div>{t('list.empty')}</div>
           )}
         </div>
       ) : null}
       <Modal open={creating} onClose={() => setCreating(false)}>
-        <h2 className="text-lg font-semibold mb-2">New Member</h2>
+        <h2 className="text-lg font-semibold mb-2">{t('modals.createTitle')}</h2>
         <MemberForm onSubmit={handleCreate} onCancel={() => setCreating(false)} />
       </Modal>
       <Modal open={!!editing} onClose={() => setEditing(null)}>
-        <h2 className="text-lg font-semibold mb-2">Edit Member</h2>
+        <h2 className="text-lg font-semibold mb-2">{t('modals.editTitle')}</h2>
         {editing && (
           <MemberForm
             defaultValues={{

--- a/apps/web/src/pages/services/ServiceDetailPage.tsx
+++ b/apps/web/src/pages/services/ServiceDetailPage.tsx
@@ -3,6 +3,7 @@ import { useParams, Link } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { useQuery } from '@tanstack/react-query';
 import type { components } from '../../api/types';
@@ -53,7 +54,7 @@ const addSchema = z
     notes: z.string().max(1000).optional(),
   })
   .refine((d) => d.type !== 'song' || !!d.arrangementId, {
-    message: 'Arrangement required',
+    message: 'validation.arrangementRequired',
     path: ['arrangementId'],
   });
 
@@ -61,6 +62,10 @@ type AddItemForm = z.infer<typeof addSchema>;
 
 export default function ServiceDetailPage() {
   const { id } = useParams();
+  const { t } = useTranslation('services');
+  const { t: tCommon } = useTranslation('common');
+  const { t: tSongs } = useTranslation('songs');
+  const { t: tArrangements } = useTranslation('arrangements');
   const { data: service, isLoading, isError } = useService(id);
   const { data: planItems, isLoading: planLoading } = usePlanItems(id);
   const { data: arrangementLabels } = usePlanArrangementInfo(planItems);
@@ -121,8 +126,8 @@ export default function ServiceDetailPage() {
       })
     : null;
 
-  if (isLoading) return <div className="p-4">Loading…</div>;
-  if (isError || !service) return <div className="p-4">Failed to load</div>;
+  if (isLoading) return <div className="p-4">{tCommon('status.loading')}</div>;
+  if (isError || !service) return <div className="p-4">{tCommon('status.loadFailed')}</div>;
 
   const handleServiceUpdate = (vals: ServiceRequest) => {
     updateServiceMut.mutate({ id: id!, body: vals }, { onSuccess: () => setEditingService(false) });
@@ -138,11 +143,11 @@ export default function ServiceDetailPage() {
       },
       {
         onSuccess: () => {
-          toast('Item added');
+          toast(t('plan.notifications.itemAdded'));
           reset({ type: 'note' });
           setSongId(undefined);
         },
-        onError: () => toast('Failed to add item'),
+        onError: () => toast(t('plan.notifications.addFailed')),
       },
     );
   });
@@ -152,7 +157,9 @@ export default function ServiceDetailPage() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-xl font-semibold">
-            {service.startsAt ? new Date(service.startsAt).toLocaleString() : 'Service'}
+            {service.startsAt
+              ? new Date(service.startsAt).toLocaleString()
+              : t('fallback.title')}
           </h1>
           {service.location && <div>{service.location}</div>}
         </div>
@@ -161,30 +168,30 @@ export default function ServiceDetailPage() {
             to={`plan?share=preview`}
             className="px-2 py-1 text-sm bg-indigo-500 text-white rounded"
           >
-            Plan View
+            {t('actions.planView')}
           </Link>
           <button
             className="px-2 py-1 text-sm bg-gray-200 rounded"
             onClick={() => setEditingService(true)}
           >
-            Edit
+            {tCommon('actions.edit')}
           </button>
           <Link
             to="print"
             className="px-2 py-1 text-sm bg-blue-500 text-white rounded"
           >
-            Print
+            {tCommon('actions.print')}
           </Link>
         </div>
       </div>
       <div className="flex flex-col md:flex-row gap-4">
         <div className="md:w-1/3">
-          <h2 className="font-semibold mb-2">Add Item</h2>
+          <h2 className="font-semibold mb-2">{t('plan.addItemTitle')}</h2>
           <form onSubmit={handleAddItem} className="space-y-2">
             <select {...register('type')} className="border p-2 rounded w-full">
-              <option value="song">Song</option>
-              <option value="reading">Reading</option>
-              <option value="note">Note</option>
+              <option value="song">{t('plan.itemTypes.song')}</option>
+              <option value="reading">{t('plan.itemTypes.reading')}</option>
+              <option value="note">{t('plan.itemTypes.note')}</option>
             </select>
             {type === 'song' && (
               <div className="space-y-2">
@@ -194,7 +201,7 @@ export default function ServiceDetailPage() {
                     setSongId(id);
                     setValue('arrangementId', undefined);
                   }}
-                  placeholder="Search songs..."
+                  placeholder={tSongs('pickers.searchPlaceholder')}
                 />
                 <ArrangementPicker
                   songId={songId}
@@ -208,30 +215,38 @@ export default function ServiceDetailPage() {
                   </div>
                 )}
                 {errors.arrangementId && (
-                  <p className="text-red-500 text-sm">{errors.arrangementId.message}</p>
+                  <p className="text-red-500 text-sm">
+                    {t(errors.arrangementId.message ?? '', {
+                      defaultValue: errors.arrangementId.message ?? '',
+                    })}
+                  </p>
                 )}
               </div>
             )}
             <textarea
-              placeholder="Notes"
+              placeholder={t('plan.notesPlaceholder')}
               className="border p-2 rounded w-full"
               {...register('notes')}
             />
             {errors.notes && (
-              <p className="text-red-500 text-sm">{errors.notes.message}</p>
+              <p className="text-red-500 text-sm">
+                {t(errors.notes.message ?? '', {
+                  defaultValue: errors.notes.message ?? '',
+                })}
+              </p>
             )}
             <button
               type="submit"
               disabled={addItemMut.isPending || (type === 'song' && !arrangementId)}
               className="px-4 py-2 bg-green-500 text-white rounded disabled:opacity-50"
             >
-              Add
+              {tCommon('actions.add')}
             </button>
           </form>
         </div>
         <div className="flex-1">
-          <h2 className="font-semibold mb-2">Plan</h2>
-          {planLoading && <div>Loading…</div>}
+          <h2 className="font-semibold mb-2">{t('plan.title')}</h2>
+          {planLoading && <div>{tCommon('status.loading')}</div>}
           {!planLoading && planItems && planItems.length > 0 ? (
             <ul className="space-y-2">
               {planItems.map((item) => {
@@ -240,7 +255,7 @@ export default function ServiceDetailPage() {
 
                 if (item.type === 'song' && item.refId) {
                   const label = arrangementLabelMap[item.refId];
-                  const fallbackTitle = `Arrangement ${item.refId}`;
+                  const fallbackTitle = tArrangements('labels.fallback', { id: item.refId });
                   const extras = item as Record<string, unknown>;
                   const transpose =
                     typeof extras['transpose'] === 'number' ? (extras['transpose'] as number) : 0;
@@ -256,8 +271,10 @@ export default function ServiceDetailPage() {
                     meter: label?.meter ?? null,
                   });
                   keySummary = formatKeyTransform({
-                    originalKey: keyInfo?.originalKey ?? label?.key ?? 'N/A',
-                    soundingKey: keyInfo?.soundingKey ?? label?.key ?? 'N/A',
+                    originalKey:
+                      keyInfo?.originalKey ?? label?.key ?? tCommon('labels.notAvailable'),
+                    soundingKey:
+                      keyInfo?.soundingKey ?? label?.key ?? tCommon('labels.notAvailable'),
                     shapeKey: keyInfo?.shapeKey,
                     transpose,
                     capo,
@@ -268,7 +285,11 @@ export default function ServiceDetailPage() {
                   <li key={item.id} className="border p-2 rounded">
                     <div className="flex justify-between mb-2">
                       <div className="space-y-1">
-                        <div className="font-semibold capitalize">{item.type}</div>
+                        <div className="font-semibold capitalize">
+                          {t('plan.itemTypes.' + item.type, {
+                            defaultValue: item.type,
+                          })}
+                        </div>
                         {line ? (
                           <div className="space-y-0.5">
                             <div>{line}</div>
@@ -282,7 +303,7 @@ export default function ServiceDetailPage() {
                         className="px-2 py-1 text-sm bg-red-500 text-white rounded"
                         onClick={() => item.id && removeItemMut.mutate(item.id)}
                       >
-                        Remove
+                        {tCommon('actions.remove')}
                       </button>
                     </div>
                     <textarea
@@ -298,12 +319,12 @@ export default function ServiceDetailPage() {
               })}
             </ul>
           ) : (
-            !planLoading && <div>No plan items</div>
+            !planLoading && <div>{t('plan.empty')}</div>
           )}
         </div>
       </div>
       <Modal open={editingService} onClose={() => setEditingService(false)}>
-        <h2 className="text-lg font-semibold mb-2">Edit Service</h2>
+        <h2 className="text-lg font-semibold mb-2">{t('modals.editTitle')}</h2>
         <ServiceForm
           defaultValues={{
             startsAt: service.startsAt ? service.startsAt.slice(0, 16) : '',

--- a/apps/web/src/pages/services/ServicePlanViewPage.tsx
+++ b/apps/web/src/pages/services/ServicePlanViewPage.tsx
@@ -1,19 +1,18 @@
 import { useMemo } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { usePlanItems, useService } from '@/features/services/hooks';
 import { usePlanArrangementInfo } from '@/features/services/usePlanArrangementInfo';
 import { formatArrangementLine, formatKeyTransform } from '@/lib/arrangement-labels';
 import { computeKeys } from '@/lib/keys';
 
-function formatType(type?: string | null) {
-  if (!type) return 'Item';
-  return type.charAt(0).toUpperCase() + type.slice(1);
-}
-
 export default function ServicePlanViewPage() {
   const { id } = useParams();
   const [searchParams] = useSearchParams();
   const shareToken = searchParams.get('share');
+  const { t } = useTranslation('services');
+  const { t: tCommon } = useTranslation('common');
+  const { t: tArrangements } = useTranslation('arrangements');
 
   const {
     data: service,
@@ -31,15 +30,21 @@ export default function ServicePlanViewPage() {
 
   const plan = useMemo(() => planItems ?? [], [planItems]);
 
+  const formatType = (type?: string | null) => {
+    if (!type) {
+      return t('plan.itemTypes.itemFallback');
+    }
+    return t(`plan.itemTypes.${type}`, {
+      defaultValue: type.charAt(0).toUpperCase() + type.slice(1),
+    });
+  };
+
   if (!shareToken) {
     return (
       <div className="plan-view px-4 py-10">
         <div className="mx-auto max-w-3xl rounded border border-dashed border-red-200 bg-red-50 p-6 text-center text-red-700">
-          <h1 className="text-lg font-semibold">Share token required</h1>
-          <p className="mt-2 text-sm">
-            A valid share link is required to view this service plan. Please check your link and try
-            again.
-          </p>
+          <h1 className="text-lg font-semibold">{t('planView.shareRequiredTitle')}</h1>
+          <p className="mt-2 text-sm">{t('planView.shareRequiredDescription')}</p>
         </div>
       </div>
     );
@@ -48,7 +53,9 @@ export default function ServicePlanViewPage() {
   if (serviceLoading || planLoading) {
     return (
       <div className="plan-view px-4 py-10">
-        <div className="mx-auto max-w-3xl text-center text-muted-foreground">Loading plan…</div>
+        <div className="mx-auto max-w-3xl text-center text-muted-foreground">
+          {t('planView.loading')}
+        </div>
       </div>
     );
   }
@@ -57,10 +64,8 @@ export default function ServicePlanViewPage() {
     return (
       <div className="plan-view px-4 py-10">
         <div className="mx-auto max-w-3xl rounded border border-red-100 bg-red-50 p-6 text-center text-red-700">
-          <h1 className="text-lg font-semibold">Plan unavailable</h1>
-          <p className="mt-2 text-sm">
-            We were unable to load this service plan. Please try again later or contact the organizer.
-          </p>
+          <h1 className="text-lg font-semibold">{t('planView.unavailableTitle')}</h1>
+          <p className="mt-2 text-sm">{t('planView.unavailableDescription')}</p>
         </div>
       </div>
     );
@@ -73,9 +78,11 @@ export default function ServicePlanViewPage() {
       <div className="mx-auto flex max-w-4xl flex-col gap-6">
         <header className="flex flex-col gap-4 border-b border-gray-200 pb-4 print:border-0 print:pb-0">
           <div>
-            <p className="text-sm uppercase tracking-wide text-muted-foreground">Service Plan</p>
+            <p className="text-sm uppercase tracking-wide text-muted-foreground">{t('planView.title')}</p>
             <h1 className="mt-1 text-2xl font-semibold text-gray-900">
-              {service.startsAt ? new Date(service.startsAt).toLocaleString() : 'Service'}
+              {service.startsAt
+                ? new Date(service.startsAt).toLocaleString()
+                : t('fallback.title')}
             </h1>
             {service.location ? (
               <p className="mt-1 text-base text-gray-600">{service.location}</p>
@@ -83,14 +90,15 @@ export default function ServicePlanViewPage() {
           </div>
           <div className="flex flex-wrap items-center justify-between gap-3 print:hidden">
             <div className="rounded bg-gray-100 px-3 py-1 text-xs font-medium uppercase tracking-wide text-gray-600">
-              Share Token: <span className="font-semibold text-gray-800">{shareToken}</span>
+              {t('planView.shareTokenLabel')}{' '}
+              <span className="font-semibold text-gray-800">{shareToken}</span>
             </div>
             <button
               type="button"
               onClick={handleExport}
               className="rounded border border-blue-600 px-4 py-2 text-sm font-medium text-blue-600 transition hover:bg-blue-50"
             >
-              Export PDF
+              {tCommon('actions.exportPdf')}
             </button>
           </div>
         </header>
@@ -104,7 +112,7 @@ export default function ServicePlanViewPage() {
 
               if (isSong && item.refId) {
                 const label = arrangementLabelMap[item.refId];
-                const fallbackTitle = `Arrangement ${item.refId}`;
+                const fallbackTitle = tArrangements('labels.fallback', { id: item.refId });
                 const extras = item as Record<string, unknown>;
                 const transpose =
                   typeof extras['transpose'] === 'number' ? (extras['transpose'] as number) : 0;
@@ -118,8 +126,10 @@ export default function ServicePlanViewPage() {
                   meter: label?.meter ?? null,
                 });
                 keySummary = formatKeyTransform({
-                  originalKey: keyInfo?.originalKey ?? label?.key ?? 'N/A',
-                  soundingKey: keyInfo?.soundingKey ?? label?.key ?? 'N/A',
+                  originalKey:
+                    keyInfo?.originalKey ?? label?.key ?? tCommon('labels.notAvailable'),
+                  soundingKey:
+                    keyInfo?.soundingKey ?? label?.key ?? tCommon('labels.notAvailable'),
                   shapeKey: keyInfo?.shapeKey,
                   transpose,
                   capo,
@@ -158,7 +168,7 @@ export default function ServicePlanViewPage() {
           </ol>
         ) : (
           <div className="rounded border border-dashed border-gray-300 bg-gray-50 p-6 text-center text-sm text-gray-600">
-            No plan items have been scheduled yet.
+            {t('planView.empty')}
           </div>
         )}
       </div>

--- a/apps/web/src/pages/services/ServicePrintPage.tsx
+++ b/apps/web/src/pages/services/ServicePrintPage.tsx
@@ -1,4 +1,5 @@
 import { useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { useService, usePlanItems } from '../../features/services/hooks';
 import { usePlanArrangementInfo } from '@/features/services/usePlanArrangementInfo';
 import { formatArrangementLine, formatKeyTransform } from '@/lib/arrangement-labels';
@@ -6,14 +7,19 @@ import { computeKeys } from '@/lib/keys';
 
 export default function ServicePrintPage() {
   const { id } = useParams();
+  const { t } = useTranslation('services');
+  const { t: tCommon } = useTranslation('common');
+  const { t: tArrangements } = useTranslation('arrangements');
   const { data: service } = useService(id);
   const { data: plan } = usePlanItems(id);
   const { data: arrangementLabels } = usePlanArrangementInfo(plan);
   const arrangementLabelMap = arrangementLabels ?? {};
 
   const formatType = (type?: string | null) => {
-    if (!type) return 'Item';
-    return type.charAt(0).toUpperCase() + type.slice(1);
+    if (!type) return t('plan.itemTypes.itemFallback');
+    return t(`plan.itemTypes.${type}`, {
+      defaultValue: type.charAt(0).toUpperCase() + type.slice(1),
+    });
   };
 
   const handlePrint = () => window.print();
@@ -22,14 +28,16 @@ export default function ServicePrintPage() {
     <div className="p-4 print:p-0">
       <div className="mb-4 flex justify-between print:block">
         <h1 className="text-xl font-semibold">
-          {service?.startsAt ? new Date(service.startsAt).toLocaleString() : 'Service'}
+          {service?.startsAt
+            ? new Date(service.startsAt).toLocaleString()
+            : t('fallback.title')}
           {service?.location ? ` - ${service.location}` : ''}
         </h1>
         <button
           onClick={handlePrint}
           className="px-2 py-1 text-sm bg-blue-500 text-white rounded print:hidden"
         >
-          Print
+          {tCommon('actions.print')}
         </button>
       </div>
       {plan && plan.length > 0 ? (
@@ -41,7 +49,7 @@ export default function ServicePrintPage() {
 
             if (isSong && item.refId) {
               const label = arrangementLabelMap[item.refId];
-              const fallbackTitle = `Arrangement ${item.refId}`;
+              const fallbackTitle = tArrangements('labels.fallback', { id: item.refId });
               const extras = item as Record<string, unknown>;
               const transpose =
                 typeof extras['transpose'] === 'number' ? (extras['transpose'] as number) : 0;
@@ -57,8 +65,10 @@ export default function ServicePrintPage() {
                 meter: label?.meter ?? null,
               });
               keySummary = formatKeyTransform({
-                originalKey: keyInfo?.originalKey ?? label?.key ?? 'N/A',
-                soundingKey: keyInfo?.soundingKey ?? label?.key ?? 'N/A',
+                originalKey:
+                  keyInfo?.originalKey ?? label?.key ?? tCommon('labels.notAvailable'),
+                soundingKey:
+                  keyInfo?.soundingKey ?? label?.key ?? tCommon('labels.notAvailable'),
                 shapeKey: keyInfo?.shapeKey,
                 transpose,
                 capo,
@@ -81,7 +91,7 @@ export default function ServicePrintPage() {
           })}
         </ol>
       ) : (
-        <div>No items</div>
+        <div>{t('plan.noItems')}</div>
       )}
     </div>
   );

--- a/apps/web/src/pages/services/ServicesPage.tsx
+++ b/apps/web/src/pages/services/ServicesPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useEffect } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import {
   useServicesList,
   useCreateService,
@@ -32,6 +33,8 @@ function Modal({
 }
 
 export default function ServicesPage() {
+  const { t } = useTranslation('services');
+  const { t: tCommon } = useTranslation('common');
   const [searchParams, setSearchParams] = useSearchParams();
   const queryParam = searchParams.get('query') ?? '';
   const fromParam = searchParams.get('from') ?? '';
@@ -94,12 +97,12 @@ export default function ServicesPage() {
 
   return (
     <div className="p-4">
-      <h1 className="text-xl font-semibold mb-4">Services</h1>
+      <h1 className="text-xl font-semibold mb-4">{t('page.title')}</h1>
       <div className="flex flex-wrap items-end gap-2 mb-4">
         <input
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search..."
+          placeholder={t('list.searchPlaceholder')}
           className="border p-2 rounded w-full max-w-sm"
         />
         <input
@@ -118,19 +121,19 @@ export default function ServicesPage() {
           onClick={() => setCreating(true)}
           className="px-4 py-2 bg-blue-500 text-white rounded"
         >
-          New Service
+          {t('actions.new')}
         </button>
       </div>
-      {isLoading && <div>Loading…</div>}
-      {isError && <div>Failed to load</div>}
+      {isLoading && <div>{tCommon('status.loading')}</div>}
+      {isError && <div>{tCommon('status.loadFailed')}</div>}
       {!isLoading && services.length > 0 ? (
         <div className="mt-4">
           <table className="w-full border">
             <thead>
               <tr className="bg-gray-50">
-                <th className="text-left p-2">Starts At</th>
-                <th className="text-left p-2">Location</th>
-                <th className="p-2 text-right">Actions</th>
+                <th className="text-left p-2">{t('table.startsAt')}</th>
+                <th className="text-left p-2">{t('table.location')}</th>
+                <th className="p-2 text-right">{tCommon('table.actions')}</th>
               </tr>
             </thead>
             <tbody>
@@ -144,19 +147,19 @@ export default function ServicesPage() {
                         to={s.id ?? ''}
                         className="px-2 py-1 text-sm bg-green-500 text-white rounded"
                       >
-                        Open plan
+                        {t('actions.openPlan')}
                       </Link>
                       <button
                         className="px-2 py-1 text-sm bg-gray-200 rounded"
                         onClick={() => setEditing(s)}
                       >
-                        Edit
+                        {tCommon('actions.edit')}
                       </button>
                       <button
                         className="px-2 py-1 text-sm bg-red-500 text-white rounded"
                         onClick={() => deleteMut.mutate(s.id!)}
                       >
-                        Delete
+                        {tCommon('actions.delete')}
                       </button>
                     </div>
                   </td>
@@ -170,10 +173,13 @@ export default function ServicesPage() {
               disabled={pageParam === 0}
               onClick={() => goToPage(Math.max(0, pageParam - 1))}
             >
-              Previous
+              {tCommon('pagination.previous')}
             </button>
             <span>
-              Page {(data?.number ?? 0) + 1} of {data?.totalPages ?? 1}
+              {tCommon('pagination.pageOf', {
+                page: (data?.number ?? 0) + 1,
+                total: data?.totalPages ?? 1,
+              })}
             </span>
             <button
               className="px-3 py-1 border rounded disabled:opacity-50"
@@ -184,16 +190,16 @@ export default function ServicesPage() {
               }
               onClick={() => goToPage(pageParam + 1)}
             >
-              Next
+              {tCommon('pagination.next')}
             </button>
           </div>
         </div>
       ) : (
-        !isLoading && <div>No services found</div>
+        !isLoading && <div>{t('list.empty')}</div>
       )}
 
       <Modal open={creating} onClose={() => setCreating(false)}>
-        <h2 className="text-lg font-semibold mb-2">New Service</h2>
+        <h2 className="text-lg font-semibold mb-2">{t('modals.createTitle')}</h2>
         <ServiceForm
           onSubmit={handleCreate}
           onCancel={() => setCreating(false)}
@@ -201,7 +207,7 @@ export default function ServicesPage() {
       </Modal>
 
       <Modal open={!!editing} onClose={() => setEditing(null)}>
-        <h2 className="text-lg font-semibold mb-2">Edit Service</h2>
+        <h2 className="text-lg font-semibold mb-2">{t('modals.editTitle')}</h2>
         {editing && (
           <ServiceForm
             defaultValues={{

--- a/apps/web/src/pages/sets/SongSetsPage.tsx
+++ b/apps/web/src/pages/sets/SongSetsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import {
   useSongSetsList,
   useCreateSet,
@@ -38,6 +39,8 @@ function Modal({
 const PAGE_SIZE = 20;
 
 export default function SongSetsPage() {
+  const { t } = useTranslation('songSets');
+  const { t: tCommon } = useTranslation('common');
   const [searchParams, setSearchParams] = useSearchParams();
   const queryParam = searchParams.get('query') ?? '';
   const rawPage = Number(searchParams.get('page') ?? '0');
@@ -101,7 +104,7 @@ export default function SongSetsPage() {
   };
 
   const handleDelete = (id: string) => {
-    if (window.confirm('Are you sure you want to delete this set?')) {
+    if (window.confirm(t('confirm.delete'))) {
       deleteMut.mutate(id);
     }
   };
@@ -117,24 +120,24 @@ export default function SongSetsPage() {
 
   return (
     <div className="p-4">
-      <h1 className="text-xl font-semibold mb-4">Song Sets</h1>
+      <h1 className="text-xl font-semibold mb-4">{t('page.title')}</h1>
       <div className="flex items-center gap-2 mb-4">
         <input
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search by name..."
+          placeholder={t('list.searchPlaceholder')}
           className="border p-2 rounded w-full max-w-sm"
         />
         <button
           onClick={() => setCreating(true)}
           className="px-4 py-2 bg-blue-500 text-white rounded"
         >
-          New Set
+          {t('actions.new')}
         </button>
       </div>
 
-      {isLoading && <div>Loading…</div>}
-      {isError && <div>Failed to load song sets.</div>}
+      {isLoading && <div>{tCommon('status.loading')}</div>}
+      {isError && <div>{t('status.loadFailed')}</div>}
 
       {!isLoading && data ? (
         <div className="mt-4">
@@ -143,9 +146,9 @@ export default function SongSetsPage() {
               <table className="w-full border">
                 <thead>
                   <tr className="bg-gray-50">
-                    <th className="text-left p-2">Name</th>
-                    <th className="text-left p-2">Items</th>
-                    <th className="p-2 text-right">Actions</th>
+                    <th className="text-left p-2">{t('table.name')}</th>
+                    <th className="text-left p-2">{t('table.items')}</th>
+                    <th className="p-2 text-right">{tCommon('table.actions')}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -166,19 +169,19 @@ export default function SongSetsPage() {
                               to={setId}
                               className="px-2 py-1 text-sm bg-gray-100 rounded hover:bg-gray-200"
                             >
-                              Open
+                              {tCommon('actions.open')}
                             </Link>
                             <button
                               className="px-2 py-1 text-sm bg-gray-200 rounded"
                               onClick={() => setEditing({ id: setId, name: set.name ?? '' })}
                             >
-                              Edit
+                              {tCommon('actions.edit')}
                             </button>
                             <button
                               className="px-2 py-1 text-sm bg-red-500 text-white rounded"
                               onClick={() => handleDelete(setId)}
                             >
-                              Delete
+                              {tCommon('actions.delete')}
                             </button>
                           </div>
                         </td>
@@ -193,10 +196,13 @@ export default function SongSetsPage() {
                   disabled={pageParam === 0}
                   onClick={() => goToPage(pageParam - 1)}
                 >
-                  Previous
+                  {tCommon('pagination.previous')}
                 </button>
                 <span>
-                  Page {(data.number ?? pageParam) + 1} of {data.totalPages ?? 1}
+                  {tCommon('pagination.pageOf', {
+                    page: (data.number ?? pageParam) + 1,
+                    total: data.totalPages ?? 1,
+                  })}
                 </span>
                 <button
                   className="px-3 py-1 border rounded disabled:opacity-50"
@@ -207,23 +213,23 @@ export default function SongSetsPage() {
                   }
                   onClick={() => goToPage(pageParam + 1)}
                 >
-                  Next
+                  {tCommon('pagination.next')}
                 </button>
               </div>
             </>
           ) : (
-            <div>No song sets found.</div>
+            <div>{t('list.empty')}</div>
           )}
         </div>
       ) : null}
 
       <Modal open={creating} onClose={() => setCreating(false)}>
-        <h2 className="text-lg font-semibold mb-2">New Set</h2>
+        <h2 className="text-lg font-semibold mb-2">{t('modals.createTitle')}</h2>
         <SetForm onSubmit={handleCreate} onCancel={() => setCreating(false)} />
       </Modal>
 
       <Modal open={!!editing} onClose={() => setEditing(null)}>
-        <h2 className="text-lg font-semibold mb-2">Edit Set</h2>
+        <h2 className="text-lg font-semibold mb-2">{t('modals.editTitle')}</h2>
         {editing && (
           <SetForm
             defaultValues={{ name: editing.name }}

--- a/apps/web/src/pages/songs/SongDetailPage.tsx
+++ b/apps/web/src/pages/songs/SongDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import type { components } from '../../api/types';
 import {
   useSong,
@@ -43,6 +44,9 @@ type ArrangementRequest = components['schemas']['ArrangementRequest'];
 
 export default function SongDetailPage() {
   const { id } = useParams();
+  const { t } = useTranslation('songs');
+  const { t: tArrangements } = useTranslation('arrangements');
+  const { t: tCommon } = useTranslation('common');
   const { data: song, isLoading, isError } = useSong(id);
   const { data: arrangements } = useArrangements(id);
 
@@ -55,8 +59,8 @@ export default function SongDetailPage() {
   const [creatingArr, setCreatingArr] = useState(false);
   const [editingArr, setEditingArr] = useState<Arrangement | null>(null);
 
-  if (isLoading) return <div className="p-4">Loading…</div>;
-  if (isError || !song) return <div className="p-4">Failed to load</div>;
+  if (isLoading) return <div className="p-4">{tCommon('status.loading')}</div>;
+  if (isError || !song) return <div className="p-4">{tCommon('status.loadFailed')}</div>;
 
   const handleSongUpdate = (vals: SongRequest) => {
     updateSongMut.mutate({ id: id!, body: vals }, { onSuccess: () => setEditingSong(false) });
@@ -85,34 +89,48 @@ export default function SongDetailPage() {
           className="px-2 py-1 text-sm bg-gray-200 rounded"
           onClick={() => setEditingSong(true)}
         >
-          Edit
+          {tCommon('actions.edit')}
         </button>
       </div>
       <div className="mb-6 space-y-1">
-        {song.author && <div>Author: {song.author}</div>}
-        {song.ccli && <div>CCLI: {song.ccli}</div>}
-        {song.defaultKey && <div>Default Key: {song.defaultKey}</div>}
+        {song.author && (
+          <div>
+            {t('detail.author')}: {song.author}
+          </div>
+        )}
+        {song.ccli && (
+          <div>
+            {t('detail.ccli')}: {song.ccli}
+          </div>
+        )}
+        {song.defaultKey && (
+          <div>
+            {t('detail.defaultKey')}: {song.defaultKey}
+          </div>
+        )}
         {song.tags && song.tags.length > 0 && (
-          <div>Tags: {song.tags.join(', ')}</div>
+          <div>
+            {t('detail.tags')}: {song.tags.join(', ')}
+          </div>
         )}
       </div>
       <div className="flex items-center justify-between mb-2">
-        <h2 className="text-lg font-semibold">Arrangements</h2>
+        <h2 className="text-lg font-semibold">{tArrangements('page.title')}</h2>
         <button
           className="px-2 py-1 text-sm bg-blue-500 text-white rounded"
           onClick={() => setCreatingArr(true)}
         >
-          New Arrangement
+          {tArrangements('actions.new')}
         </button>
       </div>
       {arrangements && arrangements.length > 0 ? (
         <table className="w-full border">
           <thead>
             <tr className="bg-gray-50">
-              <th className="text-left p-2">Key</th>
-              <th className="text-left p-2">BPM</th>
-              <th className="text-left p-2">Meter</th>
-              <th className="p-2 text-right">Actions</th>
+              <th className="text-left p-2">{tArrangements('table.key')}</th>
+              <th className="text-left p-2">{tArrangements('table.bpm')}</th>
+              <th className="text-left p-2">{tArrangements('table.meter')}</th>
+              <th className="p-2 text-right">{tCommon('table.actions')}</th>
             </tr>
           </thead>
           <tbody>
@@ -127,13 +145,13 @@ export default function SongDetailPage() {
                       className="px-2 py-1 text-sm bg-gray-200 rounded"
                       onClick={() => setEditingArr(a)}
                     >
-                      Edit
+                      {tCommon('actions.edit')}
                     </button>
                     <button
                       className="px-2 py-1 text-sm bg-red-500 text-white rounded"
                       onClick={() => a.id && handleDeleteArr(a.id)}
                     >
-                      Delete
+                      {tCommon('actions.delete')}
                     </button>
                   </div>
                 </td>
@@ -142,10 +160,10 @@ export default function SongDetailPage() {
           </tbody>
         </table>
       ) : (
-        <div>No arrangements</div>
+        <div>{tArrangements('list.empty')}</div>
       )}
       <Modal open={editingSong} onClose={() => setEditingSong(false)}>
-        <h2 className="text-lg font-semibold mb-2">Edit Song</h2>
+        <h2 className="text-lg font-semibold mb-2">{t('modals.editTitle')}</h2>
         <SongForm
           defaultValues={{
             title: song.title || '',
@@ -159,14 +177,14 @@ export default function SongDetailPage() {
         />
       </Modal>
       <Modal open={creatingArr} onClose={() => setCreatingArr(false)}>
-        <h2 className="text-lg font-semibold mb-2">New Arrangement</h2>
+        <h2 className="text-lg font-semibold mb-2">{tArrangements('modals.createTitle')}</h2>
         <ArrangementForm
           onSubmit={handleCreateArr}
           onCancel={() => setCreatingArr(false)}
         />
       </Modal>
       <Modal open={!!editingArr} onClose={() => setEditingArr(null)}>
-        <h2 className="text-lg font-semibold mb-2">Edit Arrangement</h2>
+        <h2 className="text-lg font-semibold mb-2">{tArrangements('modals.editTitle')}</h2>
         {editingArr && (
           <ArrangementForm
             defaultValues={{

--- a/apps/web/src/pages/songs/SongsPage.tsx
+++ b/apps/web/src/pages/songs/SongsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import type { components } from '../../api/types';
 import {
   useSongsList,
@@ -38,6 +39,8 @@ type Song = components['schemas']['SongResponse'];
 type SongRequest = components['schemas']['SongRequest'];
 
 export default function SongsPage() {
+  const { t } = useTranslation('songs');
+  const { t: tCommon } = useTranslation('common');
   const [searchParams, setSearchParams] = useSearchParams();
   const titleParam = searchParams.get('title') ?? '';
   const tagParam = searchParams.get('tag') ?? '';
@@ -100,19 +103,19 @@ export default function SongsPage() {
 
   return (
     <div className="p-4">
-      <h1 className="text-xl font-semibold mb-4">Songs</h1>
+      <h1 className="text-xl font-semibold mb-4">{t('page.title')}</h1>
       <div className="flex items-center gap-2 mb-4">
         <input
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search by title..."
+          placeholder={t('list.searchPlaceholder')}
           className="border p-2 rounded w-full max-w-sm"
         />
         <button
           onClick={() => setCreating(true)}
           className="px-4 py-2 bg-blue-500 text-white rounded"
         >
-          New Song
+          {t('actions.new')}
         </button>
       </div>
       {tags.length > 0 && (
@@ -136,8 +139,8 @@ export default function SongsPage() {
           ))}
         </div>
       )}
-      {isLoading && <div>Loading…</div>}
-      {isError && <div>Failed to load</div>}
+      {isLoading && <div>{tCommon('status.loading')}</div>}
+      {isError && <div>{tCommon('status.loadFailed')}</div>}
       {!isLoading && data ? (
         <div className="mt-4">
           {data.content && data.content.length > 0 ? (
@@ -145,10 +148,10 @@ export default function SongsPage() {
               <table className="w-full border">
                 <thead>
                   <tr className="bg-gray-50">
-                    <th className="text-left p-2">Title</th>
-                    <th className="text-left p-2">Default Key</th>
-                    <th className="text-left p-2">Tags</th>
-                    <th className="p-2 text-right">Actions</th>
+                    <th className="text-left p-2">{t('fields.title')}</th>
+                    <th className="text-left p-2">{t('fields.defaultKey')}</th>
+                    <th className="text-left p-2">{t('fields.tags')}</th>
+                    <th className="p-2 text-right">{tCommon('table.actions')}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -170,13 +173,13 @@ export default function SongsPage() {
                             className="px-2 py-1 text-sm bg-gray-200 rounded"
                             onClick={() => setEditing(s)}
                           >
-                            Edit
+                            {tCommon('actions.edit')}
                           </button>
                           <button
                             className="px-2 py-1 text-sm bg-red-500 text-white rounded"
                             onClick={() => s.id && deleteMut.mutate(s.id)}
                           >
-                            Delete
+                            {tCommon('actions.delete')}
                           </button>
                         </div>
                       </td>
@@ -190,10 +193,13 @@ export default function SongsPage() {
                   disabled={pageParam === 0}
                   onClick={() => goToPage(Math.max(0, pageParam - 1))}
                 >
-                  Previous
+                  {tCommon('pagination.previous')}
                 </button>
                 <span>
-                  Page {(data.number ?? 0) + 1} of {data.totalPages ?? 1}
+                  {tCommon('pagination.pageOf', {
+                    page: (data.number ?? 0) + 1,
+                    total: data.totalPages ?? 1,
+                  })}
                 </span>
                 <button
                   className="px-3 py-1 border rounded disabled:opacity-50"
@@ -204,21 +210,21 @@ export default function SongsPage() {
                   }
                   onClick={() => goToPage(pageParam + 1)}
                 >
-                  Next
+                  {tCommon('pagination.next')}
                 </button>
               </div>
             </>
           ) : (
-            <div>No songs found</div>
+            <div>{t('list.empty')}</div>
           )}
         </div>
       ) : null}
       <Modal open={creating} onClose={() => setCreating(false)}>
-        <h2 className="text-lg font-semibold mb-2">New Song</h2>
+        <h2 className="text-lg font-semibold mb-2">{t('modals.createTitle')}</h2>
         <SongForm onSubmit={handleCreate} onCancel={() => setCreating(false)} />
       </Modal>
       <Modal open={!!editing} onClose={() => setEditing(null)}>
-        <h2 className="text-lg font-semibold mb-2">Edit Song</h2>
+        <h2 className="text-lg font-semibold mb-2">{t('modals.editTitle')}</h2>
         {editing && (
           <SongForm
             defaultValues={{


### PR DESCRIPTION
## Summary
- convert member forms and list views to use namespace-based translations
- localize songs, arrangements, song sets, and service management screens including plan builder and print views
- expand English and Spanish locale resources with the keys referenced by the updated components

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68ccca115ecc8330914ead3166681d5e