### PR TITLE
feat(web): seed toolbar translations

### DIFF
--- a/apps/web/src/locales/en/arrangements.json
+++ b/apps/web/src/locales/en/arrangements.json
@@ -22,6 +22,28 @@
     "layoutAbove": "Chords above",
     "layoutInline": "Inline"
   },
+  "editor": {
+    "toolbar": {
+      "title": "Arrangement editor",
+      "transpose": {
+        "label": "Transpose",
+        "increase": "Raise key",
+        "decrease": "Lower key",
+        "reset": "Reset transpose"
+      },
+      "accidentals": {
+        "label": "Accidentals",
+        "useSharps": "Show sharps (♯)",
+        "useFlats": "Show flats (♭)"
+      },
+      "preview": {
+        "label": "Preview",
+        "open": "Open preview",
+        "close": "Hide preview",
+        "live": "Live preview updates automatically"
+      }
+    }
+  },
   "actions": {
     "new": "New Arrangement"
   },

--- a/apps/web/src/locales/en/services.json
+++ b/apps/web/src/locales/en/services.json
@@ -49,6 +49,29 @@
     "notifications": {
       "itemAdded": "Item added",
       "addFailed": "Failed to add item"
+    },
+    "toolbar": {
+      "title": "Plan builder",
+      "add": {
+        "label": "Add to plan",
+        "song": "Add song",
+        "reading": "Add reading",
+        "note": "Add note"
+      },
+      "arrangement": {
+        "label": "Choose arrangement",
+        "placeholder": "Search arrangements…"
+      },
+      "actions": {
+        "duplicate": "Duplicate item",
+        "remove": "Remove item",
+        "moveUp": "Move up",
+        "moveDown": "Move down",
+        "clearPlan": "Clear plan",
+        "preview": "Preview plan",
+        "share": "Share link",
+        "print": "Print"
+      }
     }
   },
   "planView": {

--- a/apps/web/src/locales/en/songSets.json
+++ b/apps/web/src/locales/en/songSets.json
@@ -38,7 +38,20 @@
     "title": "Items",
     "loadFailed": "Failed to load items.",
     "empty": "No items",
-    "dragHandle": "Drag to reorder"
+    "dragHandle": "Drag to reorder",
+    "drag": {
+      "grab": "Grab to drag",
+      "dragging": "Dragging {{title}}",
+      "drop": "Drop to reorder",
+      "cancel": "Cancel drag",
+      "keyboard": {
+        "hint": "Press space to grab, arrow keys to move, space again to drop.",
+        "moveUp": "Move item up",
+        "moveDown": "Move item down",
+        "moveToTop": "Move item to top",
+        "moveToBottom": "Move item to bottom"
+      }
+    }
   },
   "notifications": {
     "itemAdded": "Item added",

--- a/apps/web/src/locales/es/arrangements.json
+++ b/apps/web/src/locales/es/arrangements.json
@@ -22,6 +22,28 @@
     "layoutAbove": "Acordes arriba",
     "layoutInline": "En línea"
   },
+  "editor": {
+    "toolbar": {
+      "title": "Editor de arreglos",
+      "transpose": {
+        "label": "Transponer",
+        "increase": "Subir tonalidad",
+        "decrease": "Bajar tonalidad",
+        "reset": "Restablecer transposición"
+      },
+      "accidentals": {
+        "label": "Alteraciones",
+        "useSharps": "Mostrar sostenidos (♯)",
+        "useFlats": "Mostrar bemoles (♭)"
+      },
+      "preview": {
+        "label": "Vista previa",
+        "open": "Abrir vista previa",
+        "close": "Ocultar vista previa",
+        "live": "La vista previa se actualiza automáticamente"
+      }
+    }
+  },
   "actions": {
     "new": "Nuevo arreglo"
   },

--- a/apps/web/src/locales/es/services.json
+++ b/apps/web/src/locales/es/services.json
@@ -49,6 +49,29 @@
     "notifications": {
       "itemAdded": "Elemento agregado",
       "addFailed": "No se pudo agregar el elemento"
+    },
+    "toolbar": {
+      "title": "Constructor del plan",
+      "add": {
+        "label": "Agregar al plan",
+        "song": "Agregar canción",
+        "reading": "Agregar lectura",
+        "note": "Agregar nota"
+      },
+      "arrangement": {
+        "label": "Elegir arreglo",
+        "placeholder": "Buscar arreglos…"
+      },
+      "actions": {
+        "duplicate": "Duplicar elemento",
+        "remove": "Eliminar elemento",
+        "moveUp": "Mover arriba",
+        "moveDown": "Mover abajo",
+        "clearPlan": "Limpiar plan",
+        "preview": "Vista previa del plan",
+        "share": "Compartir enlace",
+        "print": "Imprimir"
+      }
     }
   },
   "planView": {

--- a/apps/web/src/locales/es/songSets.json
+++ b/apps/web/src/locales/es/songSets.json
@@ -38,7 +38,20 @@
     "title": "Elementos",
     "loadFailed": "No se pudieron cargar los elementos.",
     "empty": "Sin elementos",
-    "dragHandle": "Arrastrar para reordenar"
+    "dragHandle": "Arrastrar para reordenar",
+    "drag": {
+      "grab": "Sujetar para arrastrar",
+      "dragging": "Arrastrando {{title}}",
+      "drop": "Soltar para reordenar",
+      "cancel": "Cancelar arrastre",
+      "keyboard": {
+        "hint": "Presiona espacio para sujetar, flechas para mover y espacio otra vez para soltar.",
+        "moveUp": "Mover elemento arriba",
+        "moveDown": "Mover elemento abajo",
+        "moveToTop": "Mover elemento al inicio",
+        "moveToBottom": "Mover elemento al final"
+      }
+    }
   },
   "notifications": {
     "itemAdded": "Elemento agregado",


### PR DESCRIPTION
## Summary
- seed service plan builder toolbar strings in English and Spanish
- add arrangement editor toolbar translations for transpose, accidentals, and preview controls
- expand song set drag-and-drop instruction verbs for both locales

## Testing
- not run (localization-only change)

- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68cdef253d948330a3a3998525535e08