### PR TITLE
feat: implement password reset flows

### DIFF
--- a/apps/api-java/pom.xml
+++ b/apps/api-java/pom.xml
@@ -26,6 +26,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/ApiExceptionHandler.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/ApiExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.homeputers.ebal2.api;
 
 import com.homeputers.ebal2.api.auth.InvalidCredentialsException;
+import com.homeputers.ebal2.api.auth.InvalidPasswordResetTokenException;
 import com.homeputers.ebal2.api.auth.InvalidRefreshTokenException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
@@ -35,6 +36,13 @@ public class ApiExceptionHandler {
     @ExceptionHandler({InvalidCredentialsException.class, InvalidRefreshTokenException.class})
     public ProblemDetail handleUnauthorized(RuntimeException ex) {
         ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.UNAUTHORIZED);
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    @ExceptionHandler(InvalidPasswordResetTokenException.class)
+    public ProblemDetail handleInvalidPasswordResetToken(InvalidPasswordResetTokenException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
         pd.setDetail(ex.getMessage());
         return pd;
     }

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/auth/AuthController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/auth/AuthController.java
@@ -9,7 +9,6 @@ import com.homeputers.ebal2.api.generated.model.RefreshTokenRequest;
 import com.homeputers.ebal2.api.generated.model.ResetPasswordRequest;
 import com.homeputers.ebal2.api.generated.model.User;
 import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -70,11 +69,10 @@ public class AuthController implements AuthApi {
     }
 
     @Override
-    public ResponseEntity<Void> requestPasswordReset(ForgotPasswordRequest forgotPasswordRequest) {
-        String headerValue = request.getHeader(HttpHeaders.ACCEPT_LANGUAGE);
+    public ResponseEntity<Void> requestPasswordReset(ForgotPasswordRequest forgotPasswordRequest, String acceptLanguage) {
         passwordResetService.requestPasswordReset(
                 forgotPasswordRequest.getEmail(),
-                headerValue);
+                acceptLanguage);
         return ResponseEntity.noContent().build();
     }
 

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/auth/AuthController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/auth/AuthController.java
@@ -4,7 +4,9 @@ import com.homeputers.ebal2.api.generated.AuthApi;
 import com.homeputers.ebal2.api.generated.model.AuthLoginRequest;
 import com.homeputers.ebal2.api.generated.model.AuthTokenPair;
 import com.homeputers.ebal2.api.generated.model.ChangePasswordRequest;
+import com.homeputers.ebal2.api.generated.model.ForgotPasswordRequest;
 import com.homeputers.ebal2.api.generated.model.RefreshTokenRequest;
+import com.homeputers.ebal2.api.generated.model.ResetPasswordRequest;
 import com.homeputers.ebal2.api.generated.model.User;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
@@ -21,13 +23,16 @@ public class AuthController implements AuthApi {
 
     private final CurrentUserFactory currentUserFactory;
     private final AuthService authService;
+    private final PasswordResetService passwordResetService;
     private final HttpServletRequest request;
 
     public AuthController(CurrentUserFactory currentUserFactory,
                          AuthService authService,
+                         PasswordResetService passwordResetService,
                          HttpServletRequest request) {
         this.currentUserFactory = currentUserFactory;
         this.authService = authService;
+        this.passwordResetService = passwordResetService;
         this.request = request;
     }
 
@@ -60,6 +65,20 @@ public class AuthController implements AuthApi {
                 authentication.getName(),
                 changePasswordRequest.getCurrentPassword(),
                 changePasswordRequest.getNewPassword());
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<Void> requestPasswordReset(ForgotPasswordRequest forgotPasswordRequest) {
+        passwordResetService.requestPasswordReset(forgotPasswordRequest.getEmail());
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<Void> completePasswordReset(ResetPasswordRequest resetPasswordRequest) {
+        passwordResetService.resetPassword(
+                resetPasswordRequest.getToken(),
+                resetPasswordRequest.getNewPassword());
         return ResponseEntity.noContent().build();
     }
 

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/auth/AuthController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/auth/AuthController.java
@@ -9,6 +9,7 @@ import com.homeputers.ebal2.api.generated.model.RefreshTokenRequest;
 import com.homeputers.ebal2.api.generated.model.ResetPasswordRequest;
 import com.homeputers.ebal2.api.generated.model.User;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -69,8 +70,14 @@ public class AuthController implements AuthApi {
     }
 
     @Override
-    public ResponseEntity<Void> requestPasswordReset(ForgotPasswordRequest forgotPasswordRequest) {
-        passwordResetService.requestPasswordReset(forgotPasswordRequest.getEmail());
+    public ResponseEntity<Void> requestPasswordReset(String acceptLanguage,
+                                                     ForgotPasswordRequest forgotPasswordRequest) {
+        String headerValue = StringUtils.hasText(acceptLanguage)
+                ? acceptLanguage
+                : request.getHeader(HttpHeaders.ACCEPT_LANGUAGE);
+        passwordResetService.requestPasswordReset(
+                forgotPasswordRequest.getEmail(),
+                headerValue);
         return ResponseEntity.noContent().build();
     }
 

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/auth/AuthController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/auth/AuthController.java
@@ -70,11 +70,8 @@ public class AuthController implements AuthApi {
     }
 
     @Override
-    public ResponseEntity<Void> requestPasswordReset(String acceptLanguage,
-                                                     ForgotPasswordRequest forgotPasswordRequest) {
-        String headerValue = StringUtils.hasText(acceptLanguage)
-                ? acceptLanguage
-                : request.getHeader(HttpHeaders.ACCEPT_LANGUAGE);
+    public ResponseEntity<Void> requestPasswordReset(ForgotPasswordRequest forgotPasswordRequest) {
+        String headerValue = request.getHeader(HttpHeaders.ACCEPT_LANGUAGE);
         passwordResetService.requestPasswordReset(
                 forgotPasswordRequest.getEmail(),
                 headerValue);

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/auth/InvalidPasswordResetTokenException.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/auth/InvalidPasswordResetTokenException.java
@@ -1,0 +1,8 @@
+package com.homeputers.ebal2.api.auth;
+
+public class InvalidPasswordResetTokenException extends RuntimeException {
+
+    public InvalidPasswordResetTokenException() {
+        super("Password reset link is invalid or has expired.");
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/auth/PasswordResetService.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/auth/PasswordResetService.java
@@ -1,0 +1,111 @@
+package com.homeputers.ebal2.api.auth;
+
+import com.homeputers.ebal2.api.config.MailProperties;
+import com.homeputers.ebal2.api.config.SecurityProperties;
+import com.homeputers.ebal2.api.domain.user.PasswordResetMapper;
+import com.homeputers.ebal2.api.domain.user.PasswordResetToken;
+import com.homeputers.ebal2.api.domain.user.User;
+import com.homeputers.ebal2.api.domain.user.UserMapper;
+import com.homeputers.ebal2.api.email.EmailSender;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.Locale;
+import java.util.UUID;
+
+@Service
+public class PasswordResetService {
+
+    private final PasswordResetMapper passwordResetMapper;
+    private final UserMapper userMapper;
+    private final PasswordEncoder passwordEncoder;
+    private final RefreshTokenService refreshTokenService;
+    private final SecurityProperties securityProperties;
+    private final MailProperties mailProperties;
+    private final EmailSender emailSender;
+
+    public PasswordResetService(PasswordResetMapper passwordResetMapper,
+                                UserMapper userMapper,
+                                PasswordEncoder passwordEncoder,
+                                RefreshTokenService refreshTokenService,
+                                SecurityProperties securityProperties,
+                                MailProperties mailProperties,
+                                EmailSender emailSender) {
+        this.passwordResetMapper = passwordResetMapper;
+        this.userMapper = userMapper;
+        this.passwordEncoder = passwordEncoder;
+        this.refreshTokenService = refreshTokenService;
+        this.securityProperties = securityProperties;
+        this.mailProperties = mailProperties;
+        this.emailSender = emailSender;
+    }
+
+    public void requestPasswordReset(String email) {
+        if (!StringUtils.hasText(email)) {
+            return;
+        }
+
+        String normalizedEmail = normalizeEmail(email);
+        User user = userMapper.findByEmail(normalizedEmail);
+        if (user == null || !user.isActive()) {
+            return;
+        }
+
+        OffsetDateTime now = OffsetDateTime.now();
+        passwordResetMapper.deleteExpired(now);
+
+        String token = UUID.randomUUID().toString();
+        OffsetDateTime expiresAt = now.plus(securityProperties.getPasswordReset().getTtl());
+        passwordResetMapper.insert(token, user.id(), expiresAt, now);
+
+        String resetUrl = buildResetUrl(token);
+        emailSender.sendPasswordResetEmail(user.email(), resetUrl);
+    }
+
+    public void resetPassword(String token, String newPassword) {
+        if (!StringUtils.hasText(token) || !StringUtils.hasText(newPassword)) {
+            throw new InvalidPasswordResetTokenException();
+        }
+
+        OffsetDateTime now = OffsetDateTime.now();
+        passwordResetMapper.deleteExpired(now);
+
+        PasswordResetToken resetToken = passwordResetMapper.findByToken(token);
+        if (resetToken == null) {
+            throw new InvalidPasswordResetTokenException();
+        }
+        if (resetToken.usedAt() != null) {
+            throw new InvalidPasswordResetTokenException();
+        }
+        if (!resetToken.expiresAt().isAfter(now)) {
+            throw new InvalidPasswordResetTokenException();
+        }
+
+        User user = userMapper.findById(resetToken.userId());
+        if (user == null || !user.isActive()) {
+            throw new InvalidPasswordResetTokenException();
+        }
+
+        String newHash = passwordEncoder.encode(newPassword);
+        userMapper.updatePassword(user.id(), newHash, now);
+        passwordResetMapper.markUsed(token, now);
+        refreshTokenService.revokeAllForUser(user.id());
+    }
+
+    private String normalizeEmail(String email) {
+        return email.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private String buildResetUrl(String token) {
+        URI uri = UriComponentsBuilder.fromUriString(mailProperties.getFrontendBaseUrl())
+                .path("/reset-password")
+                .queryParam("token", token)
+                .build()
+                .toUri();
+        return uri.toString();
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/MailConfig.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/MailConfig.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -40,15 +41,16 @@ public class MailConfig {
     @Bean
     @ConditionalOnMissingBean(EmailSender.class)
     public EmailSender emailSender(MailProperties properties,
-                                   ObjectProvider<JavaMailSender> javaMailSenderProvider) {
+                                   ObjectProvider<JavaMailSender> javaMailSenderProvider,
+                                   MessageSource messageSource) {
         if (properties.getSmtp().isEnabled()) {
             JavaMailSender javaMailSender = javaMailSenderProvider.getIfAvailable();
             if (javaMailSender == null) {
                 throw new IllegalStateException(
                         "SMTP email sender requires JavaMailSender bean when smtp.enabled=true");
             }
-            return new SmtpEmailSender(javaMailSender, properties);
+            return new SmtpEmailSender(javaMailSender, properties, messageSource);
         }
-        return new DevEmailSender(properties);
+        return new DevEmailSender(properties, messageSource);
     }
 }

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/MailConfig.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/MailConfig.java
@@ -1,0 +1,50 @@
+package com.homeputers.ebal2.api.config;
+
+import com.homeputers.ebal2.api.email.DevEmailSender;
+import com.homeputers.ebal2.api.email.EmailSender;
+import com.homeputers.ebal2.api.email.SmtpEmailSender;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+@EnableConfigurationProperties(MailProperties.class)
+public class MailConfig {
+
+    @Bean
+    @ConditionalOnProperty(value = "ebal.mail.smtp.enabled", havingValue = "true")
+    public JavaMailSender javaMailSender(MailProperties properties) {
+        MailProperties.Smtp smtp = properties.getSmtp();
+        JavaMailSenderImpl sender = new JavaMailSenderImpl();
+        sender.setHost(smtp.getHost());
+        if (smtp.getPort() != null) {
+            sender.setPort(smtp.getPort());
+        }
+        sender.setUsername(smtp.getUsername());
+        sender.setPassword(smtp.getPassword());
+
+        Properties javaMailProperties = sender.getJavaMailProperties();
+        javaMailProperties.put("mail.transport.protocol", "smtp");
+        javaMailProperties.put("mail.smtp.auth", Boolean.toString(smtp.isAuth()));
+        javaMailProperties.put("mail.smtp.starttls.enable", Boolean.toString(smtp.isStartTls()));
+        return sender;
+    }
+
+    @Bean
+    @ConditionalOnProperty(value = "ebal.mail.smtp.enabled", havingValue = "true")
+    public EmailSender smtpEmailSender(JavaMailSender javaMailSender, MailProperties properties) {
+        return new SmtpEmailSender(javaMailSender, properties);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(EmailSender.class)
+    public EmailSender devEmailSender(MailProperties properties) {
+        return new DevEmailSender(properties);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/MailProperties.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/MailProperties.java
@@ -1,0 +1,102 @@
+package com.homeputers.ebal2.api.config;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties("ebal.mail")
+public class MailProperties {
+
+    @NotBlank
+    private String frontendBaseUrl = "http://localhost:5173";
+
+    private final Smtp smtp = new Smtp();
+
+    public String getFrontendBaseUrl() {
+        return frontendBaseUrl;
+    }
+
+    public void setFrontendBaseUrl(String frontendBaseUrl) {
+        this.frontendBaseUrl = frontendBaseUrl;
+    }
+
+    public Smtp getSmtp() {
+        return smtp;
+    }
+
+    public static class Smtp {
+        private boolean enabled = false;
+        private String host;
+        private Integer port = 587;
+        private String username;
+        private String password;
+        private boolean startTls = true;
+        private boolean auth = true;
+        private String fromAddress = "no-reply@example.com";
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getHost() {
+            return host;
+        }
+
+        public void setHost(String host) {
+            this.host = host;
+        }
+
+        public Integer getPort() {
+            return port;
+        }
+
+        public void setPort(Integer port) {
+            this.port = port;
+        }
+
+        public String getUsername() {
+            return username;
+        }
+
+        public void setUsername(String username) {
+            this.username = username;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public void setPassword(String password) {
+            this.password = password;
+        }
+
+        public boolean isStartTls() {
+            return startTls;
+        }
+
+        public void setStartTls(boolean startTls) {
+            this.startTls = startTls;
+        }
+
+        public boolean isAuth() {
+            return auth;
+        }
+
+        public void setAuth(boolean auth) {
+            this.auth = auth;
+        }
+
+        public String getFromAddress() {
+            return fromAddress;
+        }
+
+        public void setFromAddress(String fromAddress) {
+            this.fromAddress = fromAddress;
+        }
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/MyBatisConfig.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/MyBatisConfig.java
@@ -4,7 +4,7 @@ import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@MapperScan("com.homeputers.ebal2.api")
+@MapperScan("com.homeputers.ebal2.api.domain")
 public class MyBatisConfig {
 }
 

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/SecurityProperties.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/SecurityProperties.java
@@ -16,6 +16,7 @@ public class SecurityProperties {
     private boolean enabled = true;
     private final Cors cors = new Cors();
     private final Jwt jwt = new Jwt();
+    private final PasswordReset passwordReset = new PasswordReset();
 
     public boolean isEnabled() {
         return enabled;
@@ -31,6 +32,10 @@ public class SecurityProperties {
 
     public Jwt getJwt() {
         return jwt;
+    }
+
+    public PasswordReset getPasswordReset() {
+        return passwordReset;
     }
 
     public static class Cors {
@@ -104,6 +109,23 @@ public class SecurityProperties {
         @AssertTrue(message = "Refresh token TTL must be positive")
         public boolean isRefreshTtlPositive() {
             return refreshTokenTtl != null && !refreshTokenTtl.isNegative() && !refreshTokenTtl.isZero();
+        }
+    }
+
+    public static class PasswordReset {
+        private Duration ttl = Duration.ofMinutes(60);
+
+        public Duration getTtl() {
+            return ttl;
+        }
+
+        public void setTtl(Duration ttl) {
+            this.ttl = ttl;
+        }
+
+        @AssertTrue(message = "Password reset TTL must be positive")
+        public boolean isTtlPositive() {
+            return ttl != null && !ttl.isNegative() && !ttl.isZero();
         }
     }
 }

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/PasswordResetMapper.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/user/PasswordResetMapper.java
@@ -10,6 +10,8 @@ import java.util.UUID;
 public interface PasswordResetMapper {
     PasswordResetToken findByToken(@Param("token") String token);
 
+    PasswordResetToken findLatestByUserId(@Param("userId") UUID userId);
+
     void insert(@Param("token") String token,
                 @Param("userId") UUID userId,
                 @Param("expiresAt") OffsetDateTime expiresAt,

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/email/DevEmailSender.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/email/DevEmailSender.java
@@ -1,0 +1,22 @@
+package com.homeputers.ebal2.api.email;
+
+import com.homeputers.ebal2.api.config.MailProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DevEmailSender implements EmailSender {
+
+    private static final Logger log = LoggerFactory.getLogger(DevEmailSender.class);
+
+    private final MailProperties mailProperties;
+
+    public DevEmailSender(MailProperties mailProperties) {
+        this.mailProperties = mailProperties;
+    }
+
+    @Override
+    public void sendPasswordResetEmail(String to, String resetUrl) {
+        log.info("Password reset requested for {}. Provide link via frontend {}: {}", to,
+                mailProperties.getFrontendBaseUrl(), resetUrl);
+    }
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/email/DevEmailSender.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/email/DevEmailSender.java
@@ -3,20 +3,30 @@ package com.homeputers.ebal2.api.email;
 import com.homeputers.ebal2.api.config.MailProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.MessageSource;
+
+import java.util.Locale;
 
 public class DevEmailSender implements EmailSender {
 
     private static final Logger log = LoggerFactory.getLogger(DevEmailSender.class);
 
     private final MailProperties mailProperties;
+    private final MessageSource messageSource;
 
-    public DevEmailSender(MailProperties mailProperties) {
+    public DevEmailSender(MailProperties mailProperties, MessageSource messageSource) {
         this.mailProperties = mailProperties;
+        this.messageSource = messageSource;
     }
 
     @Override
-    public void sendPasswordResetEmail(String to, String resetUrl) {
-        log.info("Password reset requested for {}. Provide link via frontend {}: {}", to,
-                mailProperties.getFrontendBaseUrl(), resetUrl);
+    public void sendPasswordResetEmail(String to, String resetUrl, Locale locale) {
+        String subject = messageSource.getMessage("mail.password-reset.subject", null, locale);
+        String body = messageSource.getMessage("mail.password-reset.body", new Object[]{resetUrl}, locale);
+
+        log.info("Password reset requested for {} using locale {} via frontend {}.",
+                to, locale, mailProperties.getFrontendBaseUrl());
+        log.info("Password reset email subject: {}", subject);
+        log.info("Password reset email body: {}", body);
     }
 }

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/email/EmailSender.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/email/EmailSender.java
@@ -1,6 +1,8 @@
 package com.homeputers.ebal2.api.email;
 
+import java.util.Locale;
+
 public interface EmailSender {
 
-    void sendPasswordResetEmail(String to, String resetUrl);
+    void sendPasswordResetEmail(String to, String resetUrl, Locale locale);
 }

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/email/EmailSender.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/email/EmailSender.java
@@ -1,0 +1,6 @@
+package com.homeputers.ebal2.api.email;
+
+public interface EmailSender {
+
+    void sendPasswordResetEmail(String to, String resetUrl);
+}

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/email/SmtpEmailSender.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/email/SmtpEmailSender.java
@@ -1,27 +1,35 @@
 package com.homeputers.ebal2.api.email;
 
 import com.homeputers.ebal2.api.config.MailProperties;
+import org.springframework.context.MessageSource;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+
+import java.util.Locale;
 
 public class SmtpEmailSender implements EmailSender {
 
     private final JavaMailSender mailSender;
     private final MailProperties mailProperties;
+    private final MessageSource messageSource;
 
-    public SmtpEmailSender(JavaMailSender mailSender, MailProperties mailProperties) {
+    public SmtpEmailSender(JavaMailSender mailSender, MailProperties mailProperties,
+                          MessageSource messageSource) {
         this.mailSender = mailSender;
         this.mailProperties = mailProperties;
+        this.messageSource = messageSource;
     }
 
     @Override
-    public void sendPasswordResetEmail(String to, String resetUrl) {
+    public void sendPasswordResetEmail(String to, String resetUrl, Locale locale) {
+        String subject = messageSource.getMessage("mail.password-reset.subject", null, locale);
+        String body = messageSource.getMessage("mail.password-reset.body", new Object[]{resetUrl}, locale);
+
         SimpleMailMessage message = new SimpleMailMessage();
         message.setFrom(mailProperties.getSmtp().getFromAddress());
         message.setTo(to);
-        message.setSubject("Reset your password");
-        message.setText("We received a request to reset your password. Use the link below to set a new password:\n\n"
-                + resetUrl + "\n\nIf you did not request a password reset, you can safely ignore this email.");
+        message.setSubject(subject);
+        message.setText(body);
         mailSender.send(message);
     }
 }

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/email/SmtpEmailSender.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/email/SmtpEmailSender.java
@@ -1,0 +1,27 @@
+package com.homeputers.ebal2.api.email;
+
+import com.homeputers.ebal2.api.config.MailProperties;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+public class SmtpEmailSender implements EmailSender {
+
+    private final JavaMailSender mailSender;
+    private final MailProperties mailProperties;
+
+    public SmtpEmailSender(JavaMailSender mailSender, MailProperties mailProperties) {
+        this.mailSender = mailSender;
+        this.mailProperties = mailProperties;
+    }
+
+    @Override
+    public void sendPasswordResetEmail(String to, String resetUrl) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(mailProperties.getSmtp().getFromAddress());
+        message.setTo(to);
+        message.setSubject("Reset your password");
+        message.setText("We received a request to reset your password. Use the link below to set a new password:\n\n"
+                + resetUrl + "\n\nIf you did not request a password reset, you can safely ignore this email.");
+        mailSender.send(message);
+    }
+}

--- a/apps/api-java/src/main/resources/application.yaml
+++ b/apps/api-java/src/main/resources/application.yaml
@@ -21,6 +21,19 @@ ebal:
       secret: ${EBAL_JWT_SECRET:ThisIsADefaultJwtSecretForLocalDevOnly_DoNotUseInProduction_ButItIsLongEnough1234}
       access-token-ttl: ${EBAL_JWT_ACCESS_TTL:PT15M}
       refresh-token-ttl: ${EBAL_JWT_REFRESH_TTL:P30D}
+    password-reset:
+      ttl: ${EBAL_PASSWORD_RESET_TTL:PT1H}
+  mail:
+    frontend-base-url: ${FRONTEND_BASE_URL:http://localhost:5173}
+    smtp:
+      enabled: ${EBAL_MAIL_SMTP_ENABLED:false}
+      host: ${EBAL_MAIL_SMTP_HOST:}
+      port: ${EBAL_MAIL_SMTP_PORT:587}
+      username: ${EBAL_MAIL_SMTP_USERNAME:}
+      password: ${EBAL_MAIL_SMTP_PASSWORD:}
+      start-tls: ${EBAL_MAIL_SMTP_STARTTLS:true}
+      auth: ${EBAL_MAIL_SMTP_AUTH:true}
+      from-address: ${EBAL_MAIL_FROM:no-reply@example.com}
   otel:
     enabled: ${EBAL_OTEL_ENABLED:false}
     exporter:

--- a/apps/api-java/src/main/resources/mappers/PasswordResetMapper.xml
+++ b/apps/api-java/src/main/resources/mappers/PasswordResetMapper.xml
@@ -18,6 +18,14 @@
         where token = #{token}
     </select>
 
+    <select id="findLatestByUserId" resultMap="passwordResetResult">
+        select token, user_id, expires_at, used_at, created_at
+        from password_resets
+        where user_id = #{userId, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler}
+        order by created_at desc
+        limit 1
+    </select>
+
     <insert id="insert">
         insert into password_resets (token, user_id, expires_at, created_at)
         values (

--- a/apps/api-java/src/main/resources/messages.properties
+++ b/apps/api-java/src/main/resources/messages.properties
@@ -1,0 +1,2 @@
+mail.password-reset.subject=Reset your password
+mail.password-reset.body=We received a request to reset your password. Use the link below to set a new password:\n\n{0}\n\nIf you did not request a password reset, you can safely ignore this email.

--- a/apps/api-java/src/main/resources/messages_es.properties
+++ b/apps/api-java/src/main/resources/messages_es.properties
@@ -1,0 +1,2 @@
+mail.password-reset.subject=Restablece tu contraseña
+mail.password-reset.body=Hemos recibido una solicitud para restablecer tu contraseña. Utiliza el siguiente enlace para crear una nueva:\n\n{0}\n\nSi no solicitaste restablecer tu contraseña, puedes ignorar este correo.

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/auth/AuthControllerTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/auth/AuthControllerTest.java
@@ -33,6 +33,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -172,9 +173,13 @@ class AuthControllerTest extends AbstractIntegrationTest {
         request.setEmail(EMAIL);
         OffsetDateTime beforeRequest = OffsetDateTime.now();
 
-        ResponseEntity<Void> response = restTemplate.postForEntity(
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set(HttpHeaders.ACCEPT_LANGUAGE, "es-MX");
+        ResponseEntity<Void> response = restTemplate.exchange(
                 "/api/v1/auth/forgot-password",
-                request,
+                HttpMethod.POST,
+                new HttpEntity<>(request, headers),
                 Void.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
@@ -189,8 +194,10 @@ class AuthControllerTest extends AbstractIntegrationTest {
         assertThat(deltaSeconds).isLessThanOrEqualTo(5);
 
         ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
-        verify(emailSender).sendPasswordResetEmail(eq(EMAIL), urlCaptor.capture());
+        ArgumentCaptor<Locale> localeCaptor = ArgumentCaptor.forClass(Locale.class);
+        verify(emailSender).sendPasswordResetEmail(eq(EMAIL), urlCaptor.capture(), localeCaptor.capture());
         assertThat(urlCaptor.getValue()).contains(token.token());
+        assertThat(localeCaptor.getValue().toLanguageTag()).isEqualTo("es-MX");
     }
 
     @Test

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/auth/AuthControllerTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/auth/AuthControllerTest.java
@@ -2,14 +2,22 @@ package com.homeputers.ebal2.api.auth;
 
 import com.homeputers.ebal2.api.AbstractIntegrationTest;
 import com.homeputers.ebal2.api.TestAuthenticationHelper;
+import com.homeputers.ebal2.api.config.SecurityProperties;
+import com.homeputers.ebal2.api.domain.user.PasswordResetMapper;
+import com.homeputers.ebal2.api.domain.user.PasswordResetToken;
+import com.homeputers.ebal2.api.email.EmailSender;
 import com.homeputers.ebal2.api.generated.model.AuthLoginRequest;
 import com.homeputers.ebal2.api.generated.model.AuthTokenPair;
 import com.homeputers.ebal2.api.generated.model.ChangePasswordRequest;
+import com.homeputers.ebal2.api.generated.model.ForgotPasswordRequest;
 import com.homeputers.ebal2.api.generated.model.RefreshTokenRequest;
+import com.homeputers.ebal2.api.generated.model.ResetPasswordRequest;
 import com.homeputers.ebal2.api.generated.model.User;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -17,13 +25,19 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.http.ProblemDetail;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 
+import java.time.Duration;
+import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class AuthControllerTest extends AbstractIntegrationTest {
@@ -39,6 +53,18 @@ class AuthControllerTest extends AbstractIntegrationTest {
 
     @Autowired
     private JwtDecoder jwtDecoder;
+
+    @Autowired
+    private PasswordResetMapper passwordResetMapper;
+
+    @Autowired
+    private SecurityProperties securityProperties;
+
+    @MockBean
+    private EmailSender emailSender;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
 
     @Test
     void returnsUnauthorizedWhenAnonymous() {
@@ -137,6 +163,111 @@ class AuthControllerTest extends AbstractIntegrationTest {
 
         AuthTokenPair newTokens = authenticate(EMAIL, "NewSecret123!");
         assertThat(newTokens.getAccessToken()).isNotBlank();
+    }
+
+    @Test
+    void forgotPasswordCreatesTokenWithExpectedTtlAndNotifiesSender() {
+        UUID userId = authenticationHelper.ensureUser(EMAIL, PASSWORD, List.of("PLANNER"));
+        ForgotPasswordRequest request = new ForgotPasswordRequest();
+        request.setEmail(EMAIL);
+        OffsetDateTime beforeRequest = OffsetDateTime.now();
+
+        ResponseEntity<Void> response = restTemplate.postForEntity(
+                "/api/v1/auth/forgot-password",
+                request,
+                Void.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        PasswordResetToken token = passwordResetMapper.findLatestByUserId(userId);
+        assertThat(token).isNotNull();
+        assertThat(token.usedAt()).isNull();
+
+        Duration actualTtl = Duration.between(beforeRequest, token.expiresAt());
+        Duration expectedTtl = securityProperties.getPasswordReset().getTtl();
+        long deltaSeconds = Math.abs(actualTtl.minus(expectedTtl).toSeconds());
+        assertThat(deltaSeconds).isLessThanOrEqualTo(5);
+
+        ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(emailSender).sendPasswordResetEmail(eq(EMAIL), urlCaptor.capture());
+        assertThat(urlCaptor.getValue()).contains(token.token());
+    }
+
+    @Test
+    void resetPasswordValidatesTokenAndRevokesRefreshTokens() {
+        UUID userId = authenticationHelper.ensureUser(EMAIL, PASSWORD, List.of("PLANNER"));
+        AuthTokenPair initialTokens = authenticate(EMAIL, PASSWORD);
+
+        ForgotPasswordRequest request = new ForgotPasswordRequest();
+        request.setEmail(EMAIL);
+        restTemplate.postForEntity("/api/v1/auth/forgot-password", request, Void.class);
+        PasswordResetToken token = passwordResetMapper.findLatestByUserId(userId);
+        assertThat(token).isNotNull();
+
+        ResetPasswordRequest resetRequest = new ResetPasswordRequest();
+        resetRequest.setToken(token.token());
+        resetRequest.setNewPassword("ResetSecret123!");
+        ResponseEntity<Void> resetResponse = restTemplate.postForEntity(
+                "/api/v1/auth/reset-password",
+                resetRequest,
+                Void.class);
+
+        assertThat(resetResponse.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        PasswordResetToken usedToken = passwordResetMapper.findByToken(token.token());
+        assertThat(usedToken).isNotNull();
+        assertThat(usedToken.usedAt()).isNotNull();
+
+        RefreshTokenRequest refreshTokenRequest = new RefreshTokenRequest();
+        refreshTokenRequest.setRefreshToken(initialTokens.getRefreshToken());
+        ResponseEntity<ProblemDetail> refreshResponse = restTemplate.postForEntity(
+                "/api/v1/auth/refresh",
+                refreshTokenRequest,
+                ProblemDetail.class);
+        assertThat(refreshResponse.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+
+        AuthLoginRequest oldPasswordLogin = new AuthLoginRequest();
+        oldPasswordLogin.setEmail(EMAIL);
+        oldPasswordLogin.setPassword(PASSWORD);
+        ResponseEntity<ProblemDetail> oldPasswordResponse = restTemplate.postForEntity(
+                "/api/v1/auth/login",
+                oldPasswordLogin,
+                ProblemDetail.class);
+        assertThat(oldPasswordResponse.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+
+        AuthTokenPair newTokens = authenticate(EMAIL, "ResetSecret123!");
+        assertThat(newTokens.getAccessToken()).isNotBlank();
+
+        ResponseEntity<ProblemDetail> reuseResponse = restTemplate.postForEntity(
+                "/api/v1/auth/reset-password",
+                resetRequest,
+                ProblemDetail.class);
+        assertThat(reuseResponse.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void resetPasswordRejectsExpiredToken() {
+        UUID userId = authenticationHelper.ensureUser(EMAIL, PASSWORD, List.of("PLANNER"));
+        ForgotPasswordRequest request = new ForgotPasswordRequest();
+        request.setEmail(EMAIL);
+        restTemplate.postForEntity("/api/v1/auth/forgot-password", request, Void.class);
+
+        PasswordResetToken token = passwordResetMapper.findLatestByUserId(userId);
+        assertThat(token).isNotNull();
+        // Manually expire the token
+        OffsetDateTime expiredAt = OffsetDateTime.now().minusMinutes(1);
+        jdbcTemplate.update("update password_resets set expires_at = ? where token = ?", expiredAt, token.token());
+
+        ResetPasswordRequest resetRequest = new ResetPasswordRequest();
+        resetRequest.setToken(token.token());
+        resetRequest.setNewPassword("AnotherSecret123!");
+
+        ResponseEntity<ProblemDetail> response = restTemplate.postForEntity(
+                "/api/v1/auth/reset-password",
+                resetRequest,
+                ProblemDetail.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
     private AuthTokenPair authenticate(String email, String password) {

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -78,6 +78,13 @@ paths:
       summary: Request a password reset email
       description: Sends a password reset link to the provided email when a matching account exists.
       operationId: requestPasswordReset
+      parameters:
+        - name: Accept-Language
+          in: header
+          description: Preferred language for the password reset email content.
+          required: false
+          schema:
+            type: string
       requestBody:
         required: true
         content:


### PR DESCRIPTION
## Summary
- implement a dedicated password reset service that drives forgot/reset endpoints and refresh-token revocation
- introduce an EmailSender abstraction with a dev logger implementation and SMTP configuration stubs
- cover password reset TTL, misuse, and invalidation scenarios with new integration tests

## Testing
- `mvn -q -DskipTests=false verify` *(fails: network is unreachable for Maven Central)*

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68ce0dee3564833086ede5473295c390