### PR TITLE
feat(web): add Accept-Language axios interceptor

### DIFF
--- a/apps/web/src/api/axios.test.ts
+++ b/apps/web/src/api/axios.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { AxiosHeaders, type AxiosAdapter } from 'axios';
+
+import i18n from '@/i18n';
+import httpClient, { createAxiosInstance } from './axios';
+
+describe('axios Accept-Language interceptor', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('injects the current language into the Accept-Language header', async () => {
+    await i18n.changeLanguage('es');
+
+    const adapter = vi.fn<Parameters<AxiosAdapter>, ReturnType<AxiosAdapter>>(async (config) => ({
+      data: null,
+      status: 200,
+      statusText: 'OK',
+      headers: AxiosHeaders.from({}),
+      config,
+    }));
+
+    await httpClient.get('/test', { adapter });
+
+    const requestConfig = adapter.mock.calls[0][0];
+    const headers = AxiosHeaders.from(requestConfig.headers ?? {});
+
+    expect(headers.get('Accept-Language')).toBe('es');
+  });
+
+  it('applies the interceptor to new axios instances', async () => {
+    const instance = createAxiosInstance();
+
+    await i18n.changeLanguage('es');
+
+    const adapter = vi.fn<Parameters<AxiosAdapter>, ReturnType<AxiosAdapter>>(async (config) => ({
+      data: null,
+      status: 200,
+      statusText: 'OK',
+      headers: AxiosHeaders.from({}),
+      config,
+    }));
+
+    await instance.get('/other', { adapter });
+
+    const requestConfig = adapter.mock.calls[0][0];
+    const headers = AxiosHeaders.from(requestConfig.headers ?? {});
+
+    expect(headers.get('Accept-Language')).toBe('es');
+  });
+});

--- a/apps/web/src/api/axios.ts
+++ b/apps/web/src/api/axios.ts
@@ -1,0 +1,45 @@
+import axios, {
+  AxiosHeaders,
+  type AxiosInstance,
+  type CreateAxiosDefaults,
+  type InternalAxiosRequestConfig,
+} from 'axios';
+
+import { getAppLanguage } from '@/i18n';
+
+const withAcceptLanguage = (
+  config: InternalAxiosRequestConfig,
+  language: string,
+): InternalAxiosRequestConfig => {
+  const headers = AxiosHeaders.from(config.headers ?? {});
+  headers.set('Accept-Language', language);
+  config.headers = headers;
+  return config;
+};
+
+const injectAcceptLanguage = (
+  config: InternalAxiosRequestConfig,
+): InternalAxiosRequestConfig => {
+  const language = getAppLanguage();
+  return withAcceptLanguage(config, language);
+};
+
+export const attachAcceptLanguageInterceptor = (
+  instance: AxiosInstance,
+): AxiosInstance => {
+  instance.interceptors.request.use(injectAcceptLanguage);
+  return instance;
+};
+
+attachAcceptLanguageInterceptor(axios);
+
+export const createAxiosInstance = (
+  config?: CreateAxiosDefaults,
+): AxiosInstance => {
+  const instance = axios.create(config);
+  return attachAcceptLanguageInterceptor(instance);
+};
+
+export const httpClient = createAxiosInstance();
+
+export default httpClient;

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -1,6 +1,6 @@
-import axios from 'axios';
+import { createAxiosInstance } from './axios';
 
-export const apiClient = axios.create({
+export const apiClient = createAxiosInstance({
   baseURL: '/api/v1',
   withCredentials: false,
   headers: {
@@ -8,9 +8,6 @@ export const apiClient = axios.create({
     Accept: 'application/json',
   },
 });
-
-// request interceptor (placeholder for auth headers later)
-apiClient.interceptors.request.use((config) => config);
 
 // response interceptor with minimal dev logging
 apiClient.interceptors.response.use(


### PR DESCRIPTION
## Summary
- add a shared axios helper that injects the current i18n language into the `Accept-Language` header on every request
- update the API client to build on the shared axios factory
- add an integration test verifying the header is attached for existing and new axios instances

## Testing
- `yarn test src/api/axios.test.ts`

- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68cce4d63764833097cf95d510a69e59