### PR TITLE
feat(web): include language in query keys

### DIFF
--- a/apps/web/src/components/pickers/ArrangementPicker.tsx
+++ b/apps/web/src/components/pickers/ArrangementPicker.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { listArrangements } from '@/api/songs';
 import type { components } from '@/api/types';
+import { withLangKey } from '@/lib/queryClient';
 
 interface Props {
   songId: string | undefined;
@@ -20,7 +21,7 @@ export function ArrangementPicker({ songId, value, onChange }: Props) {
   const [open, setOpen] = useState(false);
   const [active, setActive] = useState(0);
   const { data, isLoading, isError } = useQuery({
-    queryKey: ['arrangements', songId],
+    queryKey: withLangKey(['arrangements', songId]),
     queryFn: () => listArrangements(songId!),
     enabled: !!songId,
   });

--- a/apps/web/src/components/pickers/SongPicker.tsx
+++ b/apps/web/src/components/pickers/SongPicker.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { listSongs } from '@/api/songs';
 import type { components } from '@/api/types';
+import { withLangKey } from '@/lib/queryClient';
 
 function useDebounce<T>(value: T, delay: number) {
   const [debounced, setDebounced] = useState(value);
@@ -25,7 +26,7 @@ export function SongPicker({ value, onChange, placeholder }: Props) {
   const debounced = useDebounce(search, 300);
 
   const { data, isLoading, isError } = useQuery({
-    queryKey: ['songs', debounced],
+    queryKey: withLangKey(['songs', debounced]),
     queryFn: () => listSongs({ title: debounced, page: 0, size: 10 }),
     enabled: open,
     staleTime: 5 * 60 * 1000,

--- a/apps/web/src/features/groups/hooks.ts
+++ b/apps/web/src/features/groups/hooks.ts
@@ -10,10 +10,11 @@ import {
   removeMemberFromGroup,
   type ListGroupsParams,
 } from '../../api/groups';
+import { withLangKey } from '../../lib/queryClient';
 
 export function useGroupsList(params: ListGroupsParams | undefined) {
   return useQuery({
-    queryKey: ['groups', params],
+    queryKey: withLangKey(['groups', params]),
     queryFn: () => listGroups(params),
     placeholderData: (prev) => prev,
   });
@@ -54,7 +55,7 @@ export function useDeleteGroup() {
 
 export function useGroup(id: string) {
   return useQuery({
-    queryKey: ['group', id],
+    queryKey: withLangKey(['group', id]),
     queryFn: () => getGroup(id),
     enabled: !!id,
   });
@@ -62,7 +63,7 @@ export function useGroup(id: string) {
 
 export function useGroupMembers(id: string) {
   return useQuery({
-    queryKey: ['groupMembers', id],
+    queryKey: withLangKey(['groupMembers', id]),
     queryFn: () => listGroupMembers(id),
     enabled: !!id,
   });

--- a/apps/web/src/features/members/hooks.ts
+++ b/apps/web/src/features/members/hooks.ts
@@ -3,10 +3,11 @@ import {
   listMembers, createMember, updateMember, deleteMember,
   type ListMembersParams
 } from '../../api/members';
+import { withLangKey } from '../../lib/queryClient';
 
 export function useMembersList(params: ListMembersParams | undefined) {
   return useQuery({
-    queryKey: ['members', params],
+    queryKey: withLangKey(['members', params]),
     queryFn: () => listMembers(params),
     placeholderData: (prev) => prev,
   });

--- a/apps/web/src/features/services/hooks.ts
+++ b/apps/web/src/features/services/hooks.ts
@@ -11,10 +11,11 @@ import {
   removePlanItem,
   type ListServicesParams,
 } from '../../api/services';
+import { withLangKey } from '../../lib/queryClient';
 
 export function useServicesList(params: ListServicesParams | undefined) {
   return useQuery({
-    queryKey: ['services', params],
+    queryKey: withLangKey(['services', params]),
     queryFn: () => listServices(params),
     placeholderData: (prev) => prev,
   });
@@ -47,7 +48,7 @@ export function useDeleteService() {
 
 export function useService(id: string | undefined) {
   return useQuery({
-    queryKey: ['service', id],
+    queryKey: withLangKey(['service', id]),
     queryFn: () => getService(id!),
     enabled: !!id,
   });
@@ -55,7 +56,7 @@ export function useService(id: string | undefined) {
 
 export function usePlanItems(serviceId: string | undefined) {
   return useQuery({
-    queryKey: ['servicePlan', serviceId],
+    queryKey: withLangKey(['servicePlan', serviceId]),
     queryFn: () => listPlanItems(serviceId!),
     enabled: !!serviceId,
   });

--- a/apps/web/src/features/sets/hooks.ts
+++ b/apps/web/src/features/sets/hooks.ts
@@ -15,10 +15,11 @@ import {
   type UpdateSetItemBody,
   type ReorderSetItemsBody,
 } from '../../api/sets';
+import { withLangKey } from '../../lib/queryClient';
 
 export function useSongSetsList(params?: ListSetsParams) {
   return useQuery({
-    queryKey: ['songSets', params],
+    queryKey: withLangKey(['songSets', params]),
     queryFn: () => listSets(params),
     placeholderData: (prev) => prev,
   });
@@ -26,7 +27,7 @@ export function useSongSetsList(params?: ListSetsParams) {
 
 export function useSongSet(id: string | undefined) {
   return useQuery({
-    queryKey: ['songSet', id],
+    queryKey: withLangKey(['songSet', id]),
     queryFn: () => getSet(id!),
     enabled: !!id,
   });
@@ -76,7 +77,7 @@ export function useDeleteSet() {
 
 export function useSetItems(setId: string | undefined) {
   return useQuery({
-    queryKey: ['songSetItems', setId],
+    queryKey: withLangKey(['songSetItems', setId]),
     queryFn: () => listSetItems(setId!),
     enabled: !!setId,
   });

--- a/apps/web/src/features/songs/hooks.ts
+++ b/apps/web/src/features/songs/hooks.ts
@@ -11,10 +11,11 @@ import {
   deleteArrangement,
   type ListSongsParams,
 } from '../../api/songs';
+import { withLangKey } from '../../lib/queryClient';
 
 export function useSongsList(params: ListSongsParams | undefined) {
   return useQuery({
-    queryKey: ['songs', params],
+    queryKey: withLangKey(['songs', params]),
     queryFn: () => listSongs(params),
     placeholderData: (prev) => prev,
   });
@@ -22,7 +23,7 @@ export function useSongsList(params: ListSongsParams | undefined) {
 
 export function useSong(id: string | undefined) {
   return useQuery({
-    queryKey: ['song', id],
+    queryKey: withLangKey(['song', id]),
     queryFn: () => getSong(id!),
     enabled: !!id,
   });
@@ -61,7 +62,7 @@ export function useDeleteSong() {
 
 export function useArrangements(songId: string | undefined) {
   return useQuery({
-    queryKey: ['songs', songId, 'arrangements'],
+    queryKey: withLangKey(['songs', songId, 'arrangements']),
     queryFn: () => listArrangements(songId!),
     enabled: !!songId,
   });

--- a/apps/web/src/hooks/useArrangementLabels.ts
+++ b/apps/web/src/hooks/useArrangementLabels.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { ensureArrangementLabels } from '@/lib/arrangements-hydrate';
 import { getArrangementLabel, type ArrangementLabel } from '@/lib/arrangements-cache';
+import { withLangKey } from '@/lib/queryClient';
 
 type ArrangementLabelMap = Record<string, ArrangementLabel | undefined>;
 
@@ -27,7 +28,7 @@ export function useArrangementLabels(ids: ArrangementIdInput) {
   }, [normalized]);
 
   return useQuery({
-    queryKey: ['arrangementLabels', ...normalized],
+    queryKey: withLangKey(['arrangementLabels', ...normalized]),
     queryFn: async () => {
       if (normalized.length === 0) {
         return {} as ArrangementLabelMap;

--- a/apps/web/src/lib/queryClient.ts
+++ b/apps/web/src/lib/queryClient.ts
@@ -1,3 +1,8 @@
 import { QueryClient } from '@tanstack/react-query';
 
+import { getAppLanguage } from '../i18n';
+
+export const withLangKey = <TKey extends readonly unknown[]>(baseKey: TKey) =>
+  [...baseKey, getAppLanguage()] as const;
+
 export const queryClient = new QueryClient();

--- a/apps/web/src/pages/services/ServiceDetailPage.tsx
+++ b/apps/web/src/pages/services/ServiceDetailPage.tsx
@@ -22,6 +22,7 @@ import ServiceForm from '../../features/services/ServiceForm';
 import { usePlanArrangementInfo } from '@/features/services/usePlanArrangementInfo';
 import { formatArrangementLine, formatKeyTransform } from '@/lib/arrangement-labels';
 import { computeKeys } from '@/lib/keys';
+import { withLangKey } from '@/lib/queryClient';
 
 function Modal({
   open,
@@ -94,12 +95,12 @@ export default function ServiceDetailPage() {
   const arrangementId = watch('arrangementId');
 
   const { data: song } = useQuery({
-    queryKey: ['song', songId],
+    queryKey: withLangKey(['song', songId]),
     queryFn: () => getSong(songId!),
     enabled: !!songId,
   });
   const { data: arrangements } = useQuery({
-    queryKey: ['arrangements', songId],
+    queryKey: withLangKey(['arrangements', songId]),
     queryFn: () => listArrangements(songId!),
     enabled: !!songId,
   });


### PR DESCRIPTION
## Summary
- add a helper to append the active language to TanStack Query keys
- update song, service, set, group, member, and picker queries to use the language-aware keys
- ensure arrangement label hydration also participates in language-specific caching

## Testing
- yarn --cwd apps/web typecheck
- yarn --cwd apps/web build

## PR Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`) (API not run; web build + typecheck completed)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68cd7d412de4833096c5ecdc724dad28