### PR TITLE
feat(web): add auth interceptors and hook

### DIFF
--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -1,0 +1,213 @@
+import {
+  AxiosError,
+  AxiosHeaders,
+  type AxiosInstance,
+  type InternalAxiosRequestConfig,
+} from 'axios';
+
+import apiClient from './client';
+import { registerAxiosInterceptor } from './axios';
+import type { paths } from './types';
+import { RequestBodyOf, ResponseOf } from './type-helpers';
+
+type LoginPath = keyof paths & '/auth/login';
+type RefreshPath = keyof paths & '/auth/refresh';
+type MePath = keyof paths & '/auth/me';
+
+type AuthTokenPair = ResponseOf<LoginPath, 'post', 200>;
+type RefreshResponse = ResponseOf<RefreshPath, 'post', 200>;
+export type CurrentUser = ResponseOf<MePath, 'get', 200>;
+
+export type LoginRequest = RequestBodyOf<LoginPath, 'post'>;
+export type LoginResponse = AuthTokenPair;
+export type Role = CurrentUser['roles'][number];
+
+export type AuthTokens = AuthTokenPair & { expiresAt: number };
+
+type AuthenticatedRequestConfig = InternalAxiosRequestConfig & {
+  _retry?: boolean;
+};
+
+const AUTH_STORAGE_KEY = 'ebal.auth.tokens';
+
+const loadStoredTokens = (): AuthTokens | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const raw = window.localStorage.getItem(AUTH_STORAGE_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<AuthTokens>;
+    if (
+      typeof parsed?.accessToken === 'string' &&
+      typeof parsed?.refreshToken === 'string' &&
+      typeof parsed?.expiresAt === 'number'
+    ) {
+      return parsed as AuthTokens;
+    }
+  } catch {
+    // ignore and reset storage below
+  }
+
+  try {
+    window.localStorage.removeItem(AUTH_STORAGE_KEY);
+  } catch {
+    // Ignore storage cleanup failures
+  }
+  return null;
+};
+
+const persistTokens = (tokens: AuthTokens | null) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    if (!tokens) {
+      window.localStorage.removeItem(AUTH_STORAGE_KEY);
+      return;
+    }
+
+    window.localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(tokens));
+  } catch {
+    // Ignore storage failures (private browsing, quota, etc.)
+  }
+};
+
+const subscribers = new Set<() => void>();
+
+let currentTokens: AuthTokens | null = loadStoredTokens();
+let refreshPromise: Promise<AuthTokenPair> | null = null;
+
+const notifySubscribers = () => {
+  subscribers.forEach((listener) => listener());
+};
+
+const setCurrentTokens = (tokens: AuthTokenPair) => {
+  currentTokens = {
+    ...tokens,
+    expiresAt: Date.now() + tokens.expiresIn * 1000,
+  } satisfies AuthTokens;
+  persistTokens(currentTokens);
+  notifySubscribers();
+};
+
+export const getAuthTokens = () => currentTokens;
+
+export const subscribeToAuthTokens = (listener: () => void) => {
+  subscribers.add(listener);
+  return () => {
+    subscribers.delete(listener);
+  };
+};
+
+export const clearAuthTokens = () => {
+  currentTokens = null;
+  persistTokens(null);
+  notifySubscribers();
+};
+
+export const login = async (body: LoginRequest) => {
+  const { data } = await apiClient.post<LoginResponse>('/auth/login', body);
+  setCurrentTokens(data);
+  return data;
+};
+
+const requestTokenRefresh = async () => {
+  if (!currentTokens?.refreshToken) {
+    throw new Error('Missing refresh token');
+  }
+
+  const { data } = await apiClient.post<RefreshResponse>('/auth/refresh', {
+    refreshToken: currentTokens.refreshToken,
+  });
+
+  setCurrentTokens(data);
+  return data;
+};
+
+const queueTokenRefresh = async () => {
+  if (!refreshPromise) {
+    refreshPromise = requestTokenRefresh().finally(() => {
+      refreshPromise = null;
+    });
+  }
+
+  return refreshPromise;
+};
+
+export const refreshTokens = () => queueTokenRefresh();
+
+export const getCurrentUser = async () => {
+  const { data } = await apiClient.get<CurrentUser>('/auth/me');
+  return data;
+};
+
+export const logout = () => {
+  clearAuthTokens();
+};
+
+const AUTH_ENDPOINTS = ['/auth/login', '/auth/refresh'];
+
+const isAuthEndpoint = (url?: string) => {
+  if (!url) {
+    return false;
+  }
+
+  const normalized = url.split('?')[0] ?? url;
+  return AUTH_ENDPOINTS.some((endpoint) => normalized.endsWith(endpoint));
+};
+
+const attachAuthInterceptors = (instance: AxiosInstance): AxiosInstance => {
+  instance.interceptors.request.use((config) => {
+    const token = currentTokens?.accessToken;
+
+    if (token && !isAuthEndpoint(config.url)) {
+      const headers = AxiosHeaders.from(config.headers ?? {});
+      headers.set('Authorization', `Bearer ${token}`);
+      config.headers = headers;
+    }
+
+    return config;
+  });
+
+  instance.interceptors.response.use(
+    (response) => response,
+    async (error: AxiosError) => {
+      const { config, response } = error;
+
+      if (!config || !response || response.status !== 401) {
+        return Promise.reject(error);
+      }
+
+      const originalRequest = config as AuthenticatedRequestConfig;
+
+      if (originalRequest._retry || isAuthEndpoint(originalRequest.url)) {
+        clearAuthTokens();
+        return Promise.reject(error);
+      }
+
+      if (!currentTokens?.refreshToken) {
+        clearAuthTokens();
+        return Promise.reject(error);
+      }
+
+      try {
+        originalRequest._retry = true;
+        await queueTokenRefresh();
+        return instance(originalRequest);
+      } catch (refreshError) {
+        clearAuthTokens();
+        return Promise.reject(refreshError);
+      }
+    },
+  );
+
+  return instance;
+};
+
+registerAxiosInterceptor(attachAuthInterceptors);

--- a/apps/web/src/api/axios.test.ts
+++ b/apps/web/src/api/axios.test.ts
@@ -1,28 +1,40 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { AxiosHeaders, type AxiosAdapter } from 'axios';
+import { AxiosError, AxiosHeaders, type AxiosAdapter } from 'axios';
 
 import i18n from '@/i18n';
 import httpClient, { createAxiosInstance } from './axios';
+import apiClient from './client';
+import * as auth from './auth';
+
+const successAdapterResponse = (config: Parameters<AxiosAdapter>[0]) => ({
+  data: null,
+  status: 200,
+  statusText: 'OK',
+  headers: AxiosHeaders.from({}),
+  config,
+});
+
+beforeEach(async () => {
+  await i18n.changeLanguage('en');
+  auth.logout();
+  window.localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+afterEach(async () => {
+  auth.logout();
+  window.localStorage.clear();
+  vi.restoreAllMocks();
+  await i18n.changeLanguage('en');
+});
 
 describe('axios Accept-Language interceptor', () => {
-  beforeEach(async () => {
-    await i18n.changeLanguage('en');
-  });
-
-  afterEach(async () => {
-    await i18n.changeLanguage('en');
-  });
-
   it('injects the current language into the Accept-Language header', async () => {
     await i18n.changeLanguage('es');
 
-    const adapter = vi.fn<Parameters<AxiosAdapter>, ReturnType<AxiosAdapter>>(async (config) => ({
-      data: null,
-      status: 200,
-      statusText: 'OK',
-      headers: AxiosHeaders.from({}),
-      config,
-    }));
+    const adapter = vi.fn<Parameters<AxiosAdapter>, ReturnType<AxiosAdapter>>(async (config) =>
+      successAdapterResponse(config),
+    );
 
     await httpClient.get('/test', { adapter });
 
@@ -37,13 +49,9 @@ describe('axios Accept-Language interceptor', () => {
 
     await i18n.changeLanguage('es');
 
-    const adapter = vi.fn<Parameters<AxiosAdapter>, ReturnType<AxiosAdapter>>(async (config) => ({
-      data: null,
-      status: 200,
-      statusText: 'OK',
-      headers: AxiosHeaders.from({}),
-      config,
-    }));
+    const adapter = vi.fn<Parameters<AxiosAdapter>, ReturnType<AxiosAdapter>>(async (config) =>
+      successAdapterResponse(config),
+    );
 
     await instance.get('/other', { adapter });
 
@@ -51,5 +59,92 @@ describe('axios Accept-Language interceptor', () => {
     const headers = AxiosHeaders.from(requestConfig.headers ?? {});
 
     expect(headers.get('Accept-Language')).toBe('es');
+  });
+});
+
+describe('axios auth interceptor', () => {
+  it('attaches Authorization header when an access token is present', async () => {
+    const tokenPair = {
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresIn: 60,
+    };
+
+    vi.spyOn(apiClient, 'post').mockResolvedValue({ data: tokenPair } as never);
+
+    await auth.login({ email: 'user@example.com', password: 'secret' });
+
+    const adapter = vi.fn<Parameters<AxiosAdapter>, ReturnType<AxiosAdapter>>(async (config) =>
+      successAdapterResponse(config),
+    );
+
+    const instance = createAxiosInstance();
+    await instance.get('/secure', { adapter });
+
+    const headers = AxiosHeaders.from(adapter.mock.calls[0][0].headers ?? {});
+    expect(headers.get('Authorization')).toBe(`Bearer ${tokenPair.accessToken}`);
+  });
+
+  it('refreshes tokens once on 401 responses and retries the original request', async () => {
+    const initialTokens = {
+      accessToken: 'expired-access',
+      refreshToken: 'refresh-token',
+      expiresIn: 60,
+    };
+    const refreshedTokens = {
+      accessToken: 'new-access',
+      refreshToken: 'new-refresh',
+      expiresIn: 120,
+    };
+
+    vi.spyOn(apiClient, 'post').mockImplementation(async (url, ...rest) => {
+      if (url === '/auth/login') {
+        return { data: initialTokens } as never;
+      }
+
+      if (url === '/auth/refresh') {
+        return { data: refreshedTokens } as never;
+      }
+
+      throw new Error(`Unexpected POST to ${url} with ${JSON.stringify(rest)}`);
+    });
+
+    await auth.login({ email: 'user@example.com', password: 'secret' });
+
+    let callCount = 0;
+    const adapter = vi.fn<Parameters<AxiosAdapter>, ReturnType<AxiosAdapter>>(async (config) => {
+      callCount += 1;
+
+      if (callCount === 1) {
+        throw new AxiosError(
+          'Unauthorized',
+          '401',
+          config,
+          undefined,
+          {
+            data: null,
+            status: 401,
+            statusText: 'Unauthorized',
+            headers: {},
+            config,
+          },
+        );
+      }
+
+      return successAdapterResponse(config);
+    });
+
+    const instance = createAxiosInstance();
+    await instance.get('/needs-refresh', { adapter });
+
+    expect(callCount).toBe(2);
+    expect(adapter).toHaveBeenCalledTimes(2);
+    expect(apiClient.post).toHaveBeenCalledWith('/auth/refresh', {
+      refreshToken: initialTokens.refreshToken,
+    });
+
+    const retryHeaders = AxiosHeaders.from(adapter.mock.calls[1][0].headers ?? {});
+    expect(retryHeaders.get('Authorization')).toBe(`Bearer ${refreshedTokens.accessToken}`);
+    expect(auth.getAuthTokens()).toMatchObject({ accessToken: refreshedTokens.accessToken });
   });
 });

--- a/apps/web/src/features/auth/useAuth.ts
+++ b/apps/web/src/features/auth/useAuth.ts
@@ -1,0 +1,83 @@
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
+
+import {
+  getAuthTokens,
+  subscribeToAuthTokens,
+  getCurrentUser,
+  login as loginRequest,
+  logout as logoutRequest,
+  type CurrentUser,
+  type LoginRequest,
+  type LoginResponse,
+  type Role,
+} from '@/api/auth';
+
+const AUTH_QUERY_KEY = ['auth', 'me'] as const;
+
+type LoginFn = (payload: LoginRequest) => Promise<LoginResponse>;
+
+type UseAuthResult = {
+  login: LoginFn;
+  logout: () => void;
+  me: CurrentUser | null;
+  isAuthenticated: boolean;
+  roles: Role[];
+  hasRole: (role: Role) => boolean;
+};
+
+export function useAuth(): UseAuthResult {
+  const queryClient = useQueryClient();
+  const tokens = useSyncExternalStore(
+    subscribeToAuthTokens,
+    getAuthTokens,
+    getAuthTokens,
+  );
+
+  const hasAccessToken = Boolean(tokens?.accessToken);
+
+  const meQuery = useQuery({
+    queryKey: AUTH_QUERY_KEY,
+    queryFn: getCurrentUser,
+    enabled: hasAccessToken,
+    retry: (failureCount, error) => {
+      if (isAxiosError(error) && error.response?.status === 401) {
+        return false;
+      }
+
+      return failureCount < 2;
+    },
+  });
+
+  const loginMutation = useMutation({
+    mutationFn: (payload: LoginRequest) => loginRequest(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: AUTH_QUERY_KEY });
+    },
+  });
+
+  const logout = useCallback(() => {
+    logoutRequest();
+    queryClient.removeQueries({ queryKey: ['auth'] });
+  }, [queryClient]);
+
+  const roles = useMemo(() => meQuery.data?.roles ?? [], [meQuery.data]);
+
+  const hasRole = useCallback(
+    (role: Role) => roles.includes(role),
+    [roles],
+  );
+
+  return useMemo(
+    () => ({
+      login: loginMutation.mutateAsync as LoginFn,
+      logout,
+      me: meQuery.data ?? null,
+      isAuthenticated: Boolean(tokens?.accessToken),
+      roles,
+      hasRole,
+    }),
+    [hasRole, loginMutation.mutateAsync, logout, meQuery.data, roles, tokens?.accessToken],
+  );
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,6 +4,7 @@ import { I18nextProvider } from 'react-i18next';
 import { z } from 'zod';
 import App from './App';
 import i18n from './i18n';
+import './api/auth';
 import './index.css';
 import zodErrorMap from './lib/zodErrorMap';
 


### PR DESCRIPTION
## Summary
- add shared axios interceptor registration so new instances inherit Accept-Language and auth behavior
- implement auth client helpers to manage tokens, attach Authorization headers, and refresh on 401s
- provide a `useAuth` hook and tests covering login header injection and refresh retry logic

## Testing
- `yarn test`
- `yarn typecheck`
- `yarn build`

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68d0a793054083309b3fe872e6f2377b