### PR TITLE
feat: localize dynamic arrangement labels

### DIFF
--- a/apps/web/src/lib/arrangement-labels.ts
+++ b/apps/web/src/lib/arrangement-labels.ts
@@ -1,3 +1,5 @@
+import type { TFunction } from 'i18next';
+
 export type LabelPieces = {
   songTitle?: string;
   key?: string | null;
@@ -14,17 +16,46 @@ function compact<T>(xs: (T | undefined | null | false)[]) {
  *   "Song Title — Key G • 72 BPM • 4/4"
  * Falls back gracefully if pieces are missing.
  */
-export function formatArrangementLine(p: LabelPieces): string {
+export function formatArrangementLine(t: TFunction<'arrangements'>, p: LabelPieces): string {
+  const separator = t('labels.meta.separator', { defaultValue: ' • ' });
   const meta = compact<string>([
-    p.key ? `Key ${p.key}` : undefined,
-    typeof p.bpm === 'number' ? `${p.bpm} BPM` : undefined,
-    p.meter || undefined,
-  ]).join(' • ');
+    p.key
+      ? t('labels.meta.key', {
+          key: p.key,
+          defaultValue: `Key ${p.key}`,
+        })
+      : undefined,
+    typeof p.bpm === 'number'
+      ? t('labels.meta.bpm', {
+          bpm: p.bpm,
+          defaultValue: `${p.bpm} BPM`,
+        })
+      : undefined,
+    p.meter
+      ? t('labels.meta.meter', {
+          meter: p.meter,
+          defaultValue: p.meter,
+        })
+      : undefined,
+  ]).join(separator);
 
-  if (p.songTitle && meta) return `${p.songTitle} — ${meta}`;
-  if (p.songTitle) return p.songTitle;
-  if (meta) return meta;
-  return 'Arrangement';
+  if (p.songTitle && meta)
+    return t('labels.line.titleWithMeta', {
+      title: p.songTitle,
+      meta,
+      defaultValue: `${p.songTitle} — ${meta}`,
+    });
+  if (p.songTitle)
+    return t('labels.line.titleOnly', {
+      title: p.songTitle,
+      defaultValue: p.songTitle,
+    });
+  if (meta)
+    return t('labels.line.metaOnly', {
+      meta,
+      defaultValue: meta,
+    });
+  return t('labels.generic', { defaultValue: 'Arrangement' });
 }
 
 /**
@@ -34,26 +65,48 @@ export function formatArrangementLine(p: LabelPieces): string {
  *  - Capo only:         "Key G, Capo 2 (shapes in F)"
  *  - Both:              "Key G → Ab (+1), Capo 4 (shapes in F)"
  */
-export function formatKeyTransform(opts: {
-  originalKey: string;
-  soundingKey: string; // after transpose
-  shapeKey?: string;   // if capo > 0
-  transpose?: number;  // semitones, may be 0
-  capo?: number;       // fret number, 0 if none
-}) {
+export function formatKeyTransform(
+  t: TFunction<'arrangements'>,
+  opts: {
+    originalKey: string;
+    soundingKey: string; // after transpose
+    shapeKey?: string;   // if capo > 0
+    transpose?: number;  // semitones, may be 0
+    capo?: number;       // fret number, 0 if none
+  },
+) {
   const { originalKey, soundingKey, shapeKey, transpose = 0, capo = 0 } = opts;
 
   const parts: string[] = [];
   if (transpose && originalKey !== soundingKey) {
     const sign = transpose > 0 ? `+${transpose}` : `${transpose}`;
-    parts.push(`Key ${originalKey} → ${soundingKey} (${sign})`);
+    parts.push(
+      t('labels.keyTransform.transpose', {
+        original: originalKey,
+        sounding: soundingKey,
+        change: sign,
+        defaultValue: `Key ${originalKey} → ${soundingKey} (${sign})`,
+      }),
+    );
   } else {
-    parts.push(`Key ${originalKey}`);
+    parts.push(
+      t('labels.keyTransform.base', {
+        key: originalKey,
+        defaultValue: `Key ${originalKey}`,
+      }),
+    );
   }
 
   if (capo > 0 && shapeKey) {
-    parts.push(`Capo ${capo} (shapes in ${shapeKey})`);
+    parts.push(
+      t('labels.keyTransform.capo', {
+        capo,
+        shape: shapeKey,
+        defaultValue: `Capo ${capo} (shapes in ${shapeKey})`,
+      }),
+    );
   }
 
-  return parts.join(', ');
+  const separator = t('labels.keyTransform.separator', { defaultValue: ', ' });
+  return parts.join(separator);
 }

--- a/apps/web/src/locales/en/arrangements.json
+++ b/apps/web/src/locales/en/arrangements.json
@@ -38,7 +38,25 @@
     "empty": "No arrangements"
   },
   "labels": {
-    "fallback": "Arrangement {{id}}"
+    "fallback": "Arrangement {{id}}",
+    "generic": "Arrangement",
+    "meta": {
+      "key": "Key {{key}}",
+      "bpm": "{{bpm}} BPM",
+      "meter": "{{meter}}",
+      "separator": " • "
+    },
+    "line": {
+      "titleWithMeta": "{{title}} — {{meta}}",
+      "titleOnly": "{{title}}",
+      "metaOnly": "{{meta}}"
+    },
+    "keyTransform": {
+      "base": "Key {{key}}",
+      "transpose": "Key {{original}} → {{sounding}} ({{change}})",
+      "capo": "Capo {{capo}} (shapes in {{shape}})",
+      "separator": ", "
+    }
   },
   "validation": {
     "keyRequired": "Key is required",

--- a/apps/web/src/locales/es/arrangements.json
+++ b/apps/web/src/locales/es/arrangements.json
@@ -38,7 +38,25 @@
     "empty": "No hay arreglos"
   },
   "labels": {
-    "fallback": "Arreglo {{id}}"
+    "fallback": "Arreglo {{id}}",
+    "generic": "Arreglo",
+    "meta": {
+      "key": "Tonalidad {{key}}",
+      "bpm": "{{bpm}} PPM",
+      "meter": "{{meter}}",
+      "separator": " • "
+    },
+    "line": {
+      "titleWithMeta": "{{title}} — {{meta}}",
+      "titleOnly": "{{title}}",
+      "metaOnly": "{{meta}}"
+    },
+    "keyTransform": {
+      "base": "Tonalidad {{key}}",
+      "transpose": "Tonalidad {{original}} → {{sounding}} ({{change}})",
+      "capo": "Capo {{capo}} (figuras en {{shape}})",
+      "separator": ", "
+    }
   },
   "validation": {
     "keyRequired": "La tonalidad es obligatoria",

--- a/apps/web/src/pages/services/ServiceDetailPage.tsx
+++ b/apps/web/src/pages/services/ServiceDetailPage.tsx
@@ -111,17 +111,22 @@ export default function ServiceDetailPage() {
   const previewKeySource = selectedLabel?.key ?? selectedArrangement?.key ?? null;
   const previewKeyInfo = previewKeySource ? computeKeys(previewKeySource, 0, 0, false) : undefined;
   const previewLine = arrangementId
-    ? formatArrangementLine({
-        songTitle: selectedLabel?.songTitle ?? song?.title ?? `Arrangement ${arrangementId}`,
+    ? formatArrangementLine(tArrangements, {
+        songTitle:
+          selectedLabel?.songTitle ??
+          song?.title ??
+          tArrangements('labels.fallback', { id: arrangementId }),
         key: previewKeyInfo?.originalKey ?? previewKeySource ?? null,
         bpm: selectedLabel?.bpm ?? selectedArrangement?.bpm ?? null,
         meter: selectedLabel?.meter ?? selectedArrangement?.meter ?? null,
       })
     : null;
   const previewKeySummary = arrangementId
-    ? formatKeyTransform({
-        originalKey: previewKeyInfo?.originalKey ?? previewKeySource ?? 'N/A',
-        soundingKey: previewKeyInfo?.soundingKey ?? previewKeySource ?? 'N/A',
+    ? formatKeyTransform(tArrangements, {
+        originalKey:
+          previewKeyInfo?.originalKey ?? previewKeySource ?? tCommon('labels.notAvailable'),
+        soundingKey:
+          previewKeyInfo?.soundingKey ?? previewKeySource ?? tCommon('labels.notAvailable'),
         shapeKey: previewKeyInfo?.shapeKey,
         transpose: 0,
         capo: 0,
@@ -266,13 +271,13 @@ export default function ServiceDetailPage() {
                     ? computeKeys(label.key, transpose, capo, false)
                     : undefined;
 
-                  line = formatArrangementLine({
+                  line = formatArrangementLine(tArrangements, {
                     songTitle: label?.songTitle ?? fallbackTitle,
                     key: keyInfo?.originalKey ?? label?.key ?? null,
                     bpm: label?.bpm ?? null,
                     meter: label?.meter ?? null,
                   });
-                  keySummary = formatKeyTransform({
+                  keySummary = formatKeyTransform(tArrangements, {
                     originalKey:
                       keyInfo?.originalKey ?? label?.key ?? tCommon('labels.notAvailable'),
                     soundingKey:

--- a/apps/web/src/pages/services/ServicePlanViewPage.tsx
+++ b/apps/web/src/pages/services/ServicePlanViewPage.tsx
@@ -119,13 +119,13 @@ export default function ServicePlanViewPage() {
                 const capo = typeof extras['capo'] === 'number' ? (extras['capo'] as number) : 0;
                 const keyInfo = label?.key ? computeKeys(label.key, transpose, capo, false) : undefined;
 
-                line = formatArrangementLine({
+                line = formatArrangementLine(tArrangements, {
                   songTitle: label?.songTitle ?? fallbackTitle,
                   key: keyInfo?.originalKey ?? label?.key ?? null,
                   bpm: label?.bpm ?? null,
                   meter: label?.meter ?? null,
                 });
-                keySummary = formatKeyTransform({
+                keySummary = formatKeyTransform(tArrangements, {
                   originalKey:
                     keyInfo?.originalKey ?? label?.key ?? tCommon('labels.notAvailable'),
                   soundingKey:

--- a/apps/web/src/pages/services/ServicePrintPage.tsx
+++ b/apps/web/src/pages/services/ServicePrintPage.tsx
@@ -58,13 +58,13 @@ export default function ServicePrintPage() {
                 ? computeKeys(label.key, transpose, capo, false)
                 : undefined;
 
-              line = formatArrangementLine({
+              line = formatArrangementLine(tArrangements, {
                 songTitle: label?.songTitle ?? fallbackTitle,
                 key: keyInfo?.originalKey ?? label?.key ?? null,
                 bpm: label?.bpm ?? null,
                 meter: label?.meter ?? null,
               });
-              keySummary = formatKeyTransform({
+              keySummary = formatKeyTransform(tArrangements, {
                 originalKey:
                   keyInfo?.originalKey ?? label?.key ?? tCommon('labels.notAvailable'),
                 soundingKey:

--- a/apps/web/src/pages/sets/SongSetDetailPage.tsx
+++ b/apps/web/src/pages/sets/SongSetDetailPage.tsx
@@ -109,7 +109,7 @@ function SortableSetItem({
     ? computeKeys(arrangement.key, transpose, capo, useFlats)
     : undefined;
 
-  const line = formatArrangementLine({
+  const line = formatArrangementLine(tArrangements, {
     songTitle:
       arrangement?.songTitle ??
       (item.arrangementId
@@ -120,7 +120,7 @@ function SortableSetItem({
     meter: arrangement?.meter ?? null,
   });
 
-  const keySummary = formatKeyTransform({
+  const keySummary = formatKeyTransform(tArrangements, {
     originalKey: keyInfo?.originalKey ?? arrangement?.key ?? tCommon('labels.notAvailable'),
     soundingKey: keyInfo?.soundingKey ?? arrangement?.key ?? tCommon('labels.notAvailable'),
     shapeKey: keyInfo?.shapeKey,
@@ -255,7 +255,7 @@ export default function SongSetDetailPage() {
     ? computeKeys(previewKeySource, transpose, capo, useFlats)
     : undefined;
   const previewLine = arrangementId
-    ? formatArrangementLine({
+    ? formatArrangementLine(tArrangements, {
         songTitle:
           selectedArrangementInfo?.songTitle ??
           tArrangements('labels.fallback', { id: arrangementId }),
@@ -265,7 +265,7 @@ export default function SongSetDetailPage() {
       })
     : null;
   const previewKeySummary = arrangementId
-    ? formatKeyTransform({
+    ? formatKeyTransform(tArrangements, {
         originalKey:
           previewKeyInfo?.originalKey ?? previewKeySource ?? tCommon('labels.notAvailable'),
         soundingKey:


### PR DESCRIPTION
## Summary
- add placeholder-based arrangement metadata and key transform strings in both English and Spanish locales
- refactor arrangement label helpers to format text via translation functions
- update pickers, song set items, and service plan views to render dynamic arrangement details through i18n helpers

## Testing
- yarn lint
- yarn typecheck
- yarn build

## Checklist
- [x] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68cd9b1fb45c8330b1ee0f28b721ac7d