### PR TITLE
feat: add stateless jwt authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,28 @@ The API seeds the user with a BCrypt password hash and grants the `ADMIN` role
 when the account does not already exist. Existing accounts are reactivated and
 granted the admin role if necessary.
 
+### Authentication configuration
+
+JWT-based authentication is enabled by default. Configure the secrets and
+allowed web origins through environment variables before starting the API:
+
+```dotenv
+EBAL_JWT_SECRET=replace-with-a-64-char-minimum-random-string
+EBAL_WEB_ORIGIN_DEV=http://localhost:5173
+EBAL_WEB_ORIGIN_PROD=https://app.example.com
+```
+
+Optional overrides:
+
+```dotenv
+EBAL_SECURITY_ENABLED=true             # set to false to disable auth entirely
+EBAL_JWT_ACCESS_TTL=PT15M              # ISO-8601 duration for access tokens
+EBAL_JWT_REFRESH_TTL=P30D              # ISO-8601 duration for refresh tokens
+```
+
+Refresh tokens are persisted and revoked automatically when passwords are
+changed or reset.
+
 ## Service calendar export
 
 The API provides a read-only iCalendar feed of upcoming services at

--- a/apps/api-java/pom.xml
+++ b/apps/api-java/pom.xml
@@ -30,6 +30,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/ApiExceptionHandler.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/ApiExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.homeputers.ebal2.api;
 
+import com.homeputers.ebal2.api.auth.InvalidCredentialsException;
+import com.homeputers.ebal2.api.auth.InvalidRefreshTokenException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.validation.FieldError;
@@ -26,6 +28,13 @@ public class ApiExceptionHandler {
     @ExceptionHandler(NoSuchElementException.class)
     public ProblemDetail handleNotFound(NoSuchElementException ex) {
         ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    @ExceptionHandler({InvalidCredentialsException.class, InvalidRefreshTokenException.class})
+    public ProblemDetail handleUnauthorized(RuntimeException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.UNAUTHORIZED);
         pd.setDetail(ex.getMessage());
         return pd;
     }

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/auth/AuthService.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/auth/AuthService.java
@@ -1,0 +1,106 @@
+package com.homeputers.ebal2.api.auth;
+
+import com.homeputers.ebal2.api.config.SecurityProperties;
+import com.homeputers.ebal2.api.domain.user.RefreshToken;
+import com.homeputers.ebal2.api.domain.user.User;
+import com.homeputers.ebal2.api.domain.user.UserMapper;
+import com.homeputers.ebal2.api.domain.user.UserRoleMapper;
+import com.homeputers.ebal2.api.generated.model.AuthTokenPair;
+import com.homeputers.ebal2.api.security.JwtTokenService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+@Service
+public class AuthService {
+
+    private final UserMapper userMapper;
+    private final UserRoleMapper userRoleMapper;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenService jwtTokenService;
+    private final RefreshTokenService refreshTokenService;
+    private final SecurityProperties securityProperties;
+
+    public AuthService(UserMapper userMapper,
+                       UserRoleMapper userRoleMapper,
+                       PasswordEncoder passwordEncoder,
+                       JwtTokenService jwtTokenService,
+                       RefreshTokenService refreshTokenService,
+                       SecurityProperties securityProperties) {
+        this.userMapper = userMapper;
+        this.userRoleMapper = userRoleMapper;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtTokenService = jwtTokenService;
+        this.refreshTokenService = refreshTokenService;
+        this.securityProperties = securityProperties;
+    }
+
+    public AuthTokenPair login(String email, String password, String userAgent, String ipAddress) {
+        refreshTokenService.deleteExpired();
+        User user = findActiveUser(email);
+        if (!passwordEncoder.matches(password, user.passwordHash())) {
+            throw new InvalidCredentialsException();
+        }
+        List<String> roles = userRoleMapper.findRolesByUserId(user.id());
+        return issueTokens(user, roles, userAgent, ipAddress);
+    }
+
+    public AuthTokenPair refresh(String refreshTokenValue, String userAgent, String ipAddress) {
+        refreshTokenService.deleteExpired();
+        RefreshToken existing = refreshTokenService.findActive(refreshTokenValue)
+                .orElseThrow(InvalidRefreshTokenException::new);
+
+        User user = userMapper.findById(existing.userId());
+        if (user == null || !user.isActive()) {
+            refreshTokenService.revoke(refreshTokenValue);
+            throw new InvalidRefreshTokenException();
+        }
+
+        refreshTokenService.revoke(existing.token());
+        List<String> roles = userRoleMapper.findRolesByUserId(user.id());
+        return issueTokens(user, roles, userAgent, ipAddress);
+    }
+
+    public void changePassword(String email, String currentPassword, String newPassword) {
+        User user = findActiveUser(email);
+        if (!passwordEncoder.matches(currentPassword, user.passwordHash())) {
+            throw new InvalidCredentialsException();
+        }
+        OffsetDateTime now = OffsetDateTime.now();
+        String newHash = passwordEncoder.encode(newPassword);
+        userMapper.updatePassword(user.id(), newHash, now);
+        refreshTokenService.revokeAllForUser(user.id());
+    }
+
+    private AuthTokenPair issueTokens(User user, List<String> roles, String userAgent, String ipAddress) {
+        RefreshToken refreshToken = refreshTokenService.create(user.id(), userAgent, ipAddress);
+        String accessToken = jwtTokenService.createAccessToken(user.id(), user.email(), roles);
+
+        AuthTokenPair tokenPair = new AuthTokenPair();
+        tokenPair.setAccessToken(accessToken);
+        tokenPair.setRefreshToken(refreshToken.token());
+        tokenPair.setExpiresIn(Math.toIntExact(securityProperties.getJwt().getAccessTokenTtl().toSeconds()));
+        return tokenPair;
+    }
+
+    private User findActiveUser(String email) {
+        if (!StringUtils.hasText(email)) {
+            throw new InvalidCredentialsException();
+        }
+        String normalizedEmail = normalizeEmail(email);
+        User user = userMapper.findByEmail(normalizedEmail);
+        if (user == null || !user.isActive()) {
+            throw new InvalidCredentialsException();
+        }
+        return user;
+    }
+
+    private String normalizeEmail(String email) {
+        return Objects.requireNonNull(email).trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/auth/InvalidCredentialsException.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/auth/InvalidCredentialsException.java
@@ -1,0 +1,7 @@
+package com.homeputers.ebal2.api.auth;
+
+public class InvalidCredentialsException extends RuntimeException {
+    public InvalidCredentialsException() {
+        super("Invalid email or password.");
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/auth/InvalidRefreshTokenException.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/auth/InvalidRefreshTokenException.java
@@ -1,0 +1,7 @@
+package com.homeputers.ebal2.api.auth;
+
+public class InvalidRefreshTokenException extends RuntimeException {
+    public InvalidRefreshTokenException() {
+        super("Refresh token is invalid or has expired.");
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/auth/RefreshTokenService.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/auth/RefreshTokenService.java
@@ -1,0 +1,55 @@
+package com.homeputers.ebal2.api.auth;
+
+import com.homeputers.ebal2.api.config.SecurityProperties;
+import com.homeputers.ebal2.api.domain.user.RefreshToken;
+import com.homeputers.ebal2.api.domain.user.RefreshTokenMapper;
+import org.springframework.stereotype.Service;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class RefreshTokenService {
+
+    private final RefreshTokenMapper refreshTokenMapper;
+    private final SecurityProperties securityProperties;
+
+    public RefreshTokenService(RefreshTokenMapper refreshTokenMapper, SecurityProperties securityProperties) {
+        this.refreshTokenMapper = refreshTokenMapper;
+        this.securityProperties = securityProperties;
+    }
+
+    public RefreshToken create(UUID userId, String userAgent, String ipAddress) {
+        OffsetDateTime now = OffsetDateTime.now();
+        OffsetDateTime expiresAt = now.plus(securityProperties.getJwt().getRefreshTokenTtl());
+        String token = UUID.randomUUID().toString();
+        refreshTokenMapper.insert(token, userId, expiresAt, now, userAgent, ipAddress);
+        return new RefreshToken(token, userId, expiresAt, null, now, userAgent, ipAddress);
+    }
+
+    public Optional<RefreshToken> findActive(String tokenValue) {
+        RefreshToken token = refreshTokenMapper.findByToken(tokenValue);
+        if (token == null) {
+            return Optional.empty();
+        }
+        boolean expired = token.expiresAt() != null && token.expiresAt().isBefore(OffsetDateTime.now());
+        boolean revoked = token.revokedAt() != null;
+        if (expired || revoked) {
+            return Optional.empty();
+        }
+        return Optional.of(token);
+    }
+
+    public void revoke(String tokenValue) {
+        refreshTokenMapper.revoke(tokenValue, OffsetDateTime.now());
+    }
+
+    public void revokeAllForUser(UUID userId) {
+        refreshTokenMapper.revokeByUserId(userId, OffsetDateTime.now());
+    }
+
+    public void deleteExpired() {
+        refreshTokenMapper.deleteExpired(OffsetDateTime.now());
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/SecurityConfig.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/SecurityConfig.java
@@ -1,69 +1,166 @@
 package com.homeputers.ebal2.api.config;
 
+import com.homeputers.ebal2.api.security.ApiAccessDeniedHandler;
+import com.homeputers.ebal2.api.security.ApiAuthenticationEntryPoint;
+import com.homeputers.ebal2.api.security.JwtAuthenticationConverter;
+import com.nimbusds.jose.jwk.source.ImmutableSecret;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationTrustResolver;
 import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
-import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.context.DelegatingSecurityContextRepository;
-import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
-import org.springframework.security.web.context.RequestAttributeSecurityContextRepository;
-import org.springframework.security.web.context.SecurityContextRepository;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 
 @Configuration
 @EnableWebSecurity
+@EnableConfigurationProperties(SecurityProperties.class)
 public class SecurityConfig {
 
-    private static final String[] PUBLIC_ENDPOINTS = {"/api/**", "/actuator/**"};
+    private static final String[] AUTH_PUBLIC_ENDPOINTS = {
+            "/api/v1/auth/login",
+            "/api/v1/auth/refresh",
+            "/api/v1/auth/forgot-password",
+            "/api/v1/auth/reset-password"
+    };
+
+    private static final String[] PUBLIC_GET_ENDPOINTS = {
+            "/api/v1/health",
+            "/api/v1/storage/health",
+            "/api/v1/services/ical"
+    };
+
+    private static final String[] SWAGGER_ENDPOINTS = {
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html"
+    };
+
+    private static final String[] DOMAIN_ENDPOINTS = {
+            "/api/v1/members/**",
+            "/api/v1/groups/**",
+            "/api/v1/songs/**",
+            "/api/v1/services/**",
+            "/api/v1/song-sets/**",
+            "/api/v1/song-set-items/**",
+            "/api/v1/service-plan-items/**",
+            "/api/v1/search"
+    };
 
     @Bean
-    SecurityFilterChain securityFilterChain(HttpSecurity http, SecurityContextRepository securityContextRepository)
-            throws Exception {
-        http
-                .csrf(AbstractHttpConfigurer::disable)
-                .securityContext(context -> context.securityContextRepository(securityContextRepository))
-                .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
-                        .anyRequest().permitAll())
+    SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                            SecurityProperties properties,
+                                            ApiAuthenticationEntryPoint authenticationEntryPoint,
+                                            ApiAccessDeniedHandler accessDeniedHandler,
+                                            JwtAuthenticationConverter jwtAuthenticationConverter,
+                                            CorsConfigurationSource corsConfigurationSource) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
-        // When the security flag is enabled we can require authentication by swapping the authorizations
-        // above for authenticated() and adjusting the session policy. For OIDC, call oauth2Login() and
-        // provide a ClientRegistrationRepository bean.
+
+        if (!properties.isEnabled()) {
+            http.oauth2ResourceServer(OAuth2ResourceServerConfigurer::disable)
+                    .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll());
+            return http.build();
+        }
+
+        http.authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .requestMatchers(SWAGGER_ENDPOINTS).permitAll()
+                        .requestMatchers(AUTH_PUBLIC_ENDPOINTS).permitAll()
+                        .requestMatchers(HttpMethod.GET, PUBLIC_GET_ENDPOINTS).permitAll()
+                        .requestMatchers("/api/v1/auth/change-password", "/api/v1/auth/me").authenticated()
+                        .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.GET, DOMAIN_ENDPOINTS)
+                        .hasAnyRole("ADMIN", "PLANNER", "MUSICIAN", "VIEWER")
+                        .requestMatchers(HttpMethod.POST, DOMAIN_ENDPOINTS)
+                        .hasAnyRole("ADMIN", "PLANNER")
+                        .requestMatchers(HttpMethod.PUT, DOMAIN_ENDPOINTS)
+                        .hasAnyRole("ADMIN", "PLANNER")
+                        .requestMatchers(HttpMethod.PATCH, DOMAIN_ENDPOINTS)
+                        .hasAnyRole("ADMIN", "PLANNER")
+                        .requestMatchers(HttpMethod.DELETE, DOMAIN_ENDPOINTS)
+                        .hasAnyRole("ADMIN", "PLANNER")
+                        .anyRequest().authenticated())
+                .oauth2ResourceServer(oauth -> oauth
+                        .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter))
+                        .authenticationEntryPoint(authenticationEntryPoint))
+                .exceptionHandling(exceptions -> exceptions
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler));
+
         return http.build();
     }
 
     @Bean
-    SecurityContextRepository securityContextRepository() {
-        // Delegating repository keeps request-scoped auth today and allows flipping to HttpSession-based
-        // persistence without rewriting the filter chain once session authentication is enabled.
-        return new DelegatingSecurityContextRepository(
-                new RequestAttributeSecurityContextRepository(),
-                new HttpSessionSecurityContextRepository());
+    CorsConfigurationSource corsConfigurationSource(SecurityProperties properties) {
+        CorsConfiguration configuration = new CorsConfiguration();
+        List<String> allowedOrigins = properties.getCors().getAllowedOrigins();
+        configuration.setAllowedOrigins(allowedOrigins);
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "Accept", "Origin", "X-Requested-With"));
+        configuration.setExposedHeaders(List.of("Authorization"));
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(Duration.ofHours(1));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 
     @Bean
-    AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
-        // Expose AuthenticationManager so session logins or an OAuth2 login controller can inject it later.
-        return configuration.getAuthenticationManager();
+    JwtDecoder jwtDecoder(SecurityProperties properties) {
+        SecretKey secretKey = secretKey(properties);
+        return NimbusJwtDecoder.withSecretKey(secretKey)
+                .macAlgorithm(MacAlgorithm.HS512)
+                .build();
+    }
+
+    @Bean
+    JwtEncoder jwtEncoder(SecurityProperties properties) {
+        SecretKey secretKey = secretKey(properties);
+        return new NimbusJwtEncoder(new ImmutableSecret<>(secretKey));
+    }
+
+    @Bean
+    JwtAuthenticationConverter jwtAuthenticationConverter() {
+        return new JwtAuthenticationConverter();
     }
 
     @Bean
     AuthenticationTrustResolver authenticationTrustResolver() {
-        // Allows collaborators like CurrentUserFactory to detect anonymous tokens while keeping the bean overrideable
-        // for future OIDC-specific trust resolvers.
         return new AuthenticationTrustResolverImpl();
     }
 
     @Bean
     PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
+        return new BCryptPasswordEncoder(12);
+    }
+
+    private SecretKey secretKey(SecurityProperties properties) {
+        byte[] keyBytes = properties.getJwt().getSecret().getBytes(StandardCharsets.UTF_8);
+        return new SecretKeySpec(keyBytes, "HmacSHA512");
     }
 }

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/SecurityProperties.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/SecurityProperties.java
@@ -1,0 +1,109 @@
+package com.homeputers.ebal2.api.config;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Stream;
+
+@ConfigurationProperties("ebal.security")
+@Validated
+public class SecurityProperties {
+
+    private boolean enabled = true;
+    private final Cors cors = new Cors();
+    private final Jwt jwt = new Jwt();
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Cors getCors() {
+        return cors;
+    }
+
+    public Jwt getJwt() {
+        return jwt;
+    }
+
+    public static class Cors {
+        private String devOrigin;
+        private String prodOrigin;
+
+        public String getDevOrigin() {
+            return devOrigin;
+        }
+
+        public void setDevOrigin(String devOrigin) {
+            this.devOrigin = devOrigin;
+        }
+
+        public String getProdOrigin() {
+            return prodOrigin;
+        }
+
+        public void setProdOrigin(String prodOrigin) {
+            this.prodOrigin = prodOrigin;
+        }
+
+        public List<String> getAllowedOrigins() {
+            return Stream.of(devOrigin, prodOrigin)
+                    .filter(origin -> origin != null && !origin.isBlank())
+                    .distinct()
+                    .toList();
+        }
+    }
+
+    public static class Jwt {
+        @NotBlank
+        private String secret;
+        private Duration accessTokenTtl = Duration.ofMinutes(15);
+        private Duration refreshTokenTtl = Duration.ofDays(30);
+
+        public String getSecret() {
+            return secret;
+        }
+
+        public void setSecret(String secret) {
+            this.secret = secret;
+        }
+
+        public Duration getAccessTokenTtl() {
+            return accessTokenTtl;
+        }
+
+        public void setAccessTokenTtl(Duration accessTokenTtl) {
+            this.accessTokenTtl = accessTokenTtl;
+        }
+
+        public Duration getRefreshTokenTtl() {
+            return refreshTokenTtl;
+        }
+
+        public void setRefreshTokenTtl(Duration refreshTokenTtl) {
+            this.refreshTokenTtl = refreshTokenTtl;
+        }
+
+        @AssertTrue(message = "JWT secret must be at least 64 characters long")
+        public boolean isSecretStrongEnough() {
+            return secret != null && secret.length() >= 64;
+        }
+
+        @AssertTrue(message = "Access token TTL must be positive")
+        public boolean isAccessTtlPositive() {
+            return accessTokenTtl != null && !accessTokenTtl.isNegative() && !accessTokenTtl.isZero();
+        }
+
+        @AssertTrue(message = "Refresh token TTL must be positive")
+        public boolean isRefreshTtlPositive() {
+            return refreshTokenTtl != null && !refreshTokenTtl.isNegative() && !refreshTokenTtl.isZero();
+        }
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/RefreshTokenMapper.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/RefreshTokenMapper.java
@@ -20,5 +20,8 @@ public interface RefreshTokenMapper {
     void revoke(@Param("token") String token,
                 @Param("revokedAt") OffsetDateTime revokedAt);
 
+    void revokeByUserId(@Param("userId") UUID userId,
+                        @Param("revokedAt") OffsetDateTime revokedAt);
+
     void deleteExpired(@Param("now") OffsetDateTime now);
 }

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/security/ApiAccessDeniedHandler.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/security/ApiAccessDeniedHandler.java
@@ -1,0 +1,30 @@
+package com.homeputers.ebal2.api.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class ApiAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ProblemDetailHttpWriter writer;
+
+    public ApiAccessDeniedHandler(ProblemDetailHttpWriter writer) {
+        this.writer = writer;
+    }
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.FORBIDDEN);
+        problemDetail.setDetail("You do not have permission to perform this action.");
+        writer.write(response, problemDetail);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/security/ApiAuthenticationEntryPoint.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/security/ApiAuthenticationEntryPoint.java
@@ -1,0 +1,30 @@
+package com.homeputers.ebal2.api.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class ApiAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ProblemDetailHttpWriter writer;
+
+    public ApiAuthenticationEntryPoint(ProblemDetailHttpWriter writer) {
+        this.writer = writer;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.UNAUTHORIZED);
+        problemDetail.setDetail("Authentication is required to access this resource.");
+        writer.write(response, problemDetail);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/security/JwtAuthenticationConverter.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/security/JwtAuthenticationConverter.java
@@ -1,0 +1,38 @@
+package com.homeputers.ebal2.api.security;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+public class JwtAuthenticationConverter implements Converter<Jwt, AbstractAuthenticationToken> {
+
+    @Override
+    public AbstractAuthenticationToken convert(Jwt jwt) {
+        Collection<GrantedAuthority> authorities = extractAuthorities(jwt);
+        String principalName = jwt.getClaimAsString("email");
+        if (principalName == null || principalName.isBlank()) {
+            principalName = jwt.getSubject();
+        }
+        return new JwtAuthenticationToken(jwt, authorities, principalName);
+    }
+
+    private Collection<GrantedAuthority> extractAuthorities(Jwt jwt) {
+        List<String> roles = jwt.getClaimAsStringList("roles");
+        if (roles == null) {
+            return List.of();
+        }
+        return roles.stream()
+                .filter(role -> role != null && !role.isBlank())
+                .map(role -> role.startsWith("ROLE_") ? role : "ROLE_" + role.toUpperCase(Locale.ROOT))
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toUnmodifiableList());
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/security/JwtTokenService.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/security/JwtTokenService.java
@@ -1,0 +1,42 @@
+package com.homeputers.ebal2.api.security;
+
+import com.homeputers.ebal2.api.config.SecurityProperties;
+import org.springframework.security.oauth2.jose.jws.JwsHeader;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class JwtTokenService {
+
+    private final JwtEncoder jwtEncoder;
+    private final SecurityProperties securityProperties;
+
+    public JwtTokenService(JwtEncoder jwtEncoder, SecurityProperties securityProperties) {
+        this.jwtEncoder = jwtEncoder;
+        this.securityProperties = securityProperties;
+    }
+
+    public String createAccessToken(UUID userId, String email, List<String> roles) {
+        Instant now = Instant.now();
+        Instant expiresAt = now.plus(securityProperties.getJwt().getAccessTokenTtl());
+
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+                .subject(userId.toString())
+                .claim("email", email)
+                .claim("roles", roles)
+                .issuedAt(now)
+                .expiresAt(expiresAt)
+                .id(UUID.randomUUID().toString())
+                .build();
+
+        JwsHeader jwsHeader = JwsHeader.with(MacAlgorithm.HS512).build();
+        return jwtEncoder.encode(JwtEncoderParameters.from(jwsHeader, claims)).getTokenValue();
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/security/JwtTokenService.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/security/JwtTokenService.java
@@ -1,11 +1,11 @@
 package com.homeputers.ebal2.api.security;
 
 import com.homeputers.ebal2.api.config.SecurityProperties;
-import org.springframework.security.oauth2.jose.jws.JwsHeader;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jwt.JwtClaimsSet;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.security.oauth2.jwt.JwsHeader;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/security/ProblemDetailHttpWriter.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/security/ProblemDetailHttpWriter.java
@@ -1,0 +1,27 @@
+package com.homeputers.ebal2.api.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class ProblemDetailHttpWriter {
+
+    private final ObjectMapper objectMapper;
+
+    public ProblemDetailHttpWriter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public void write(HttpServletResponse response, ProblemDetail problemDetail) throws IOException {
+        response.setStatus(problemDetail.getStatus());
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE);
+        objectMapper.writeValue(response.getWriter(), problemDetail);
+    }
+}

--- a/apps/api-java/src/main/resources/application.yaml
+++ b/apps/api-java/src/main/resources/application.yaml
@@ -12,6 +12,15 @@ mybatis:
     map-underscore-to-camel-case: true
 
 ebal:
+  security:
+    enabled: ${EBAL_SECURITY_ENABLED:true}
+    cors:
+      dev-origin: ${EBAL_WEB_ORIGIN_DEV:http://localhost:5173}
+      prod-origin: ${EBAL_WEB_ORIGIN_PROD:}
+    jwt:
+      secret: ${EBAL_JWT_SECRET:ThisIsADefaultJwtSecretForLocalDevOnly_DoNotUseInProduction_ButItIsLongEnough1234}
+      access-token-ttl: ${EBAL_JWT_ACCESS_TTL:PT15M}
+      refresh-token-ttl: ${EBAL_JWT_REFRESH_TTL:P30D}
   otel:
     enabled: ${EBAL_OTEL_ENABLED:false}
     exporter:

--- a/apps/api-java/src/main/resources/mappers/RefreshTokenMapper.xml
+++ b/apps/api-java/src/main/resources/mappers/RefreshTokenMapper.xml
@@ -38,6 +38,13 @@
         where token = #{token}
     </update>
 
+    <update id="revokeByUserId">
+        update refresh_tokens
+        set revoked_at = #{revokedAt}
+        where user_id = #{userId, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler}
+          and revoked_at IS NULL
+    </update>
+
     <delete id="deleteExpired">
         delete from refresh_tokens
         where expires_at &lt; #{now}

--- a/apps/api-java/src/main/resources/mappers/UserMapper.xml
+++ b/apps/api-java/src/main/resources/mappers/UserMapper.xml
@@ -7,7 +7,7 @@
                    typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler"/>
             <arg column="email" javaType="java.lang.String"/>
             <arg column="password_hash" javaType="java.lang.String"/>
-            <arg column="is_active" javaType="boolean"/>
+            <arg column="is_active" javaType="_boolean"/>
             <arg column="created_at" javaType="java.time.OffsetDateTime"/>
             <arg column="updated_at" javaType="java.time.OffsetDateTime"/>
         </constructor>

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/AbstractIntegrationTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/AbstractIntegrationTest.java
@@ -21,5 +21,10 @@ public abstract class AbstractIntegrationTest {
         registry.add("spring.datasource.url", postgres::getJdbcUrl);
         registry.add("spring.datasource.username", postgres::getUsername);
         registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("ebal.security.enabled", () -> true);
+        registry.add("ebal.security.jwt.secret",
+                () -> "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF");
+        registry.add("ebal.security.cors.dev-origin", () -> "http://localhost:5173");
+        registry.add("ebal.security.cors.prod-origin", () -> "");
     }
 }

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/TestAuthenticationHelper.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/TestAuthenticationHelper.java
@@ -1,0 +1,80 @@
+package com.homeputers.ebal2.api;
+
+import com.homeputers.ebal2.api.domain.user.User;
+import com.homeputers.ebal2.api.domain.user.UserMapper;
+import com.homeputers.ebal2.api.domain.user.UserRoleMapper;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+
+@Component
+public class TestAuthenticationHelper {
+
+    private final UserMapper userMapper;
+    private final UserRoleMapper userRoleMapper;
+    private final PasswordEncoder passwordEncoder;
+
+    public TestAuthenticationHelper(UserMapper userMapper,
+                                    UserRoleMapper userRoleMapper,
+                                    PasswordEncoder passwordEncoder) {
+        this.userMapper = userMapper;
+        this.userRoleMapper = userRoleMapper;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public UUID ensureUser(String email, String password, List<String> roles) {
+        String normalizedEmail = normalizeEmail(email);
+        OffsetDateTime now = OffsetDateTime.now();
+        User existing = userMapper.findByEmail(normalizedEmail);
+        String passwordHash = passwordEncoder.encode(password);
+
+        if (existing == null) {
+            UUID userId = UUID.randomUUID();
+            userMapper.insert(userId, normalizedEmail, passwordHash, true, now, now);
+            assignRoles(userId, roles, now);
+            return userId;
+        }
+
+        userMapper.updatePassword(existing.id(), passwordHash, now);
+        userMapper.updateActive(existing.id(), true, now);
+        refreshRoles(existing.id(), roles, now);
+        return existing.id();
+    }
+
+    private void assignRoles(UUID userId, List<String> roles, OffsetDateTime now) {
+        for (String role : roles) {
+            userRoleMapper.insert(userId, normalizeRole(role), now);
+        }
+    }
+
+    private void refreshRoles(UUID userId, List<String> desiredRoles, OffsetDateTime now) {
+        Set<String> desired = desiredRoles.stream().map(this::normalizeRole).collect(HashSet::new, Set::add, Set::addAll);
+        Set<String> existing = new HashSet<>(userRoleMapper.findRolesByUserId(userId)
+                .stream().map(this::normalizeRole).toList());
+
+        for (String role : existing) {
+            if (!desired.contains(role)) {
+                userRoleMapper.delete(userId, role);
+            }
+        }
+        for (String role : desired) {
+            if (!existing.contains(role)) {
+                userRoleMapper.insert(userId, role, now);
+            }
+        }
+    }
+
+    private String normalizeEmail(String email) {
+        return email.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private String normalizeRole(String role) {
+        return role == null ? null : role.trim().toUpperCase(Locale.ROOT);
+    }
+}

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/auth/AuthControllerTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/auth/AuthControllerTest.java
@@ -1,21 +1,44 @@
 package com.homeputers.ebal2.api.auth;
 
 import com.homeputers.ebal2.api.AbstractIntegrationTest;
+import com.homeputers.ebal2.api.TestAuthenticationHelper;
+import com.homeputers.ebal2.api.generated.model.AuthLoginRequest;
+import com.homeputers.ebal2.api.generated.model.AuthTokenPair;
+import com.homeputers.ebal2.api.generated.model.ChangePasswordRequest;
+import com.homeputers.ebal2.api.generated.model.RefreshTokenRequest;
 import com.homeputers.ebal2.api.generated.model.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.ProblemDetail;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class AuthControllerTest extends AbstractIntegrationTest {
 
+    private static final String EMAIL = "planner@example.com";
+    private static final String PASSWORD = "Secret123!";
+
     @Autowired
     private TestRestTemplate restTemplate;
+
+    @Autowired
+    private TestAuthenticationHelper authenticationHelper;
+
+    @Autowired
+    private JwtDecoder jwtDecoder;
 
     @Test
     void returnsUnauthorizedWhenAnonymous() {
@@ -23,5 +46,114 @@ class AuthControllerTest extends AbstractIntegrationTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
         assertThat(response.getBody()).isNull();
+    }
+
+    @Test
+    void loginIssuesTokenPairAndAllowsCurrentUserLookup() {
+        authenticationHelper.ensureUser(EMAIL, PASSWORD, List.of("PLANNER"));
+
+        AuthTokenPair tokens = authenticate(EMAIL, PASSWORD);
+        assertThat(tokens.getAccessToken()).isNotBlank();
+        assertThat(tokens.getRefreshToken()).isNotBlank();
+        assertThat(tokens.getExpiresIn()).isPositive();
+
+        Jwt jwt = jwtDecoder.decode(tokens.getAccessToken());
+        assertThat(jwt.getClaimAsStringList("roles")).contains("PLANNER");
+        assertThat(jwt.getClaimAsString("email")).isEqualTo(EMAIL);
+
+        ResponseEntity<User> meResponse = restTemplate.exchange(
+                "/api/v1/auth/me",
+                HttpMethod.GET,
+                new HttpEntity<>(bearerHeaders(tokens.getAccessToken())),
+                User.class);
+
+        assertThat(meResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(meResponse.getBody()).isNotNull();
+        assertThat(meResponse.getBody().getEmail()).isEqualTo(EMAIL);
+    }
+
+    @Test
+    void refreshRotatesTokensAndRevokesOldRefreshToken() {
+        authenticationHelper.ensureUser(EMAIL, PASSWORD, List.of("PLANNER"));
+        AuthTokenPair initialTokens = authenticate(EMAIL, PASSWORD);
+
+        RefreshTokenRequest refreshTokenRequest = new RefreshTokenRequest();
+        refreshTokenRequest.setRefreshToken(initialTokens.getRefreshToken());
+        ResponseEntity<AuthTokenPair> refreshResponse = restTemplate.postForEntity(
+                "/api/v1/auth/refresh",
+                refreshTokenRequest,
+                AuthTokenPair.class);
+
+        assertThat(refreshResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        AuthTokenPair rotated = refreshResponse.getBody();
+        assertThat(rotated).isNotNull();
+        assertThat(rotated.getAccessToken()).isNotBlank();
+        assertThat(rotated.getRefreshToken()).isNotEqualTo(initialTokens.getRefreshToken());
+
+        ResponseEntity<ProblemDetail> reuseResponse = restTemplate.postForEntity(
+                "/api/v1/auth/refresh",
+                refreshTokenRequest,
+                ProblemDetail.class);
+
+        assertThat(reuseResponse.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void changePasswordRevokesRefreshTokensAndRequiresNewLogin() {
+        authenticationHelper.ensureUser(EMAIL, PASSWORD, List.of("PLANNER"));
+        AuthTokenPair initialTokens = authenticate(EMAIL, PASSWORD);
+
+        ChangePasswordRequest changePasswordRequest = new ChangePasswordRequest();
+        changePasswordRequest.setCurrentPassword(PASSWORD);
+        changePasswordRequest.setNewPassword("NewSecret123!");
+
+        HttpHeaders headers = bearerHeaders(initialTokens.getAccessToken());
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        ResponseEntity<Void> changePasswordResponse = restTemplate.exchange(
+                "/api/v1/auth/change-password",
+                HttpMethod.POST,
+                new HttpEntity<>(changePasswordRequest, headers),
+                Void.class);
+
+        assertThat(changePasswordResponse.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        RefreshTokenRequest refreshTokenRequest = new RefreshTokenRequest();
+        refreshTokenRequest.setRefreshToken(initialTokens.getRefreshToken());
+        ResponseEntity<ProblemDetail> refreshAfterChange = restTemplate.postForEntity(
+                "/api/v1/auth/refresh",
+                refreshTokenRequest,
+                ProblemDetail.class);
+        assertThat(refreshAfterChange.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+
+        AuthLoginRequest oldPasswordLogin = new AuthLoginRequest();
+        oldPasswordLogin.setEmail(EMAIL);
+        oldPasswordLogin.setPassword(PASSWORD);
+        ResponseEntity<ProblemDetail> oldPasswordResponse = restTemplate.postForEntity(
+                "/api/v1/auth/login",
+                oldPasswordLogin,
+                ProblemDetail.class);
+        assertThat(oldPasswordResponse.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+
+        AuthTokenPair newTokens = authenticate(EMAIL, "NewSecret123!");
+        assertThat(newTokens.getAccessToken()).isNotBlank();
+    }
+
+    private AuthTokenPair authenticate(String email, String password) {
+        AuthLoginRequest loginRequest = new AuthLoginRequest();
+        loginRequest.setEmail(email);
+        loginRequest.setPassword(password);
+        ResponseEntity<AuthTokenPair> response = restTemplate.postForEntity(
+                "/api/v1/auth/login",
+                loginRequest,
+                AuthTokenPair.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        return response.getBody();
+    }
+
+    private HttpHeaders bearerHeaders(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        return headers;
     }
 }

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/auth/AuthControllerTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/auth/AuthControllerTest.java
@@ -42,10 +42,11 @@ class AuthControllerTest extends AbstractIntegrationTest {
 
     @Test
     void returnsUnauthorizedWhenAnonymous() {
-        ResponseEntity<User> response = restTemplate.getForEntity("/api/v1/auth/me", User.class);
+        ResponseEntity<ProblemDetail> response = restTemplate.getForEntity("/api/v1/auth/me", ProblemDetail.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
-        assertThat(response.getBody()).isNull();
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getDetail()).isEqualTo("Authentication is required to access this resource.");
     }
 
     @Test

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/auth/CurrentUserFactoryTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/auth/CurrentUserFactoryTest.java
@@ -8,6 +8,8 @@ import org.springframework.security.authentication.AuthenticationTrustResolverIm
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 import java.util.List;
 import java.util.Optional;
@@ -54,5 +56,20 @@ class CurrentUserFactoryTest {
         assertThat(user.getIsActive()).isTrue();
         assertThat(user.getCreatedAt()).isNotNull();
         assertThat(user.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    void extractsEmailFromJwtAuthenticationToken() {
+        Jwt jwt = Jwt.withTokenValue("token")
+                .subject("3fa85f64-5717-4562-b3fc-2c963f66afa6")
+                .claim("email", "jwt-user@example.com")
+                .claim("roles", List.of("PLANNER"))
+                .build();
+        JwtAuthenticationToken authentication = new JwtAuthenticationToken(jwt, AuthorityUtils.createAuthorityList("ROLE_PLANNER"));
+
+        Optional<User> currentUser = factory.create(authentication);
+
+        assertThat(currentUser).isPresent();
+        assertThat(currentUser.get().getEmail()).isEqualTo("jwt-user@example.com");
     }
 }

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/auth/CurrentUserFactoryTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/auth/CurrentUserFactoryTest.java
@@ -61,6 +61,7 @@ class CurrentUserFactoryTest {
     @Test
     void extractsEmailFromJwtAuthenticationToken() {
         Jwt jwt = Jwt.withTokenValue("token")
+                .header("alg", "none")
                 .subject("3fa85f64-5717-4562-b3fc-2c963f66afa6")
                 .claim("email", "jwt-user@example.com")
                 .claim("roles", List.of("PLANNER"))

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/member/MemberControllerTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/member/MemberControllerTest.java
@@ -1,6 +1,9 @@
 package com.homeputers.ebal2.api.member;
 
 import com.homeputers.ebal2.api.AbstractIntegrationTest;
+import com.homeputers.ebal2.api.TestAuthenticationHelper;
+import com.homeputers.ebal2.api.generated.model.AuthLoginRequest;
+import com.homeputers.ebal2.api.generated.model.AuthTokenPair;
 import com.homeputers.ebal2.api.generated.model.MemberRequest;
 import com.homeputers.ebal2.api.generated.model.MemberResponse;
 import com.homeputers.ebal2.api.generated.model.PageMemberResponse;
@@ -8,6 +11,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -22,22 +28,35 @@ class MemberControllerTest extends AbstractIntegrationTest {
     @Autowired
     private TestRestTemplate restTemplate;
 
+    @Autowired
+    private TestAuthenticationHelper authenticationHelper;
+
     @Test
     void createAndGetMember() {
+        authenticationHelper.ensureUser("planner+member@example.com", "Secret123!", List.of("PLANNER"));
+        AuthTokenPair tokens = authenticate("planner+member@example.com", "Secret123!");
+        HttpHeaders headers = bearerHeaders(tokens.getAccessToken());
+
         MemberRequest request = new MemberRequest();
         request.setDisplayName("John Doe");
         request.setInstruments(List.of("guitar"));
 
-        ResponseEntity<MemberResponse> create =
-                restTemplate.postForEntity("/api/v1/members", request, MemberResponse.class);
+        ResponseEntity<MemberResponse> create = restTemplate.exchange(
+                "/api/v1/members",
+                HttpMethod.POST,
+                new HttpEntity<>(request, headers),
+                MemberResponse.class);
 
         assertThat(create.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         assertThat(create.getBody()).isNotNull();
         UUID id = create.getBody().getId();
         assertThat(id).isNotNull();
 
-        ResponseEntity<MemberResponse> get =
-                restTemplate.getForEntity("/api/v1/members/" + id, MemberResponse.class);
+        ResponseEntity<MemberResponse> get = restTemplate.exchange(
+                "/api/v1/members/" + id,
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                MemberResponse.class);
         assertThat(get.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(get.getBody()).isNotNull();
         assertThat(get.getBody().getDisplayName()).isEqualTo("John Doe");
@@ -45,15 +64,49 @@ class MemberControllerTest extends AbstractIntegrationTest {
 
     @Test
     void listMembers() {
+        authenticationHelper.ensureUser("planner+memberlist@example.com", "Secret123!", List.of("PLANNER"));
+        AuthTokenPair plannerTokens = authenticate("planner+memberlist@example.com", "Secret123!");
+        HttpHeaders plannerHeaders = bearerHeaders(plannerTokens.getAccessToken());
+
         MemberRequest request = new MemberRequest();
         request.setDisplayName("Jane");
-        restTemplate.postForEntity("/api/v1/members", request, MemberResponse.class);
+        restTemplate.exchange(
+                "/api/v1/members",
+                HttpMethod.POST,
+                new HttpEntity<>(request, plannerHeaders),
+                MemberResponse.class);
 
-        ResponseEntity<PageMemberResponse> response =
-                restTemplate.getForEntity("/api/v1/members?q=ja&page=0&size=10", PageMemberResponse.class);
+        authenticationHelper.ensureUser("viewer+memberlist@example.com", "Secret123!", List.of("VIEWER"));
+        AuthTokenPair viewerTokens = authenticate("viewer+memberlist@example.com", "Secret123!");
+        HttpHeaders viewerHeaders = bearerHeaders(viewerTokens.getAccessToken());
+
+        ResponseEntity<PageMemberResponse> response = restTemplate.exchange(
+                "/api/v1/members?q=ja&page=0&size=10",
+                HttpMethod.GET,
+                new HttpEntity<>(viewerHeaders),
+                PageMemberResponse.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().getContent()).isNotEmpty();
+    }
+
+    private AuthTokenPair authenticate(String email, String password) {
+        AuthLoginRequest loginRequest = new AuthLoginRequest();
+        loginRequest.setEmail(email);
+        loginRequest.setPassword(password);
+        ResponseEntity<AuthTokenPair> response = restTemplate.postForEntity(
+                "/api/v1/auth/login",
+                loginRequest,
+                AuthTokenPair.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        return response.getBody();
+    }
+
+    private HttpHeaders bearerHeaders(String token) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        return headers;
     }
 }

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/search/SearchControllerTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/search/SearchControllerTest.java
@@ -1,6 +1,9 @@
 package com.homeputers.ebal2.api.search;
 
 import com.homeputers.ebal2.api.AbstractIntegrationTest;
+import com.homeputers.ebal2.api.TestAuthenticationHelper;
+import com.homeputers.ebal2.api.generated.model.AuthLoginRequest;
+import com.homeputers.ebal2.api.generated.model.AuthTokenPair;
 import com.homeputers.ebal2.api.generated.model.MemberRequest;
 import com.homeputers.ebal2.api.generated.model.MemberResponse;
 import com.homeputers.ebal2.api.generated.model.SearchResult;
@@ -12,6 +15,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -26,23 +32,49 @@ class SearchControllerTest extends AbstractIntegrationTest {
     @Autowired
     private TestRestTemplate restTemplate;
 
+    @Autowired
+    private TestAuthenticationHelper authenticationHelper;
+
     @Test
     void searchAcrossEntities() {
+        authenticationHelper.ensureUser("planner+search@example.com", "Secret123!", List.of("PLANNER"));
+        AuthTokenPair plannerTokens = authenticate("planner+search@example.com", "Secret123!");
+        HttpHeaders plannerHeaders = bearerHeaders(plannerTokens.getAccessToken());
+
         MemberRequest mr = new MemberRequest();
         mr.setDisplayName("Searchy Person");
-        restTemplate.postForEntity("/api/v1/members", mr, MemberResponse.class);
+        restTemplate.exchange(
+                "/api/v1/members",
+                HttpMethod.POST,
+                new HttpEntity<>(mr, plannerHeaders),
+                MemberResponse.class);
 
         SongRequest sr = new SongRequest();
         sr.setTitle("Searchy Song");
-        restTemplate.postForEntity("/api/v1/songs", sr, SongResponse.class);
+        restTemplate.exchange(
+                "/api/v1/songs",
+                HttpMethod.POST,
+                new HttpEntity<>(sr, plannerHeaders),
+                SongResponse.class);
 
         ServiceRequest svcReq = new ServiceRequest();
         svcReq.setStartsAt(OffsetDateTime.now().plusDays(1));
         svcReq.setLocation("Search Hall");
-        restTemplate.postForEntity("/api/v1/services", svcReq, ServiceResponse.class);
+        restTemplate.exchange(
+                "/api/v1/services",
+                HttpMethod.POST,
+                new HttpEntity<>(svcReq, plannerHeaders),
+                ServiceResponse.class);
 
-        ResponseEntity<SearchResult[]> response =
-                restTemplate.getForEntity("/api/v1/search?q=Search", SearchResult[].class);
+        authenticationHelper.ensureUser("viewer+search@example.com", "Secret123!", List.of("VIEWER"));
+        AuthTokenPair viewerTokens = authenticate("viewer+search@example.com", "Secret123!");
+        HttpHeaders viewerHeaders = bearerHeaders(viewerTokens.getAccessToken());
+
+        ResponseEntity<SearchResult[]> response = restTemplate.exchange(
+                "/api/v1/search?q=Search",
+                HttpMethod.GET,
+                new HttpEntity<>(viewerHeaders),
+                SearchResult[].class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
@@ -52,5 +84,23 @@ class SearchControllerTest extends AbstractIntegrationTest {
                         SearchResult.KindEnum.SONG,
                         SearchResult.KindEnum.SERVICE);
     }
-}
 
+    private AuthTokenPair authenticate(String email, String password) {
+        AuthLoginRequest loginRequest = new AuthLoginRequest();
+        loginRequest.setEmail(email);
+        loginRequest.setPassword(password);
+        ResponseEntity<AuthTokenPair> response = restTemplate.postForEntity(
+                "/api/v1/auth/login",
+                loginRequest,
+                AuthTokenPair.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        return response.getBody();
+    }
+
+    private HttpHeaders bearerHeaders(String token) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        return headers;
+    }
+}

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/song/SongControllerTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/song/SongControllerTest.java
@@ -1,14 +1,22 @@
 package com.homeputers.ebal2.api.song;
 
 import com.homeputers.ebal2.api.AbstractIntegrationTest;
+import com.homeputers.ebal2.api.TestAuthenticationHelper;
+import com.homeputers.ebal2.api.generated.model.AuthLoginRequest;
+import com.homeputers.ebal2.api.generated.model.AuthTokenPair;
 import com.homeputers.ebal2.api.generated.model.SongRequest;
 import com.homeputers.ebal2.api.generated.model.SongResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -18,13 +26,23 @@ class SongControllerTest extends AbstractIntegrationTest {
     @Autowired
     private TestRestTemplate restTemplate;
 
+    @Autowired
+    private TestAuthenticationHelper authenticationHelper;
+
     @Test
     void createSong() {
+        authenticationHelper.ensureUser("planner+song@example.com", "Secret123!", List.of("PLANNER"));
+        AuthTokenPair tokens = authenticate("planner+song@example.com", "Secret123!");
+        HttpHeaders headers = bearerHeaders(tokens.getAccessToken());
+
         SongRequest request = new SongRequest();
         request.setTitle("Test Song");
 
-        ResponseEntity<SongResponse> response =
-                restTemplate.postForEntity("/api/v1/songs", request, SongResponse.class);
+        ResponseEntity<SongResponse> response = restTemplate.exchange(
+                "/api/v1/songs",
+                HttpMethod.POST,
+                new HttpEntity<>(request, headers),
+                SongResponse.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         assertThat(response.getBody()).isNotNull();
@@ -34,12 +52,38 @@ class SongControllerTest extends AbstractIntegrationTest {
 
     @Test
     void createSongValidationError() {
+        authenticationHelper.ensureUser("planner+songvalidation@example.com", "Secret123!", List.of("PLANNER"));
+        AuthTokenPair tokens = authenticate("planner+songvalidation@example.com", "Secret123!");
+        HttpHeaders headers = bearerHeaders(tokens.getAccessToken());
+
         SongRequest request = new SongRequest();
 
-        ResponseEntity<String> response =
-                restTemplate.postForEntity("/api/v1/songs", request, String.class);
+        ResponseEntity<String> response = restTemplate.exchange(
+                "/api/v1/songs",
+                HttpMethod.POST,
+                new HttpEntity<>(request, headers),
+                String.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody()).contains("title");
+    }
+
+    private AuthTokenPair authenticate(String email, String password) {
+        AuthLoginRequest loginRequest = new AuthLoginRequest();
+        loginRequest.setEmail(email);
+        loginRequest.setPassword(password);
+        ResponseEntity<AuthTokenPair> response = restTemplate.postForEntity(
+                "/api/v1/auth/login",
+                loginRequest,
+                AuthTokenPair.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        return response.getBody();
+    }
+
+    private HttpHeaders bearerHeaders(String token) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        return headers;
     }
 }

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/songset/SongSetControllerTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/songset/SongSetControllerTest.java
@@ -1,8 +1,11 @@
 package com.homeputers.ebal2.api.songset;
 
 import com.homeputers.ebal2.api.AbstractIntegrationTest;
+import com.homeputers.ebal2.api.TestAuthenticationHelper;
 import com.homeputers.ebal2.api.generated.model.ArrangementRequest;
 import com.homeputers.ebal2.api.generated.model.ArrangementResponse;
+import com.homeputers.ebal2.api.generated.model.AuthLoginRequest;
+import com.homeputers.ebal2.api.generated.model.AuthTokenPair;
 import com.homeputers.ebal2.api.generated.model.SongRequest;
 import com.homeputers.ebal2.api.generated.model.SongResponse;
 import com.homeputers.ebal2.api.generated.model.SongSetItemRequest;
@@ -13,9 +16,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,29 +33,42 @@ class SongSetControllerTest extends AbstractIntegrationTest {
     @Autowired
     private TestRestTemplate restTemplate;
 
+    @Autowired
+    private TestAuthenticationHelper authenticationHelper;
+
     @Test
     void listSongSetItems_returnsPersistedItems() {
+        authenticationHelper.ensureUser("planner+songset@example.com", "Secret123!", List.of("PLANNER"));
+        AuthTokenPair tokens = authenticate("planner+songset@example.com", "Secret123!");
+        HttpHeaders headers = bearerHeaders(tokens.getAccessToken());
+
         SongSetRequest setRequest = new SongSetRequest();
         setRequest.setName("Integration Set");
-        ResponseEntity<SongSetResponse> setResponse =
-                restTemplate.postForEntity("/api/v1/song-sets", setRequest, SongSetResponse.class);
+        ResponseEntity<SongSetResponse> setResponse = restTemplate.exchange(
+                "/api/v1/song-sets",
+                HttpMethod.POST,
+                new HttpEntity<>(setRequest, headers),
+                SongSetResponse.class);
         assertThat(setResponse.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         UUID songSetId = setResponse.getBody().getId();
 
         SongRequest songRequest = new SongRequest();
         songRequest.setTitle("Integration Song");
-        ResponseEntity<SongResponse> songResponse =
-                restTemplate.postForEntity("/api/v1/songs", songRequest, SongResponse.class);
+        ResponseEntity<SongResponse> songResponse = restTemplate.exchange(
+                "/api/v1/songs",
+                HttpMethod.POST,
+                new HttpEntity<>(songRequest, headers),
+                SongResponse.class);
         assertThat(songResponse.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         UUID songId = songResponse.getBody().getId();
 
         ArrangementRequest arrangementRequest = new ArrangementRequest();
         arrangementRequest.setKey("C");
-        ResponseEntity<ArrangementResponse> arrangementResponse = restTemplate.postForEntity(
+        ResponseEntity<ArrangementResponse> arrangementResponse = restTemplate.exchange(
                 "/api/v1/songs/" + songId + "/arrangements",
-                arrangementRequest,
-                ArrangementResponse.class
-        );
+                HttpMethod.POST,
+                new HttpEntity<>(arrangementRequest, headers),
+                ArrangementResponse.class);
         assertThat(arrangementResponse.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         UUID arrangementId = arrangementResponse.getBody().getId();
 
@@ -57,17 +77,18 @@ class SongSetControllerTest extends AbstractIntegrationTest {
         itemRequest.setSortOrder(0);
         itemRequest.setTranspose(2);
         itemRequest.setCapo(1);
-        ResponseEntity<SongSetItemResponse> createItemResponse = restTemplate.postForEntity(
+        ResponseEntity<SongSetItemResponse> createItemResponse = restTemplate.exchange(
                 "/api/v1/song-sets/" + songSetId + "/items",
-                itemRequest,
-                SongSetItemResponse.class
-        );
+                HttpMethod.POST,
+                new HttpEntity<>(itemRequest, headers),
+                SongSetItemResponse.class);
         assertThat(createItemResponse.getStatusCode()).isEqualTo(HttpStatus.CREATED);
 
-        ResponseEntity<SongSetItemResponse[]> itemsResponse = restTemplate.getForEntity(
+        ResponseEntity<SongSetItemResponse[]> itemsResponse = restTemplate.exchange(
                 "/api/v1/song-sets/" + songSetId + "/items",
-                SongSetItemResponse[].class
-        );
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                SongSetItemResponse[].class);
 
         assertThat(itemsResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(itemsResponse.getBody()).isNotNull();
@@ -78,5 +99,23 @@ class SongSetControllerTest extends AbstractIntegrationTest {
         assertThat(item.getTranspose()).isEqualTo(2);
         assertThat(item.getCapo()).isEqualTo(1);
     }
-}
 
+    private AuthTokenPair authenticate(String email, String password) {
+        AuthLoginRequest loginRequest = new AuthLoginRequest();
+        loginRequest.setEmail(email);
+        loginRequest.setPassword(password);
+        ResponseEntity<AuthTokenPair> response = restTemplate.postForEntity(
+                "/api/v1/auth/login",
+                loginRequest,
+                AuthTokenPair.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        return response.getBody();
+    }
+
+    private HttpHeaders bearerHeaders(String token) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        return headers;
+    }
+}


### PR DESCRIPTION
## Summary
- configure the API for stateless JWT authentication with per-endpoint role rules and CORS driven by environment variables
- add token services, refresh-token persistence and controller flows for login, refresh and password changes with unified 401/403 responses
- update integration tests to authenticate requests via helper utilities and document new security variables

## Testing
- `mvn -q -DskipTests=false verify` *(fails: network access to Maven Central is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce0282b01c8330ac04c50047db5c4b