### PR TITLE
feat(web): log missing translations in dev

### DIFF
--- a/apps/web/src/components/MissingTranslationBoundary.tsx
+++ b/apps/web/src/components/MissingTranslationBoundary.tsx
@@ -1,0 +1,61 @@
+import { useEffect, type ReactNode } from 'react';
+
+import i18n from '@/i18n';
+
+const isDevEnvironment = import.meta.env.DEV;
+
+type MissingTranslationBoundaryProps = {
+  componentName: string;
+  namespaces?: readonly string[] | string;
+  children: ReactNode;
+};
+
+export function MissingTranslationBoundary({
+  componentName,
+  namespaces,
+  children,
+}: MissingTranslationBoundaryProps) {
+  useEffect(() => {
+    if (!isDevEnvironment) {
+      return;
+    }
+
+    const namespaceFilter =
+      namespaces === undefined
+        ? null
+        : new Set(
+            Array.isArray(namespaces)
+              ? namespaces
+              : ([namespaces] as const),
+          );
+
+    const seenKeys = new Set<string>();
+
+    const handleMissingKey = (_lng: string, ns: string, key: string) => {
+      if (namespaceFilter && !namespaceFilter.has(ns)) {
+        return;
+      }
+
+      const identifier = `${ns}:${key}`;
+      if (seenKeys.has(identifier)) {
+        return;
+      }
+
+      seenKeys.add(identifier);
+
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[i18n][${componentName}] Missing translation key "${key}" in namespace "${ns}".`,
+      );
+    };
+
+    i18n.on('missingKey', handleMissingKey);
+
+    return () => {
+      i18n.off('missingKey', handleMissingKey);
+    };
+  }, [componentName, namespaces]);
+
+  return <>{children}</>;
+}
+

--- a/apps/web/src/routes/GroupDetail.tsx
+++ b/apps/web/src/routes/GroupDetail.tsx
@@ -1,2 +1,15 @@
-export { default } from '@/pages/groups/GroupDetailPage';
+import { MissingTranslationBoundary } from '@/components/MissingTranslationBoundary';
+import GroupDetailPage from '@/pages/groups/GroupDetailPage';
 
+const groupDetailNamespaces = ['groups', 'common'] as const;
+
+export default function GroupDetailRoute() {
+  return (
+    <MissingTranslationBoundary
+      componentName="GroupDetailPage"
+      namespaces={groupDetailNamespaces}
+    >
+      <GroupDetailPage />
+    </MissingTranslationBoundary>
+  );
+}

--- a/apps/web/src/routes/Groups.tsx
+++ b/apps/web/src/routes/Groups.tsx
@@ -1,1 +1,15 @@
-export { default } from '@/pages/groups/GroupsPage';
+import { MissingTranslationBoundary } from '@/components/MissingTranslationBoundary';
+import GroupsPage from '@/pages/groups/GroupsPage';
+
+const groupsNamespaces = ['groups', 'common'] as const;
+
+export default function GroupsRoute() {
+  return (
+    <MissingTranslationBoundary
+      componentName="GroupsPage"
+      namespaces={groupsNamespaces}
+    >
+      <GroupsPage />
+    </MissingTranslationBoundary>
+  );
+}

--- a/apps/web/src/routes/Members.tsx
+++ b/apps/web/src/routes/Members.tsx
@@ -1,1 +1,15 @@
-export { default } from '@/pages/members/MembersPage';
+import { MissingTranslationBoundary } from '@/components/MissingTranslationBoundary';
+import MembersPage from '@/pages/members/MembersPage';
+
+const membersNamespaces = ['members', 'common'] as const;
+
+export default function MembersRoute() {
+  return (
+    <MissingTranslationBoundary
+      componentName="MembersPage"
+      namespaces={membersNamespaces}
+    >
+      <MembersPage />
+    </MissingTranslationBoundary>
+  );
+}

--- a/apps/web/src/routes/ServiceDetail.tsx
+++ b/apps/web/src/routes/ServiceDetail.tsx
@@ -1,1 +1,20 @@
-export { default } from '@/pages/services/ServiceDetailPage';
+import { MissingTranslationBoundary } from '@/components/MissingTranslationBoundary';
+import ServiceDetailPage from '@/pages/services/ServiceDetailPage';
+
+const serviceDetailNamespaces = [
+  'services',
+  'songs',
+  'arrangements',
+  'common',
+] as const;
+
+export default function ServiceDetailRoute() {
+  return (
+    <MissingTranslationBoundary
+      componentName="ServiceDetailPage"
+      namespaces={serviceDetailNamespaces}
+    >
+      <ServiceDetailPage />
+    </MissingTranslationBoundary>
+  );
+}

--- a/apps/web/src/routes/ServicePlanView.tsx
+++ b/apps/web/src/routes/ServicePlanView.tsx
@@ -1,2 +1,15 @@
-export { default } from '@/pages/services/ServicePlanViewPage';
+import { MissingTranslationBoundary } from '@/components/MissingTranslationBoundary';
+import ServicePlanViewPage from '@/pages/services/ServicePlanViewPage';
 
+const servicePlanViewNamespaces = ['services', 'arrangements', 'common'] as const;
+
+export default function ServicePlanViewRoute() {
+  return (
+    <MissingTranslationBoundary
+      componentName="ServicePlanViewPage"
+      namespaces={servicePlanViewNamespaces}
+    >
+      <ServicePlanViewPage />
+    </MissingTranslationBoundary>
+  );
+}

--- a/apps/web/src/routes/ServicePrint.tsx
+++ b/apps/web/src/routes/ServicePrint.tsx
@@ -1,1 +1,15 @@
-export { default } from '@/pages/services/ServicePrintPage';
+import { MissingTranslationBoundary } from '@/components/MissingTranslationBoundary';
+import ServicePrintPage from '@/pages/services/ServicePrintPage';
+
+const servicePrintNamespaces = ['services', 'arrangements', 'common'] as const;
+
+export default function ServicePrintRoute() {
+  return (
+    <MissingTranslationBoundary
+      componentName="ServicePrintPage"
+      namespaces={servicePrintNamespaces}
+    >
+      <ServicePrintPage />
+    </MissingTranslationBoundary>
+  );
+}

--- a/apps/web/src/routes/Services.tsx
+++ b/apps/web/src/routes/Services.tsx
@@ -1,1 +1,15 @@
-export { default } from '@/pages/services/ServicesPage';
+import { MissingTranslationBoundary } from '@/components/MissingTranslationBoundary';
+import ServicesPage from '@/pages/services/ServicesPage';
+
+const servicesNamespaces = ['services', 'common'] as const;
+
+export default function ServicesRoute() {
+  return (
+    <MissingTranslationBoundary
+      componentName="ServicesPage"
+      namespaces={servicesNamespaces}
+    >
+      <ServicesPage />
+    </MissingTranslationBoundary>
+  );
+}

--- a/apps/web/src/routes/SongDetail.tsx
+++ b/apps/web/src/routes/SongDetail.tsx
@@ -1,1 +1,15 @@
-export { default } from '@/pages/songs/SongDetailPage';
+import { MissingTranslationBoundary } from '@/components/MissingTranslationBoundary';
+import SongDetailPage from '@/pages/songs/SongDetailPage';
+
+const songDetailNamespaces = ['songs', 'arrangements', 'common'] as const;
+
+export default function SongDetailRoute() {
+  return (
+    <MissingTranslationBoundary
+      componentName="SongDetailPage"
+      namespaces={songDetailNamespaces}
+    >
+      <SongDetailPage />
+    </MissingTranslationBoundary>
+  );
+}

--- a/apps/web/src/routes/SongSetDetail.tsx
+++ b/apps/web/src/routes/SongSetDetail.tsx
@@ -1,1 +1,20 @@
-export { default } from '@/pages/sets/SongSetDetailPage';
+import { MissingTranslationBoundary } from '@/components/MissingTranslationBoundary';
+import SongSetDetailPage from '@/pages/sets/SongSetDetailPage';
+
+const songSetDetailNamespaces = [
+  'songSets',
+  'arrangements',
+  'songs',
+  'common',
+] as const;
+
+export default function SongSetDetailRoute() {
+  return (
+    <MissingTranslationBoundary
+      componentName="SongSetDetailPage"
+      namespaces={songSetDetailNamespaces}
+    >
+      <SongSetDetailPage />
+    </MissingTranslationBoundary>
+  );
+}

--- a/apps/web/src/routes/SongSets.tsx
+++ b/apps/web/src/routes/SongSets.tsx
@@ -1,1 +1,15 @@
-export { default } from '@/pages/sets/SetsPage';
+import { MissingTranslationBoundary } from '@/components/MissingTranslationBoundary';
+import SongSetsPage from '@/pages/sets/SongSetsPage';
+
+const songSetsNamespaces = ['songSets', 'common'] as const;
+
+export default function SongSetsRoute() {
+  return (
+    <MissingTranslationBoundary
+      componentName="SongSetsPage"
+      namespaces={songSetsNamespaces}
+    >
+      <SongSetsPage />
+    </MissingTranslationBoundary>
+  );
+}

--- a/apps/web/src/routes/Songs.tsx
+++ b/apps/web/src/routes/Songs.tsx
@@ -1,1 +1,15 @@
-export { default } from '@/pages/songs/SongsPage';
+import { MissingTranslationBoundary } from '@/components/MissingTranslationBoundary';
+import SongsPage from '@/pages/songs/SongsPage';
+
+const songsNamespaces = ['songs', 'common'] as const;
+
+export default function SongsRoute() {
+  return (
+    <MissingTranslationBoundary
+      componentName="SongsPage"
+      namespaces={songsNamespaces}
+    >
+      <SongsPage />
+    </MissingTranslationBoundary>
+  );
+}


### PR DESCRIPTION
## Summary
- add a development-only MissingTranslationBoundary that records missing keys with component and namespace context
- wrap key route components in the new boundary so screens surface missing translations during development

## Testing
- yarn --cwd apps/web build

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68cda24b83608330b424b2a42faa004a