### PR TITLE
feat: extend OpenAPI for auth and user admin

### DIFF
--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/auth/AuthController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/auth/AuthController.java
@@ -1,7 +1,8 @@
 package com.homeputers.ebal2.api.auth;
 
 import com.homeputers.ebal2.api.generated.AuthApi;
-import com.homeputers.ebal2.api.generated.model.CurrentUser;
+import com.homeputers.ebal2.api.generated.model.User;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -19,9 +20,10 @@ public class AuthController implements AuthApi {
     }
 
     @Override
-    public ResponseEntity<CurrentUser> getCurrentUser() {
+    public ResponseEntity<User> getCurrentUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        CurrentUser currentUser = currentUserFactory.create(authentication);
-        return ResponseEntity.ok(currentUser);
+        return currentUserFactory.create(authentication)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.UNAUTHORIZED).build());
     }
 }

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/auth/AuthControllerTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/auth/AuthControllerTest.java
@@ -1,7 +1,7 @@
 package com.homeputers.ebal2.api.auth;
 
 import com.homeputers.ebal2.api.AbstractIntegrationTest;
-import com.homeputers.ebal2.api.generated.model.CurrentUser;
+import com.homeputers.ebal2.api.generated.model.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -18,19 +18,10 @@ class AuthControllerTest extends AbstractIntegrationTest {
     private TestRestTemplate restTemplate;
 
     @Test
-    void returnsAnonymousUser() {
-        ResponseEntity<CurrentUser> response = restTemplate.getForEntity("/api/v1/auth/me", CurrentUser.class);
+    void returnsUnauthorizedWhenAnonymous() {
+        ResponseEntity<User> response = restTemplate.getForEntity("/api/v1/auth/me", User.class);
 
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        CurrentUser currentUser = response.getBody();
-        assertThat(currentUser).isNotNull();
-        assertThat(currentUser.getSubject()).isNotNull();
-        assertThat(currentUser.getSubject().isPresent()).isTrue();
-        assertThat(currentUser.getSubject().get()).isEqualTo("anonymous");
-        assertThat(currentUser.getDisplayName()).isEqualTo("Anonymous");
-        assertThat(Boolean.TRUE.equals(currentUser.getAnonymous())).isTrue();
-        assertThat(currentUser.getRoles()).isNotNull().isEmpty();
-        assertThat(currentUser.getProvider()).isNotNull();
-        assertThat(currentUser.getProvider().isPresent()).isFalse();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(response.getBody()).isNull();
     }
 }

--- a/apps/web/src/api/types.d.ts
+++ b/apps/web/src/api/types.d.ts
@@ -608,25 +608,6 @@ export interface components {
             /** @description High level status string for the storage module. */
             status: string;
         };
-        /** @example {
-         *       "subject": "anonymous",
-         *       "displayName": "Anonymous",
-         *       "anonymous": true,
-         *       "roles": [],
-         *       "provider": null
-         *     } */
-        CurrentUser: {
-            /** @description Unique identifier of the authenticated principal when available. */
-            subject: string | null;
-            /** @description Human readable name for the current user. */
-            displayName: string;
-            /** @description True when the request is unauthenticated or security is disabled. */
-            anonymous: boolean;
-            /** @description Granted roles or authorities, empty when anonymous. */
-            roles: string[];
-            /** @description Identity provider id used once OIDC is enabled. */
-            provider?: string | null;
-        };
         /**
          * @description Role assigned to a user determining access level.
          * @enum {string}
@@ -1022,6 +1003,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["User"];
                 };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -137,6 +137,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
+        '401':
+          description: Unauthorized
   /admin/users:
     get:
       tags:
@@ -1100,35 +1102,6 @@ components:
           description: High level status string for the storage module.
       example:
         status: enabled
-    CurrentUser:
-      type: object
-      required: [subject, displayName, anonymous, roles]
-      properties:
-        subject:
-          type: string
-          nullable: true
-          description: Unique identifier of the authenticated principal when available.
-        displayName:
-          type: string
-          description: Human readable name for the current user.
-        anonymous:
-          type: boolean
-          description: True when the request is unauthenticated or security is disabled.
-        roles:
-          type: array
-          description: Granted roles or authorities, empty when anonymous.
-          items:
-            type: string
-        provider:
-          type: string
-          nullable: true
-          description: Identity provider id used once OIDC is enabled.
-      example:
-        subject: anonymous
-        displayName: Anonymous
-        anonymous: true
-        roles: []
-        provider: null
     Role:
       type: string
       description: Role assigned to a user determining access level.


### PR DESCRIPTION
## Summary
- add JWT-based auth flows and apply bearer security to protected API operations in the OpenAPI spec
- define user and auth request/response schemas plus admin user management endpoints
- regenerate the web client types to reflect the expanded API surface

## Testing
- ⚠️ `mvn -q -DskipTests generate-sources` *(fails: unable to resolve Spring Boot parent due to network restrictions)*
- ✅ `yarn generate:api`

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [x] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68cdf5d812a083309a1c6535dc65a0f7