### PR TITLE
feat(web): add pluralization and interpolation examples

### DIFF
--- a/apps/web/src/locales/en/members.json
+++ b/apps/web/src/locales/en/members.json
@@ -1,4 +1,6 @@
 {
+  "count_one": "{{count}} member",
+  "count_other": "{{count}} members",
   "page": {
     "title": "Members",
     "empty": "No members have been added yet."

--- a/apps/web/src/locales/en/songs.json
+++ b/apps/web/src/locales/en/songs.json
@@ -35,6 +35,7 @@
     "defaultKey": "Default Key",
     "tags": "Tags"
   },
+  "lastUpdated": "Last updated {{date}}",
   "pickers": {
     "searchPlaceholder": "Search songs..."
   }

--- a/apps/web/src/locales/es/members.json
+++ b/apps/web/src/locales/es/members.json
@@ -1,4 +1,6 @@
 {
+  "count_one": "{{count}} miembro",
+  "count_other": "{{count}} miembros",
   "page": {
     "title": "Miembros",
     "empty": "Aún no se han agregado miembros."

--- a/apps/web/src/locales/es/songs.json
+++ b/apps/web/src/locales/es/songs.json
@@ -35,6 +35,7 @@
     "defaultKey": "Tonalidad predeterminada",
     "tags": "Etiquetas"
   },
+  "lastUpdated": "Última actualización {{date}}",
   "pickers": {
     "searchPlaceholder": "Buscar canciones..."
   }

--- a/apps/web/src/pages/members/MembersPage.tsx
+++ b/apps/web/src/pages/members/MembersPage.tsx
@@ -89,9 +89,21 @@ export default function MembersPage() {
     setSearchParams(params);
   };
 
+  const memberCount = data?.totalElements ?? data?.content?.length ?? 0;
+  const shouldShowCount = data?.totalElements !== undefined || data?.content !== undefined;
+
   return (
     <div className="p-4">
-      <h1 className="text-xl font-semibold mb-4">{t('page.title')}</h1>
+      <div className="mb-4">
+        <div className="flex items-baseline justify-between gap-2">
+          <h1 className="text-xl font-semibold">{t('page.title')}</h1>
+          {shouldShowCount ? (
+            <span className="text-sm text-gray-600">
+              {t('count', { count: memberCount })}
+            </span>
+          ) : null}
+        </div>
+      </div>
       <div className="flex items-center gap-2 mb-4">
         <input
           value={search}

--- a/apps/web/src/pages/songs/SongDetailPage.tsx
+++ b/apps/web/src/pages/songs/SongDetailPage.tsx
@@ -41,10 +41,13 @@ function Modal({
 type SongRequest = components['schemas']['SongRequest'];
 type Arrangement = components['schemas']['ArrangementResponse'];
 type ArrangementRequest = components['schemas']['ArrangementRequest'];
+type SongResponseWithTimestamps = components['schemas']['SongResponse'] & {
+  updatedAt?: string | null;
+};
 
 export default function SongDetailPage() {
   const { id } = useParams();
-  const { t } = useTranslation('songs');
+  const { t, i18n } = useTranslation('songs');
   const { t: tArrangements } = useTranslation('arrangements');
   const { t: tCommon } = useTranslation('common');
   const { data: song, isLoading, isError } = useSong(id);
@@ -81,6 +84,14 @@ export default function SongDetailPage() {
     deleteArrMut.mutate(arrId);
   };
 
+  const updatedAtRaw = (song as SongResponseWithTimestamps).updatedAt;
+  const formattedUpdatedAt = updatedAtRaw
+    ? new Intl.DateTimeFormat(i18n.language || undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+      }).format(new Date(updatedAtRaw))
+    : null;
+
   return (
     <div className="p-4">
       <div className="flex items-center justify-between mb-4">
@@ -111,6 +122,11 @@ export default function SongDetailPage() {
         {song.tags && song.tags.length > 0 && (
           <div>
             {t('detail.tags')}: {song.tags.join(', ')}
+          </div>
+        )}
+        {formattedUpdatedAt && (
+          <div className="text-sm text-gray-600">
+            {t('lastUpdated', { date: formattedUpdatedAt })}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- add pluralized member count strings and last updated copy in both English and Spanish locales
- surface the translated member totals with i18next pluralization on the members list
- format song update timestamps with Intl.DateTimeFormat before interpolation in the detail view

## Testing
- yarn typecheck

- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68ccd7173fe88330b76b04aefbb07eda