### PR TITLE
feat: add user auth persistence and seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,21 @@ If you prefer to avoid `make`, run `docker compose build` followed by
 Use `make logs` (or `docker compose logs -f`) from the `infra/` directory to
 monitor the containers. To stop everything, run `make down`.
 
+### Database seeding
+
+Set the following environment variables before starting the API if you want it
+to create a default administrator account automatically:
+
+```dotenv
+EBAL_SEED_ENABLED=true
+EBAL_SEED_ADMIN_EMAIL=admin@example.com
+EBAL_SEED_ADMIN_PASSWORD=ChangeMe123!
+```
+
+The API seeds the user with a BCrypt password hash and grants the `ADMIN` role
+when the account does not already exist. Existing accounts are reactivated and
+granted the admin role if necessary.
+
 ## Service calendar export
 
 The API provides a read-only iCalendar feed of upcoming services at

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/SecurityConfig.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/SecurityConfig.java
@@ -10,6 +10,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.context.DelegatingSecurityContextRepository;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
@@ -58,5 +60,10 @@ public class SecurityConfig {
         // Allows collaborators like CurrentUserFactory to detect anonymous tokens while keeping the bean overrideable
         // for future OIDC-specific trust resolvers.
         return new AuthenticationTrustResolverImpl();
+    }
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/PasswordResetMapper.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/PasswordResetMapper.java
@@ -1,0 +1,22 @@
+package com.homeputers.ebal2.api.domain.user;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Mapper
+public interface PasswordResetMapper {
+    PasswordResetToken findByToken(@Param("token") String token);
+
+    void insert(@Param("token") String token,
+                @Param("userId") UUID userId,
+                @Param("expiresAt") OffsetDateTime expiresAt,
+                @Param("createdAt") OffsetDateTime createdAt);
+
+    void markUsed(@Param("token") String token,
+                  @Param("usedAt") OffsetDateTime usedAt);
+
+    void deleteExpired(@Param("now") OffsetDateTime now);
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/PasswordResetToken.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/PasswordResetToken.java
@@ -1,0 +1,18 @@
+package com.homeputers.ebal2.api.domain.user;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record PasswordResetToken(
+        String token,
+        UUID userId,
+        OffsetDateTime expiresAt,
+        OffsetDateTime usedAt,
+        OffsetDateTime createdAt
+) {
+    public PasswordResetToken {
+        if (createdAt == null) {
+            createdAt = OffsetDateTime.now();
+        }
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/RefreshToken.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/RefreshToken.java
@@ -1,0 +1,20 @@
+package com.homeputers.ebal2.api.domain.user;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record RefreshToken(
+        String token,
+        UUID userId,
+        OffsetDateTime expiresAt,
+        OffsetDateTime revokedAt,
+        OffsetDateTime createdAt,
+        String userAgent,
+        String ipAddress
+) {
+    public RefreshToken {
+        if (createdAt == null) {
+            createdAt = OffsetDateTime.now();
+        }
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/RefreshTokenMapper.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/RefreshTokenMapper.java
@@ -1,0 +1,24 @@
+package com.homeputers.ebal2.api.domain.user;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Mapper
+public interface RefreshTokenMapper {
+    RefreshToken findByToken(@Param("token") String token);
+
+    void insert(@Param("token") String token,
+                @Param("userId") UUID userId,
+                @Param("expiresAt") OffsetDateTime expiresAt,
+                @Param("createdAt") OffsetDateTime createdAt,
+                @Param("userAgent") String userAgent,
+                @Param("ipAddress") String ipAddress);
+
+    void revoke(@Param("token") String token,
+                @Param("revokedAt") OffsetDateTime revokedAt);
+
+    void deleteExpired(@Param("now") OffsetDateTime now);
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/User.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/User.java
@@ -1,15 +1,29 @@
 package com.homeputers.ebal2.api.domain.user;
 
+import java.time.OffsetDateTime;
+import java.util.Locale;
 import java.util.UUID;
 
 public record User(
         UUID id,
         String email,
-        String role
+        String passwordHash,
+        boolean isActive,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt
 ) {
     public User {
         if (id == null) {
             id = UUID.randomUUID();
+        }
+        if (email != null) {
+            email = email.trim().toLowerCase(Locale.ROOT);
+        }
+        if (createdAt == null) {
+            createdAt = OffsetDateTime.now();
+        }
+        if (updatedAt == null) {
+            updatedAt = createdAt;
         }
     }
 }

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/UserMapper.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/UserMapper.java
@@ -1,0 +1,32 @@
+package com.homeputers.ebal2.api.domain.user;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Mapper
+public interface UserMapper {
+    User findById(@Param("id") UUID id);
+
+    User findByEmail(@Param("email") String email);
+
+    void insert(@Param("id") UUID id,
+                @Param("email") String email,
+                @Param("passwordHash") String passwordHash,
+                @Param("isActive") boolean isActive,
+                @Param("createdAt") OffsetDateTime createdAt,
+                @Param("updatedAt") OffsetDateTime updatedAt);
+
+    void updatePassword(@Param("id") UUID id,
+                        @Param("passwordHash") String passwordHash,
+                        @Param("updatedAt") OffsetDateTime updatedAt);
+
+    void updateActive(@Param("id") UUID id,
+                      @Param("isActive") boolean isActive,
+                      @Param("updatedAt") OffsetDateTime updatedAt);
+
+    void touch(@Param("id") UUID id,
+               @Param("updatedAt") OffsetDateTime updatedAt);
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/UserRole.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/UserRole.java
@@ -1,0 +1,16 @@
+package com.homeputers.ebal2.api.domain.user;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record UserRole(
+        UUID userId,
+        String role,
+        OffsetDateTime createdAt
+) {
+    public UserRole {
+        if (createdAt == null) {
+            createdAt = OffsetDateTime.now();
+        }
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/UserRoleMapper.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/UserRoleMapper.java
@@ -1,0 +1,20 @@
+package com.homeputers.ebal2.api.domain.user;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Mapper
+public interface UserRoleMapper {
+    List<String> findRolesByUserId(@Param("userId") UUID userId);
+
+    void insert(@Param("userId") UUID userId,
+                @Param("role") String role,
+                @Param("createdAt") OffsetDateTime createdAt);
+
+    void delete(@Param("userId") UUID userId,
+                @Param("role") String role);
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/seed/AdminSeeder.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/seed/AdminSeeder.java
@@ -1,0 +1,96 @@
+package com.homeputers.ebal2.api.seed;
+
+import com.homeputers.ebal2.api.domain.user.User;
+import com.homeputers.ebal2.api.domain.user.UserMapper;
+import com.homeputers.ebal2.api.domain.user.UserRoleMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
+@Component
+@ConditionalOnProperty(prefix = "ebal.seed", name = "enabled", havingValue = "true")
+public class AdminSeeder implements ApplicationRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(AdminSeeder.class);
+    private static final String ADMIN_ROLE = "ADMIN";
+
+    private final UserMapper userMapper;
+    private final UserRoleMapper userRoleMapper;
+    private final PasswordEncoder passwordEncoder;
+    private final String adminEmail;
+    private final String adminPassword;
+
+    public AdminSeeder(UserMapper userMapper,
+                       UserRoleMapper userRoleMapper,
+                       PasswordEncoder passwordEncoder,
+                       @Value("${ebal.seed.admin.email:admin@example.com}") String adminEmail,
+                       @Value("${ebal.seed.admin.password:ChangeMe123!}") String adminPassword) {
+        this.userMapper = userMapper;
+        this.userRoleMapper = userRoleMapper;
+        this.passwordEncoder = passwordEncoder;
+        this.adminEmail = adminEmail;
+        this.adminPassword = adminPassword;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        String normalizedEmail = normalizeEmail(adminEmail);
+        if (normalizedEmail == null || normalizedEmail.isBlank()) {
+            log.warn("Skipping admin seed because ebal.seed.admin.email is blank");
+            return;
+        }
+        if (adminPassword == null || adminPassword.isBlank()) {
+            log.warn("Skipping admin seed because ebal.seed.admin.password is blank");
+            return;
+        }
+
+        User existing = userMapper.findByEmail(normalizedEmail);
+        OffsetDateTime now = OffsetDateTime.now();
+
+        if (existing != null) {
+            ensureActive(existing, now);
+            ensureAdminRole(existing, now);
+            return;
+        }
+
+        UUID userId = UUID.randomUUID();
+        String passwordHash = passwordEncoder.encode(adminPassword);
+
+        userMapper.insert(userId, normalizedEmail, passwordHash, true, now, now);
+        userRoleMapper.insert(userId, ADMIN_ROLE, now);
+        log.info("Seeded default admin user {}", normalizedEmail);
+    }
+
+    private void ensureActive(User user, OffsetDateTime now) {
+        if (!user.isActive()) {
+            userMapper.updateActive(user.id(), true, now);
+            log.info("Reactivated admin user {} during seed", user.email());
+        }
+    }
+
+    private void ensureAdminRole(User user, OffsetDateTime now) {
+        List<String> roles = userRoleMapper.findRolesByUserId(user.id());
+        boolean hasAdminRole = roles.stream().anyMatch(role -> ADMIN_ROLE.equalsIgnoreCase(role));
+        if (!hasAdminRole) {
+            userRoleMapper.insert(user.id(), ADMIN_ROLE, now);
+            log.info("Granted ADMIN role to existing user {} during seed", user.email());
+        }
+    }
+
+    private String normalizeEmail(String email) {
+        if (email == null) {
+            return null;
+        }
+        return email.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/apps/api-java/src/main/resources/application.yaml
+++ b/apps/api-java/src/main/resources/application.yaml
@@ -24,3 +24,8 @@ ebal:
     secret-key: ${EBAL_STORAGE_SECRET_KEY:}
     bucket: ${EBAL_STORAGE_BUCKET:}
     region: ${EBAL_STORAGE_REGION:}
+  seed:
+    enabled: ${EBAL_SEED_ENABLED:false}
+    admin:
+      email: ${EBAL_SEED_ADMIN_EMAIL:admin@example.com}
+      password: ${EBAL_SEED_ADMIN_PASSWORD:ChangeMe123!}

--- a/apps/api-java/src/main/resources/db/migration/V4__user_auth_tables.sql
+++ b/apps/api-java/src/main/resources/db/migration/V4__user_auth_tables.sql
@@ -1,0 +1,74 @@
+-- User authentication tables and metadata
+
+-- Normalize existing emails and enforce case-insensitive uniqueness
+ALTER TABLE users
+    DROP CONSTRAINT IF EXISTS users_email_key;
+
+UPDATE users
+SET email = lower(trim(email))
+WHERE email IS NOT NULL;
+
+ALTER TABLE users
+    ALTER COLUMN email SET NOT NULL;
+
+-- Add core account metadata columns
+ALTER TABLE users
+    ADD COLUMN password_hash TEXT,
+    ADD COLUMN is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+UPDATE users
+SET password_hash = '$2b$12$A2Ru1oyn3f5.LJ9XWHaSae5a9dmSp.4s3HzxwgDoVmQpNt6lp3Vny'
+WHERE password_hash IS NULL;
+
+ALTER TABLE users
+    ALTER COLUMN password_hash SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email_lower ON users (lower(email));
+
+-- Role assignments per user
+CREATE TABLE user_roles (
+    user_id UUID NOT NULL,
+    role TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, role),
+    CONSTRAINT fk_user_roles_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT chk_user_roles_role CHECK (role IN ('ADMIN', 'PLANNER', 'MUSICIAN', 'VIEWER'))
+);
+
+INSERT INTO user_roles (user_id, role)
+SELECT id, role FROM users WHERE role IS NOT NULL;
+
+ALTER TABLE users
+    DROP COLUMN IF EXISTS role;
+
+CREATE INDEX idx_user_roles_role ON user_roles(role);
+
+-- Password reset tokens
+CREATE TABLE password_resets (
+    token TEXT PRIMARY KEY,
+    user_id UUID NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    used_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT fk_password_resets_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_password_resets_user_id ON password_resets(user_id);
+CREATE INDEX idx_password_resets_expires_at ON password_resets(expires_at);
+
+-- Refresh tokens for session continuation
+CREATE TABLE refresh_tokens (
+    token TEXT PRIMARY KEY,
+    user_id UUID NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    revoked_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    user_agent TEXT,
+    ip_address TEXT,
+    CONSTRAINT fk_refresh_tokens_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_refresh_tokens_user_id ON refresh_tokens(user_id);
+CREATE INDEX idx_refresh_tokens_expires_at ON refresh_tokens(expires_at);

--- a/apps/api-java/src/main/resources/mappers/PasswordResetMapper.xml
+++ b/apps/api-java/src/main/resources/mappers/PasswordResetMapper.xml
@@ -36,6 +36,6 @@
 
     <delete id="deleteExpired">
         delete from password_resets
-        where expires_at < #{now}
+        where expires_at &lt; #{now}
     </delete>
 </mapper>

--- a/apps/api-java/src/main/resources/mappers/PasswordResetMapper.xml
+++ b/apps/api-java/src/main/resources/mappers/PasswordResetMapper.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.homeputers.ebal2.api.domain.user.PasswordResetMapper">
+    <resultMap id="passwordResetResult" type="com.homeputers.ebal2.api.domain.user.PasswordResetToken">
+        <constructor>
+            <idArg column="token" javaType="java.lang.String" />
+            <arg column="user_id" javaType="java.util.UUID"
+                 typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler"/>
+            <arg column="expires_at" javaType="java.time.OffsetDateTime" />
+            <arg column="used_at" javaType="java.time.OffsetDateTime" />
+            <arg column="created_at" javaType="java.time.OffsetDateTime" />
+        </constructor>
+    </resultMap>
+
+    <select id="findByToken" resultMap="passwordResetResult">
+        select token, user_id, expires_at, used_at, created_at
+        from password_resets
+        where token = #{token}
+    </select>
+
+    <insert id="insert">
+        insert into password_resets (token, user_id, expires_at, created_at)
+        values (
+            #{token},
+            #{userId, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler},
+            #{expiresAt},
+            #{createdAt}
+        )
+    </insert>
+
+    <update id="markUsed">
+        update password_resets
+        set used_at = #{usedAt}
+        where token = #{token}
+    </update>
+
+    <delete id="deleteExpired">
+        delete from password_resets
+        where expires_at < #{now}
+    </delete>
+</mapper>

--- a/apps/api-java/src/main/resources/mappers/RefreshTokenMapper.xml
+++ b/apps/api-java/src/main/resources/mappers/RefreshTokenMapper.xml
@@ -40,7 +40,7 @@
 
     <delete id="deleteExpired">
         delete from refresh_tokens
-        where expires_at < #{now}
+        where expires_at &lt; #{now}
            or revoked_at IS NOT NULL
     </delete>
 </mapper>

--- a/apps/api-java/src/main/resources/mappers/RefreshTokenMapper.xml
+++ b/apps/api-java/src/main/resources/mappers/RefreshTokenMapper.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.homeputers.ebal2.api.domain.user.RefreshTokenMapper">
+    <resultMap id="refreshTokenResult" type="com.homeputers.ebal2.api.domain.user.RefreshToken">
+        <constructor>
+            <idArg column="token" javaType="java.lang.String" />
+            <arg column="user_id" javaType="java.util.UUID"
+                 typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler"/>
+            <arg column="expires_at" javaType="java.time.OffsetDateTime" />
+            <arg column="revoked_at" javaType="java.time.OffsetDateTime" />
+            <arg column="created_at" javaType="java.time.OffsetDateTime" />
+            <arg column="user_agent" javaType="java.lang.String" />
+            <arg column="ip_address" javaType="java.lang.String" />
+        </constructor>
+    </resultMap>
+
+    <select id="findByToken" resultMap="refreshTokenResult">
+        select token, user_id, expires_at, revoked_at, created_at, user_agent, ip_address
+        from refresh_tokens
+        where token = #{token}
+    </select>
+
+    <insert id="insert">
+        insert into refresh_tokens (token, user_id, expires_at, created_at, user_agent, ip_address)
+        values (
+            #{token},
+            #{userId, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler},
+            #{expiresAt},
+            #{createdAt},
+            #{userAgent},
+            #{ipAddress}
+        )
+    </insert>
+
+    <update id="revoke">
+        update refresh_tokens
+        set revoked_at = #{revokedAt}
+        where token = #{token}
+    </update>
+
+    <delete id="deleteExpired">
+        delete from refresh_tokens
+        where expires_at < #{now}
+           or revoked_at IS NOT NULL
+    </delete>
+</mapper>

--- a/apps/api-java/src/main/resources/mappers/UserMapper.xml
+++ b/apps/api-java/src/main/resources/mappers/UserMapper.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.homeputers.ebal2.api.domain.user.UserMapper">
+    <resultMap id="userResult" type="com.homeputers.ebal2.api.domain.user.User">
+        <constructor>
+            <idArg column="id" javaType="java.util.UUID"
+                   typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler"/>
+            <arg column="email" javaType="java.lang.String"/>
+            <arg column="password_hash" javaType="java.lang.String"/>
+            <arg column="is_active" javaType="boolean"/>
+            <arg column="created_at" javaType="java.time.OffsetDateTime"/>
+            <arg column="updated_at" javaType="java.time.OffsetDateTime"/>
+        </constructor>
+    </resultMap>
+
+    <select id="findById" resultMap="userResult">
+        select id, email, password_hash, is_active, created_at, updated_at
+        from users
+        where id = #{id, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler}
+    </select>
+
+    <select id="findByEmail" resultMap="userResult">
+        select id, email, password_hash, is_active, created_at, updated_at
+        from users
+        where lower(email) = lower(#{email})
+    </select>
+
+    <insert id="insert">
+        insert into users (id, email, password_hash, is_active, created_at, updated_at)
+        values (
+            #{id, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler},
+            #{email},
+            #{passwordHash},
+            #{isActive},
+            #{createdAt},
+            #{updatedAt}
+        )
+    </insert>
+
+    <update id="updatePassword">
+        update users
+        set password_hash = #{passwordHash},
+            updated_at = #{updatedAt}
+        where id = #{id, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler}
+    </update>
+
+    <update id="updateActive">
+        update users
+        set is_active = #{isActive},
+            updated_at = #{updatedAt}
+        where id = #{id, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler}
+    </update>
+
+    <update id="touch">
+        update users
+        set updated_at = #{updatedAt}
+        where id = #{id, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler}
+    </update>
+</mapper>

--- a/apps/api-java/src/main/resources/mappers/UserRoleMapper.xml
+++ b/apps/api-java/src/main/resources/mappers/UserRoleMapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.homeputers.ebal2.api.domain.user.UserRoleMapper">
+    <select id="findRolesByUserId" resultType="java.lang.String">
+        select role
+        from user_roles
+        where user_id = #{userId, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler}
+        order by role
+    </select>
+
+    <insert id="insert">
+        insert into user_roles (user_id, role, created_at)
+        values (
+            #{userId, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler},
+            #{role},
+            #{createdAt}
+        )
+        on conflict (user_id, role) do nothing
+    </insert>
+
+    <delete id="delete">
+        delete from user_roles
+        where user_id = #{userId, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler}
+          and role = #{role}
+    </delete>
+</mapper>

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/seed/AdminSeederTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/seed/AdminSeederTest.java
@@ -1,0 +1,101 @@
+package com.homeputers.ebal2.api.seed;
+
+import com.homeputers.ebal2.api.domain.user.User;
+import com.homeputers.ebal2.api.domain.user.UserMapper;
+import com.homeputers.ebal2.api.domain.user.UserRoleMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.DefaultApplicationArguments;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminSeederTest {
+
+    @Mock
+    private UserMapper userMapper;
+
+    @Mock
+    private UserRoleMapper userRoleMapper;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    private final DefaultApplicationArguments arguments = new DefaultApplicationArguments(new String[0]);
+
+    @Test
+    void seedsDefaultAdminWhenMissing() throws Exception {
+        when(userMapper.findByEmail("admin@example.com")).thenReturn(null);
+        when(passwordEncoder.encode("Secret123!"))
+                .thenReturn("encoded-secret");
+
+        AdminSeeder seeder = new AdminSeeder(userMapper, userRoleMapper, passwordEncoder,
+                "  Admin@Example.com  ", "Secret123!");
+
+        seeder.run(arguments);
+
+        verify(userMapper).findByEmail("admin@example.com");
+        ArgumentCaptor<String> emailCaptor = ArgumentCaptor.forClass(String.class);
+        verify(userMapper).insert(any(UUID.class), emailCaptor.capture(), eq("encoded-secret"), eq(true), any(), any());
+        assertThat(emailCaptor.getValue()).isEqualTo("admin@example.com");
+        verify(userRoleMapper).insert(any(UUID.class), eq("ADMIN"), any());
+        verify(passwordEncoder).encode("Secret123!");
+    }
+
+    @Test
+    void reactivatesAndAssignsRoleForExistingUser() throws Exception {
+        UUID userId = UUID.randomUUID();
+        OffsetDateTime createdAt = OffsetDateTime.now().minusDays(1);
+        User existing = new User(userId, "admin@example.com", "hash", false, createdAt, createdAt);
+        when(userMapper.findByEmail("admin@example.com")).thenReturn(existing);
+        when(userRoleMapper.findRolesByUserId(userId)).thenReturn(List.of("VIEWER"));
+
+        AdminSeeder seeder = new AdminSeeder(userMapper, userRoleMapper, passwordEncoder,
+                "admin@example.com", "Secret123!");
+
+        seeder.run(arguments);
+
+        verify(userMapper).findByEmail("admin@example.com");
+        verify(userMapper).updateActive(eq(userId), eq(true), any());
+        verify(userRoleMapper).findRolesByUserId(userId);
+        verify(userRoleMapper).insert(eq(userId), eq("ADMIN"), any());
+        verify(passwordEncoder, never()).encode(anyString());
+    }
+
+    @Test
+    void keepsExistingAdminUntouched() throws Exception {
+        UUID userId = UUID.randomUUID();
+        OffsetDateTime createdAt = OffsetDateTime.now().minusDays(2);
+        User existing = new User(userId, "admin@example.com", "hash", true, createdAt, createdAt);
+        when(userMapper.findByEmail("admin@example.com")).thenReturn(existing);
+        when(userRoleMapper.findRolesByUserId(userId)).thenReturn(List.of("ADMIN", "PLANNER"));
+
+        AdminSeeder seeder = new AdminSeeder(userMapper, userRoleMapper, passwordEncoder,
+                "admin@example.com", "Secret123!");
+
+        seeder.run(arguments);
+
+        verify(userMapper).findByEmail("admin@example.com");
+        verify(userMapper, never()).updateActive(any(UUID.class), anyBoolean(), any());
+        verify(userRoleMapper).findRolesByUserId(userId);
+        verify(userRoleMapper, never()).insert(any(UUID.class), anyString(), any());
+        verify(passwordEncoder, never()).encode(anyString());
+        verifyNoMoreInteractions(userMapper);
+    }
+}


### PR DESCRIPTION
## Summary
- add a Flyway migration that normalizes user emails, adds account metadata, and creates the user_roles, password_resets, and refresh_tokens tables
- add domain models plus MyBatis mappers for users, roles, password reset tokens, and refresh tokens
- seed a configurable default admin account and document the seed environment variables

## Testing
- mvn verify *(fails: network is unreachable when resolving Maven artifacts)*

- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [x] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [x] Feature flags respected (`ebal.*`)
- [x] Docs updated (`README.md` or `/docs/*`)

------
https://chatgpt.com/codex/tasks/task_e_68cdfb0b4f788330b5ba85309fbf02d2