### PR TITLE
feat(web): localize song form fields

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,8 @@
     "typecheck": "tsc -p .",
     "lint": "eslint . --ext .ts,.tsx",
     "format": "prettier --write .",
-    "test": "vitest"
+    "test": "vitest --run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",

--- a/apps/web/src/components/__tests__/LanguageSwitcher.test.tsx
+++ b/apps/web/src/components/__tests__/LanguageSwitcher.test.tsx
@@ -15,11 +15,16 @@ vi.mock('react-router-dom', async (importOriginal) => {
   };
 });
 
-vi.mock('@/i18n', () => ({
-  SUPPORTED_LANGUAGES: ['en', 'es'],
-  LANGUAGE_STORAGE_KEY: 'i18nextLng',
-  setAppLanguage: mockSetAppLanguage,
-}));
+vi.mock('@/i18n', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/i18n')>();
+
+  return {
+    ...actual,
+    SUPPORTED_LANGUAGES: ['en', 'es'],
+    LANGUAGE_STORAGE_KEY: 'i18nextLng',
+    setAppLanguage: mockSetAppLanguage,
+  };
+});
 
 import { MemoryRouter } from 'react-router-dom';
 import { LanguageSwitcher } from '../LanguageSwitcher';

--- a/apps/web/src/features/songs/SongForm.tsx
+++ b/apps/web/src/features/songs/SongForm.tsx
@@ -14,6 +14,11 @@ const schema = z.object({
 
 export type SongFormValues = z.infer<typeof schema>;
 
+type FieldName = keyof SongFormValues;
+
+const helpTextId = (field: FieldName) => `${field}-helptext`;
+const errorMessageId = (field: FieldName) => `${field}-error`;
+
 export function SongForm({
   defaultValues,
   onSubmit,
@@ -35,6 +40,23 @@ export function SongForm({
     defaultValues,
   });
 
+  const getFieldCopy = (field: FieldName) => {
+    const label = t(`form.fields.${field}.label`);
+
+    return {
+      label,
+      placeholder: t(`form.fields.${field}.placeholder`, { defaultValue: label }),
+      helpText: t(`form.fields.${field}.helpText`, { defaultValue: '' }),
+      ariaLabel: t(`form.fields.${field}.ariaLabel`, { defaultValue: label }),
+    };
+  };
+
+  const titleField = getFieldCopy('title');
+  const ccliField = getFieldCopy('ccli');
+  const authorField = getFieldCopy('author');
+  const defaultKeyField = getFieldCopy('defaultKey');
+  const tagsField = getFieldCopy('tags');
+
   return (
     <form
       onSubmit={handleSubmit((vals) =>
@@ -52,44 +74,168 @@ export function SongForm({
     >
       <div>
         <label htmlFor="title" className="block text-sm font-medium mb-1">
-          {t('form.titleLabel')}
+          {titleField.label}
         </label>
-        <input id="title" {...register('title')} className="border p-2 rounded w-full" />
-        {errors.title && (
-          <p className="text-red-500 text-sm">
+        <input
+          id="title"
+          aria-label={titleField.ariaLabel}
+          aria-invalid={Boolean(errors.title)}
+          aria-describedby={
+            [
+              errors.title ? errorMessageId('title') : null,
+              titleField.helpText ? helpTextId('title') : null,
+            ]
+              .filter(Boolean)
+              .join(' ') || undefined
+          }
+          placeholder={titleField.placeholder}
+          {...register('title')}
+          className="border p-2 rounded w-full"
+        />
+        {titleField.helpText ? (
+          <p id={helpTextId('title')} className="text-sm text-gray-500">
+            {titleField.helpText}
+          </p>
+        ) : null}
+        {errors.title ? (
+          <p id={errorMessageId('title')} className="text-red-500 text-sm">
             {t(errors.title.message ?? '', {
               defaultValue: errors.title.message ?? '',
             })}
           </p>
-        )}
+        ) : null}
       </div>
       <div>
         <label htmlFor="ccli" className="block text-sm font-medium mb-1">
-          {t('form.ccliLabel')}
+          {ccliField.label}
         </label>
-        <input id="ccli" {...register('ccli')} className="border p-2 rounded w-full" />
+        <input
+          id="ccli"
+          aria-label={ccliField.ariaLabel}
+          aria-invalid={Boolean(errors.ccli)}
+          aria-describedby={
+            [
+              errors.ccli ? errorMessageId('ccli') : null,
+              ccliField.helpText ? helpTextId('ccli') : null,
+            ]
+              .filter(Boolean)
+              .join(' ') || undefined
+          }
+          placeholder={ccliField.placeholder}
+          {...register('ccli')}
+          className="border p-2 rounded w-full"
+        />
+        {ccliField.helpText ? (
+          <p id={helpTextId('ccli')} className="text-sm text-gray-500">
+            {ccliField.helpText}
+          </p>
+        ) : null}
+        {errors.ccli ? (
+          <p id={errorMessageId('ccli')} className="text-red-500 text-sm">
+            {t(errors.ccli.message ?? '', {
+              defaultValue: errors.ccli.message ?? '',
+            })}
+          </p>
+        ) : null}
       </div>
       <div>
         <label htmlFor="author" className="block text-sm font-medium mb-1">
-          {t('form.authorLabel')}
+          {authorField.label}
         </label>
-        <input id="author" {...register('author')} className="border p-2 rounded w-full" />
+        <input
+          id="author"
+          aria-label={authorField.ariaLabel}
+          aria-invalid={Boolean(errors.author)}
+          aria-describedby={
+            [
+              errors.author ? errorMessageId('author') : null,
+              authorField.helpText ? helpTextId('author') : null,
+            ]
+              .filter(Boolean)
+              .join(' ') || undefined
+          }
+          placeholder={authorField.placeholder}
+          {...register('author')}
+          className="border p-2 rounded w-full"
+        />
+        {authorField.helpText ? (
+          <p id={helpTextId('author')} className="text-sm text-gray-500">
+            {authorField.helpText}
+          </p>
+        ) : null}
+        {errors.author ? (
+          <p id={errorMessageId('author')} className="text-red-500 text-sm">
+            {t(errors.author.message ?? '', {
+              defaultValue: errors.author.message ?? '',
+            })}
+          </p>
+        ) : null}
       </div>
       <div>
         <label htmlFor="defaultKey" className="block text-sm font-medium mb-1">
-          {t('form.defaultKeyLabel')}
+          {defaultKeyField.label}
         </label>
         <input
           id="defaultKey"
+          aria-label={defaultKeyField.ariaLabel}
+          aria-invalid={Boolean(errors.defaultKey)}
+          aria-describedby={
+            [
+              errors.defaultKey ? errorMessageId('defaultKey') : null,
+              defaultKeyField.helpText ? helpTextId('defaultKey') : null,
+            ]
+              .filter(Boolean)
+              .join(' ') || undefined
+          }
+          placeholder={defaultKeyField.placeholder}
           {...register('defaultKey')}
           className="border p-2 rounded w-full"
         />
+        {defaultKeyField.helpText ? (
+          <p id={helpTextId('defaultKey')} className="text-sm text-gray-500">
+            {defaultKeyField.helpText}
+          </p>
+        ) : null}
+        {errors.defaultKey ? (
+          <p id={errorMessageId('defaultKey')} className="text-red-500 text-sm">
+            {t(errors.defaultKey.message ?? '', {
+              defaultValue: errors.defaultKey.message ?? '',
+            })}
+          </p>
+        ) : null}
       </div>
       <div>
         <label htmlFor="tags" className="block text-sm font-medium mb-1">
-          {t('form.tagsLabel')}
+          {tagsField.label}
         </label>
-        <input id="tags" {...register('tags')} className="border p-2 rounded w-full" />
+        <input
+          id="tags"
+          aria-label={tagsField.ariaLabel}
+          aria-invalid={Boolean(errors.tags)}
+          aria-describedby={
+            [
+              errors.tags ? errorMessageId('tags') : null,
+              tagsField.helpText ? helpTextId('tags') : null,
+            ]
+              .filter(Boolean)
+              .join(' ') || undefined
+          }
+          placeholder={tagsField.placeholder}
+          {...register('tags')}
+          className="border p-2 rounded w-full"
+        />
+        {tagsField.helpText ? (
+          <p id={helpTextId('tags')} className="text-sm text-gray-500">
+            {tagsField.helpText}
+          </p>
+        ) : null}
+        {errors.tags ? (
+          <p id={errorMessageId('tags')} className="text-red-500 text-sm">
+            {t(errors.tags.message ?? '', {
+              defaultValue: errors.tags.message ?? '',
+            })}
+          </p>
+        ) : null}
       </div>
       <div className="flex gap-2">
         <button type="submit" className="px-4 py-2 bg-blue-500 text-white rounded">

--- a/apps/web/src/features/songs/__tests__/SongForm.test.tsx
+++ b/apps/web/src/features/songs/__tests__/SongForm.test.tsx
@@ -1,0 +1,45 @@
+import { act, render, screen } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+
+import i18n from '@/i18n';
+
+import { SongForm } from '../SongForm';
+
+describe('SongForm', () => {
+  beforeEach(async () => {
+    window.localStorage.removeItem('i18nextLng');
+
+    await act(async () => {
+      await i18n.changeLanguage('en');
+    });
+  });
+
+  it('updates label text when the language changes', async () => {
+    const onSubmit = vi.fn();
+
+    const { rerender } = render(
+      <I18nextProvider i18n={i18n}>
+        <SongForm onSubmit={onSubmit} />
+      </I18nextProvider>,
+    );
+
+    expect(screen.getByLabelText('Title')).toBeInTheDocument();
+    expect(screen.getByText('Title', { selector: 'label' })).toBeInTheDocument();
+
+    await act(async () => {
+      await i18n.changeLanguage('es');
+    });
+
+    rerender(
+      <I18nextProvider i18n={i18n}>
+        <SongForm onSubmit={onSubmit} />
+      </I18nextProvider>,
+    );
+
+    await screen.findByLabelText('Título');
+
+    expect(screen.getByLabelText('Título')).toBeInTheDocument();
+    expect(screen.getByText('Título', { selector: 'label' })).toBeInTheDocument();
+    expect(screen.queryByText('Title', { selector: 'label' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -41,7 +41,7 @@
     "select": "Select language",
     "labels": {
       "en": "English",
-      "es": "Spanish"
+      "es": "Español"
     }
   }
 }

--- a/apps/web/src/locales/en/songs.json
+++ b/apps/web/src/locales/en/songs.json
@@ -9,11 +9,38 @@
     "tags": "Tags"
   },
   "form": {
-    "titleLabel": "Title",
-    "ccliLabel": "CCLI",
-    "authorLabel": "Author",
-    "defaultKeyLabel": "Default Key",
-    "tagsLabel": "Tags (comma separated)"
+    "fields": {
+      "title": {
+        "label": "Title",
+        "placeholder": "How Great Is Our God",
+        "helpText": "This title appears on service plans and song lists.",
+        "ariaLabel": "Title"
+      },
+      "ccli": {
+        "label": "CCLI",
+        "placeholder": "Enter the CCLI number",
+        "helpText": "Use the CCLI number for reporting if available.",
+        "ariaLabel": "CCLI"
+      },
+      "author": {
+        "label": "Author",
+        "placeholder": "Chris Tomlin",
+        "helpText": "List the primary songwriter or composer.",
+        "ariaLabel": "Author"
+      },
+      "defaultKey": {
+        "label": "Default Key",
+        "placeholder": "E",
+        "helpText": "Set the key most often used for this song.",
+        "ariaLabel": "Default Key"
+      },
+      "tags": {
+        "label": "Tags",
+        "placeholder": "worship, upbeat",
+        "helpText": "Separate tags with commas to make searching easier.",
+        "ariaLabel": "Tags"
+      }
+    }
   },
   "actions": {
     "new": "New Song"

--- a/apps/web/src/locales/es/songs.json
+++ b/apps/web/src/locales/es/songs.json
@@ -9,11 +9,38 @@
     "tags": "Etiquetas"
   },
   "form": {
-    "titleLabel": "Título",
-    "ccliLabel": "CCLI",
-    "authorLabel": "Autor",
-    "defaultKeyLabel": "Tonalidad predeterminada",
-    "tagsLabel": "Etiquetas (separadas por comas)"
+    "fields": {
+      "title": {
+        "label": "Título",
+        "placeholder": "Cuán grande es Dios",
+        "helpText": "Este título aparece en los planes de servicio y listas de canciones.",
+        "ariaLabel": "Título"
+      },
+      "ccli": {
+        "label": "CCLI",
+        "placeholder": "Ingresa el número de CCLI",
+        "helpText": "Usa el número CCLI para los reportes si está disponible.",
+        "ariaLabel": "CCLI"
+      },
+      "author": {
+        "label": "Autor",
+        "placeholder": "Chris Tomlin",
+        "helpText": "Indica al compositor o autor principal.",
+        "ariaLabel": "Autor"
+      },
+      "defaultKey": {
+        "label": "Tonalidad predeterminada",
+        "placeholder": "Mi",
+        "helpText": "Establece la tonalidad que se usa con más frecuencia para esta canción.",
+        "ariaLabel": "Tonalidad predeterminada"
+      },
+      "tags": {
+        "label": "Etiquetas",
+        "placeholder": "adoración, animada",
+        "helpText": "Separa las etiquetas con comas para facilitar la búsqueda.",
+        "ariaLabel": "Etiquetas"
+      }
+    }
   },
   "actions": {
     "new": "Nueva canción"

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -6,7 +6,12 @@
       "@/*": ["src/*"]
     },
     "noEmit": true,
-    "types": ["vitest/globals", "vitest/importMeta", "node"]
+    "types": [
+      "vitest/globals",
+      "vitest/importMeta",
+      "node",
+      "@testing-library/jest-dom"
+    ]
   },
   "include": ["src", "vitest.config.ts", "setupTests.ts"],
   "references": [


### PR DESCRIPTION
## Summary
- pull SongForm field metadata (labels, placeholders, help text, aria strings) from translations while keeping form IDs stable
- extend the songs locale files with English and Spanish copy for the new form metadata
- add a SongForm i18n test and configure Vitest to pick up jest-dom matchers

## Testing
- yarn test SongForm --run
- yarn build
- yarn typecheck

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [x] Web: Loading/error states; basic a11y; responsive layout
- [x] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)

------
https://chatgpt.com/codex/tasks/task_e_68ccdf6b1ea08330ae9b3e858e6abd9d