### PR TITLE
feat(web): add intl formatting utilities

### DIFF
--- a/apps/web/src/i18n/intl.ts
+++ b/apps/web/src/i18n/intl.ts
@@ -1,0 +1,24 @@
+const dateTimeOptions: Intl.DateTimeFormatOptions = {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+};
+
+const getLanguage = (lang?: string) => lang || undefined;
+
+export const formatDate = (value: Date | string | number, lang?: string): string => {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return new Intl.DateTimeFormat(getLanguage(lang), dateTimeOptions).format(date);
+};
+
+export const formatNumber = (value: number | null | undefined, lang?: string): string => {
+  if (value == null || Number.isNaN(value)) {
+    return '';
+  }
+  return new Intl.NumberFormat(getLanguage(lang)).format(value);
+};
+
+export const formatBpm = (bpm: number | null | undefined, lang?: string): string =>
+  formatNumber(bpm, lang);

--- a/apps/web/src/pages/services/ServiceDetailPage.tsx
+++ b/apps/web/src/pages/services/ServiceDetailPage.tsx
@@ -23,6 +23,7 @@ import { usePlanArrangementInfo } from '@/features/services/usePlanArrangementIn
 import { formatArrangementLine, formatKeyTransform } from '@/lib/arrangement-labels';
 import { computeKeys } from '@/lib/keys';
 import { withLangKey } from '@/lib/queryClient';
+import { formatDate } from '@/i18n/intl';
 
 function Modal({
   open,
@@ -63,7 +64,7 @@ type AddItemForm = z.infer<typeof addSchema>;
 
 export default function ServiceDetailPage() {
   const { id } = useParams();
-  const { t } = useTranslation('services');
+  const { t, i18n } = useTranslation('services');
   const { t: tCommon } = useTranslation('common');
   const { t: tSongs } = useTranslation('songs');
   const { t: tArrangements } = useTranslation('arrangements');
@@ -159,7 +160,7 @@ export default function ServiceDetailPage() {
         <div>
           <h1 className="text-xl font-semibold">
             {service.startsAt
-              ? new Date(service.startsAt).toLocaleString()
+              ? formatDate(service.startsAt, i18n.language)
               : t('fallback.title')}
           </h1>
           {service.location && <div>{service.location}</div>}

--- a/apps/web/src/pages/services/ServicesPage.tsx
+++ b/apps/web/src/pages/services/ServicesPage.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../features/services/hooks';
 import ServiceForm from '../../features/services/ServiceForm';
 import type { ListServicesResponse } from '../../api/services';
+import { formatDate } from '@/i18n/intl';
 
 function Modal({
   open,
@@ -33,7 +34,7 @@ function Modal({
 }
 
 export default function ServicesPage() {
-  const { t } = useTranslation('services');
+  const { t, i18n } = useTranslation('services');
   const { t: tCommon } = useTranslation('common');
   const [searchParams, setSearchParams] = useSearchParams();
   const queryParam = searchParams.get('query') ?? '';
@@ -139,7 +140,7 @@ export default function ServicesPage() {
             <tbody>
               {services.map((s) => (
                 <tr key={s.id} className="border-t">
-                  <td className="p-2">{s.startsAt ? new Date(s.startsAt).toLocaleString() : ''}</td>
+                  <td className="p-2">{s.startsAt ? formatDate(s.startsAt, i18n.language) : ''}</td>
                   <td className="p-2">{s.location}</td>
                   <td className="p-2 text-right">
                     <div className="flex gap-2 justify-end">

--- a/apps/web/src/pages/songs/SongDetailPage.tsx
+++ b/apps/web/src/pages/songs/SongDetailPage.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../features/songs/hooks';
 import SongForm from '../../features/songs/SongForm';
 import ArrangementForm from '../../features/songs/ArrangementForm';
+import { formatBpm, formatDate } from '@/i18n/intl';
 
 function Modal({
   open,
@@ -86,10 +87,7 @@ export default function SongDetailPage() {
 
   const updatedAtRaw = (song as SongResponseWithTimestamps).updatedAt;
   const formattedUpdatedAt = updatedAtRaw
-    ? new Intl.DateTimeFormat(i18n.language || undefined, {
-        dateStyle: 'medium',
-        timeStyle: 'short',
-      }).format(new Date(updatedAtRaw))
+    ? formatDate(updatedAtRaw, i18n.language)
     : null;
 
   return (
@@ -153,7 +151,7 @@ export default function SongDetailPage() {
             {arrangements.map((a) => (
               <tr key={a.id} className="border-t">
                 <td className="p-2">{a.key}</td>
-                <td className="p-2">{a.bpm}</td>
+                <td className="p-2">{a.bpm != null ? formatBpm(a.bpm, i18n.language) : ''}</td>
                 <td className="p-2">{a.meter}</td>
                 <td className="p-2 text-right">
                   <div className="flex gap-2 justify-end">


### PR DESCRIPTION
## Summary
- add an i18n formatting helper that wraps Intl date and number formatters
- use the shared helper for service start dates and arrangement BPM display

## Testing
- yarn --cwd apps/web build
- yarn --cwd apps/web typecheck

## PR Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [x] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68cd873ebe888330b5d13f4f1b29cc9c