### PR TITLE
Add Playwright language switcher smoke test

### DIFF
--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -43,6 +43,11 @@ jobs:
         run: yarn test
         working-directory: apps/web
 
+      - name: Install Playwright browsers
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: yarn playwright install
+        working-directory: apps/web
+
       - name: E2E Smoke Tests
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: yarn e2e

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -39,6 +39,15 @@ jobs:
       - name: Build
         run: yarn build
 
+      - name: Test
+        run: yarn test
+        working-directory: apps/web
+
+      - name: E2E Smoke Tests
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: yarn e2e
+        working-directory: apps/web
+
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:

--- a/apps/web/.eslintrc.cjs
+++ b/apps/web/.eslintrc.cjs
@@ -4,7 +4,7 @@ module.exports = {
   ...base,
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    project: ['./tsconfig.json'],
+    project: ['./tsconfig.json', './tsconfig.playwright.json'],
     tsconfigRootDir: __dirname,
   },
   plugins: [...(base.plugins || []), '@typescript-eslint', 'i18next'],

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,8 @@
     "lint": "eslint . --ext .ts,.tsx",
     "format": "prettier --write .",
     "test": "vitest --run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",
@@ -34,6 +35,7 @@
   },
   "devDependencies": {
     "@ebal/config": "*",
+    "@playwright/test": "^1.46.0",
     "@testing-library/dom": "^9.3.4",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.2.1",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = process.env.PORT ?? '5173';
+const HOST = process.env.HOST ?? '127.0.0.1';
+const baseUrl = process.env.PLAYWRIGHT_BASE_URL ?? `http://${HOST}:${PORT}`;
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 60_000,
+  expect: {
+    timeout: 5_000,
+  },
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'list',
+  use: {
+    baseURL: baseUrl,
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: `yarn dev --host --port ${PORT}`,
+    url: baseUrl,
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/apps/web/tests/language-switcher.spec.ts
+++ b/apps/web/tests/language-switcher.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test';
+
+const EN_NAV_LABELS = ['Members', 'Groups', 'Songs', 'Song Sets', 'Services'];
+const ES_NAV_LABELS = [
+  'Miembros',
+  'Grupos',
+  'Canciones',
+  'Listas de canciones',
+  'Servicios',
+];
+
+const LANGUAGE_BUTTON_NAME = /Change language|Cambiar idioma/;
+
+test.describe('language switcher smoke', () => {
+  test('switches navigation language and persists after reload', async ({ page }) => {
+    await page.goto('/en/services');
+
+    for (const label of EN_NAV_LABELS) {
+      await expect(page.getByRole('link', { name: label })).toBeVisible();
+    }
+
+    await page.getByRole('button', { name: LANGUAGE_BUTTON_NAME }).click();
+    await page.getByRole('option', { name: 'Español' }).click();
+
+    await expect(page).toHaveURL(/\/es\/services$/);
+
+    for (const label of ES_NAV_LABELS) {
+      await expect(page.getByRole('link', { name: label })).toBeVisible();
+    }
+
+    await expect(
+      page.getByRole('button', { name: LANGUAGE_BUTTON_NAME }),
+    ).toContainText('Español');
+
+    await page.reload();
+
+    await expect(page).toHaveURL(/\/es\/services$/);
+
+    for (const label of ES_NAV_LABELS) {
+      await expect(page.getByRole('link', { name: label })).toBeVisible();
+    }
+
+    await expect(
+      page.getByRole('button', { name: LANGUAGE_BUTTON_NAME }),
+    ).toContainText('Español');
+  });
+});

--- a/apps/web/tests/language-switcher.spec.ts
+++ b/apps/web/tests/language-switcher.spec.ts
@@ -11,43 +11,37 @@ const ES_NAV_LABELS = [
 
 const LANGUAGE_BUTTON_NAME = /Change language|Cambiar idioma/;
 
-test.describe('language switcher smoke', () => {
-  test('switches navigation language and persists after reload', async ({ page }) => {
-    await page.goto('/en/services');
+test('language switcher smoke: switches navigation language and persists after reload', async ({
+  page,
+}) => {
+  await page.goto('/en/services');
 
-    for (const label of EN_NAV_LABELS) {
-      await expect(
-        page.getByRole('link', { name: label, exact: true }),
-      ).toBeVisible();
-    }
+  for (const label of EN_NAV_LABELS) {
+    await expect(page.getByRole('link', { name: label, exact: true })).toBeVisible();
+  }
 
-    await page.getByRole('button', { name: LANGUAGE_BUTTON_NAME }).click();
-    await page.getByRole('option', { name: 'Español' }).click();
+  await page.getByRole('button', { name: LANGUAGE_BUTTON_NAME }).click();
+  await page.getByRole('option', { name: 'Español' }).click();
 
-    await expect(page).toHaveURL(/\/es\/services$/);
+  await expect(page).toHaveURL(/\/es\/services$/);
 
-    for (const label of ES_NAV_LABELS) {
-      await expect(
-        page.getByRole('link', { name: label, exact: true }),
-      ).toBeVisible();
-    }
+  for (const label of ES_NAV_LABELS) {
+    await expect(page.getByRole('link', { name: label, exact: true })).toBeVisible();
+  }
 
-    await expect(
-      page.getByRole('button', { name: LANGUAGE_BUTTON_NAME }),
-    ).toContainText('Español');
+  await expect(page.getByRole('button', { name: LANGUAGE_BUTTON_NAME })).toContainText(
+    'Español',
+  );
 
-    await page.reload();
+  await page.reload();
 
-    await expect(page).toHaveURL(/\/es\/services$/);
+  await expect(page).toHaveURL(/\/es\/services$/);
 
-    for (const label of ES_NAV_LABELS) {
-      await expect(
-        page.getByRole('link', { name: label, exact: true }),
-      ).toBeVisible();
-    }
+  for (const label of ES_NAV_LABELS) {
+    await expect(page.getByRole('link', { name: label, exact: true })).toBeVisible();
+  }
 
-    await expect(
-      page.getByRole('button', { name: LANGUAGE_BUTTON_NAME }),
-    ).toContainText('Español');
-  });
+  await expect(page.getByRole('button', { name: LANGUAGE_BUTTON_NAME })).toContainText(
+    'Español',
+  );
 });

--- a/apps/web/tests/language-switcher.spec.ts
+++ b/apps/web/tests/language-switcher.spec.ts
@@ -16,7 +16,9 @@ test.describe('language switcher smoke', () => {
     await page.goto('/en/services');
 
     for (const label of EN_NAV_LABELS) {
-      await expect(page.getByRole('link', { name: label })).toBeVisible();
+      await expect(
+        page.getByRole('link', { name: label, exact: true }),
+      ).toBeVisible();
     }
 
     await page.getByRole('button', { name: LANGUAGE_BUTTON_NAME }).click();
@@ -25,7 +27,9 @@ test.describe('language switcher smoke', () => {
     await expect(page).toHaveURL(/\/es\/services$/);
 
     for (const label of ES_NAV_LABELS) {
-      await expect(page.getByRole('link', { name: label })).toBeVisible();
+      await expect(
+        page.getByRole('link', { name: label, exact: true }),
+      ).toBeVisible();
     }
 
     await expect(
@@ -37,7 +41,9 @@ test.describe('language switcher smoke', () => {
     await expect(page).toHaveURL(/\/es\/services$/);
 
     for (const label of ES_NAV_LABELS) {
-      await expect(page.getByRole('link', { name: label })).toBeVisible();
+      await expect(
+        page.getByRole('link', { name: label, exact: true }),
+      ).toBeVisible();
     }
 
     await expect(

--- a/apps/web/tsconfig.playwright.json
+++ b/apps/web/tsconfig.playwright.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../packages/config/tsconfig.json",
+  "compilerOptions": {
+    "types": ["@playwright/test", "node"]
+  },
+  "include": ["playwright.config.ts", "tests/**/*.ts"]
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: './setupTests.ts',
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
     coverage: {
       reporter: ['text', 'lcov'],
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1144,6 +1144,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@playwright/test@npm:^1.46.0":
+  version: 1.55.0
+  resolution: "@playwright/test@npm:1.55.0"
+  dependencies:
+    playwright: "npm:1.55.0"
+  bin:
+    playwright: cli.js
+  checksum: 10c0/e68b59cd8271f1b57c0649fc0562ab2d5f6bba8c3653dd7bd52ca1338dc380fde34588d0254e3cd3f0f2b20af04a80dfb080419ceb7475990bb2fc4d8c474984
+  languageName: node
+  linkType: hard
+
 "@redocly/ajv@npm:^8.11.2":
   version: 8.11.3
   resolution: "@redocly/ajv@npm:8.11.3"
@@ -3940,12 +3951,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:2.3.2":
+  version: 2.3.2
+  resolution: "fsevents@npm:2.3.2"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/be78a3efa3e181cda3cf7a4637cb527bcebb0bd0ea0440105a3bb45b86f9245b307dc10a2507e8f4498a7d4ec349d1910f4d73e4d4495b16103106e07eee735b
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>":
+  version: 2.3.2
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  dependencies:
+    node-gyp: "npm:latest"
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -6202,6 +6232,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"playwright-core@npm:1.55.0":
+  version: 1.55.0
+  resolution: "playwright-core@npm:1.55.0"
+  bin:
+    playwright-core: cli.js
+  checksum: 10c0/c39d6aa30e7a4e73965942ca5e13405ae05c9cb49f755a35f04248c864c0b24cf662d9767f1797b3ec48d1cf4e54774dce4a19c16534bd5cfd2aa3da81c9dc3a
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.55.0":
+  version: 1.55.0
+  resolution: "playwright@npm:1.55.0"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.55.0"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 10c0/51605b7e57a5650e57972c5fdfc09d7a9934cca1cbee5beacca716fa801e25cb5bb7c1663de90c22b300fde884e5545a2b13a0505a93270b660687791c478304
+  languageName: node
+  linkType: hard
+
 "pluralize@npm:^8.0.0":
   version: 8.0.0
   resolution: "pluralize@npm:8.0.0"
@@ -8282,6 +8336,7 @@ __metadata:
     "@dnd-kit/utilities": "npm:^3.2.0"
     "@ebal/config": "npm:*"
     "@hookform/resolvers": "npm:^3.3.4"
+    "@playwright/test": "npm:^1.46.0"
     "@tanstack/react-query": "npm:^5.0.0"
     "@testing-library/dom": "npm:^9.3.4"
     "@testing-library/jest-dom": "npm:^6.4.2"


### PR DESCRIPTION
## Summary
- configure Playwright for the web app with a Chromium project, dev server management, and dedicated tsconfig
- add a language switcher smoke test that verifies navigation labels swap between English and Spanish and persist after reload
- expose a yarn `e2e` script and install the Playwright test dependency

## Testing
- ⚠️ `yarn e2e` *(fails: Playwright browsers are not installed in this environment)*

## PR Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68cda832288c8330ace2c894f488b36f