### PR TITLE
feat(web): implement auth auth flows

### DIFF
--- a/apps/api-java/src/main/resources/messages_en.properties
+++ b/apps/api-java/src/main/resources/messages_en.properties
@@ -1,2 +1,2 @@
 mail.password-reset.subject=Reset your password
-mail.password-reset.body=We received a request to reset your password. Use the link below to set a new password:\n\n{0}\n\nIf you did not request a password reset, you can safely ignore this email.
+mail.password-reset.body=Reset your password.\n\nWe received a request to reset your password. Use the link below to set a new password:\n\n{0}\n\nIf you did not request a password reset, you can safely ignore this email.

--- a/apps/api-java/src/main/resources/messages_en.properties
+++ b/apps/api-java/src/main/resources/messages_en.properties
@@ -1,0 +1,2 @@
+mail.password-reset.subject=Reset your password
+mail.password-reset.body=We received a request to reset your password. Use the link below to set a new password:\n\n{0}\n\nIf you did not request a password reset, you can safely ignore this email.

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/email/MessageLocalizationTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/email/MessageLocalizationTest.java
@@ -1,0 +1,41 @@
+package com.homeputers.ebal2.api.email;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MessageLocalizationTest {
+
+    private Locale originalDefaultLocale;
+
+    @BeforeEach
+    void setUp() {
+        originalDefaultLocale = Locale.getDefault();
+        Locale.setDefault(new Locale("es", "MX"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        Locale.setDefault(originalDefaultLocale);
+    }
+
+    @Test
+    void resolvesEnglishContentWhenLocaleIsEnglish() {
+        ReloadableResourceBundleMessageSource messageSource = new ReloadableResourceBundleMessageSource();
+        messageSource.setBasename("classpath:messages");
+        messageSource.setDefaultEncoding("UTF-8");
+
+        String subject = messageSource.getMessage("mail.password-reset.subject", null, Locale.ENGLISH);
+        String body = messageSource.getMessage("mail.password-reset.body", new Object[]{"https://example.com"}, Locale.ENGLISH);
+
+        assertThat(subject).isEqualTo("Reset your password");
+        assertThat(body)
+                .contains("Reset your password")
+                .contains("https://example.com");
+    }
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -6,6 +6,7 @@ import { queryClient } from '@/lib/queryClient';
 import { Toaster } from 'sonner';
 import { ProtectedRoute } from '@/features/auth/components/ProtectedRoute';
 import { RequireRole } from '@/features/auth/components/RequireRole';
+import { DEFAULT_LANGUAGE } from '@/i18n';
 
 const Members = lazy(() => import('@/routes/Members'));
 const Groups = lazy(() => import('@/routes/Groups'));
@@ -18,34 +19,46 @@ const Services = lazy(() => import('@/routes/Services'));
 const ServiceDetail = lazy(() => import('@/routes/ServiceDetail'));
 const ServicePrint = lazy(() => import('@/routes/ServicePrint'));
 const ServicePlanView = lazy(() => import('@/routes/ServicePlanView'));
+const Login = lazy(() => import('@/routes/Login'));
+const ForgotPassword = lazy(() => import('@/routes/ForgotPassword'));
+const ResetPassword = lazy(() => import('@/routes/ResetPassword'));
+const ChangePassword = lazy(() => import('@/routes/ChangePassword'));
 
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <Routes>
-          <Route element={<LanguageGuard />}>
-            <Route path=":lang">
-              <Route element={<ProtectedRoute />}>
-                <Route index element={<Navigate to="members" replace />} />
-                <Route path="members" element={<Members />} />
-                <Route path="groups" element={<Groups />} />
-                <Route path="groups/:id" element={<GroupDetail />} />
-                <Route element={<RequireRole roles={['ADMIN', 'PLANNER']} />}>
-                  <Route path="songs" element={<Songs />} />
-                  <Route path="songs/:id" element={<SongDetail />} />
-                  <Route path="song-sets" element={<SongSets />} />
-                  <Route path="song-sets/:id" element={<SongSetDetail />} />
-                  <Route path="services/:id" element={<ServiceDetail />} />
-                </Route>
-                <Route path="services" element={<Services />} />
-                <Route path="services/:id/print" element={<ServicePrint />} />
-                <Route path="services/:id/plan" element={<ServicePlanView />} />
-                <Route path="admin/*" element={<RequireRole role="ADMIN" />} />
-                <Route path="*" element={<Navigate to="members" replace />} />
-              </Route>
-            </Route>
-          </Route>
+          <Route element={<LanguageGuard />}> 
+            <Route path=":lang"> 
+              <Route index element={<Navigate to="members" replace />} /> 
+              <Route path="login" element={<Login />} /> 
+              <Route path="forgot-password" element={<ForgotPassword />} /> 
+              <Route path="reset-password" element={<ResetPassword />} /> 
+              <Route element={<ProtectedRoute redirectTo="../login" />}> 
+                <Route path="change-password" element={<ChangePassword />} /> 
+                <Route path="members" element={<Members />} /> 
+                <Route path="groups" element={<Groups />} /> 
+                <Route path="groups/:id" element={<GroupDetail />} /> 
+                <Route element={<RequireRole roles={['ADMIN', 'PLANNER']} />}> 
+                  <Route path="songs" element={<Songs />} /> 
+                  <Route path="songs/:id" element={<SongDetail />} /> 
+                  <Route path="song-sets" element={<SongSets />} /> 
+                  <Route path="song-sets/:id" element={<SongSetDetail />} /> 
+                  <Route path="services/:id" element={<ServiceDetail />} /> 
+                </Route> 
+                <Route path="services" element={<Services />} /> 
+                <Route path="services/:id/print" element={<ServicePrint />} /> 
+                <Route path="services/:id/plan" element={<ServicePlanView />} /> 
+                <Route path="admin/*" element={<RequireRole role="ADMIN" />} /> 
+                <Route path="*" element={<Navigate to="members" replace />} /> 
+              </Route> 
+            </Route> 
+          </Route> 
+          <Route 
+            path="*" 
+            element={<Navigate to={`/${DEFAULT_LANGUAGE}`} replace />} 
+          /> 
         </Routes>
       </BrowserRouter>
       <Toaster />

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -12,6 +12,9 @@ import { RequestBodyOf, ResponseOf } from './type-helpers';
 
 type LoginPath = keyof paths & '/auth/login';
 type RefreshPath = keyof paths & '/auth/refresh';
+type ForgotPasswordPath = keyof paths & '/auth/forgot-password';
+type ResetPasswordPath = keyof paths & '/auth/reset-password';
+type ChangePasswordPath = keyof paths & '/auth/change-password';
 type MePath = keyof paths & '/auth/me';
 
 type AuthTokenPair = ResponseOf<LoginPath, 'post', 200>;
@@ -20,6 +23,9 @@ export type CurrentUser = ResponseOf<MePath, 'get', 200>;
 
 export type LoginRequest = RequestBodyOf<LoginPath, 'post'>;
 export type LoginResponse = AuthTokenPair;
+export type ForgotPasswordRequest = RequestBodyOf<ForgotPasswordPath, 'post'>;
+export type ResetPasswordRequest = RequestBodyOf<ResetPasswordPath, 'post'>;
+export type ChangePasswordRequest = RequestBodyOf<ChangePasswordPath, 'post'>;
 export type Role = CurrentUser['roles'][number];
 
 export type AuthTokens = AuthTokenPair & { expiresAt: number };
@@ -115,6 +121,20 @@ export const login = async (body: LoginRequest) => {
   const { data } = await apiClient.post<LoginResponse>('/auth/login', body);
   setCurrentTokens(data);
   return data;
+};
+
+export const requestPasswordReset = async (
+  body: ForgotPasswordRequest,
+) => {
+  await apiClient.post('/auth/forgot-password', body);
+};
+
+export const resetPassword = async (body: ResetPasswordRequest) => {
+  await apiClient.post('/auth/reset-password', body);
+};
+
+export const changePassword = async (body: ChangePasswordRequest) => {
+  await apiClient.post('/auth/change-password', body);
 };
 
 const requestTokenRefresh = async () => {

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -102,7 +102,13 @@ const setCurrentTokens = (tokens: AuthTokenPair) => {
   notifySubscribers();
 };
 
-export const getAuthTokens = () => currentTokens;
+export const getAuthTokens = () => {
+  if (!currentTokens) {
+    currentTokens = loadStoredTokens();
+  }
+
+  return currentTokens;
+};
 
 export const subscribeToAuthTokens = (listener: () => void) => {
   subscribers.add(listener);

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -36,7 +36,7 @@ const makeHref = (language: string, path: string) =>
 
 export function Navbar({ currentLanguage }: NavbarProps) {
   const { t } = useTranslation('common');
-  const { hasRole } = useAuth();
+  const { hasRole, isAuthenticated, logout } = useAuth();
 
   const visibleLinks = links.filter((link) => {
     if (!link.roles || link.roles.length === 0) {
@@ -61,7 +61,18 @@ export function Navbar({ currentLanguage }: NavbarProps) {
             </li>
           ))}
         </ul>
-        <LanguageSwitcher currentLanguage={currentLanguage} />
+        <div className="flex items-center gap-2">
+          {isAuthenticated ? (
+            <button
+              type="button"
+              onClick={logout}
+              className="rounded-md border border-white/30 bg-white/10 px-3 py-1 text-sm font-medium text-white hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+            >
+              {t('nav.logout')}
+            </button>
+          ) : null}
+          <LanguageSwitcher currentLanguage={currentLanguage} />
+        </div>
       </div>
     </nav>
   );

--- a/apps/web/src/features/auth/hooks.ts
+++ b/apps/web/src/features/auth/hooks.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import {
+  changePassword,
+  login,
+  requestPasswordReset,
+  resetPassword,
+  type ChangePasswordRequest,
+  type ForgotPasswordRequest,
+  type LoginRequest,
+  type LoginResponse,
+  type ResetPasswordRequest,
+} from '@/api/auth';
+
+const authRootKey = ['auth'] as const;
+
+export const authQueryKeys = {
+  all: authRootKey,
+  me: () => [...authRootKey, 'me'] as const,
+} as const;
+
+export function useLogin() {
+  const queryClient = useQueryClient();
+
+  return useMutation<LoginResponse, unknown, LoginRequest>({
+    mutationFn: (payload) => login(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: authQueryKeys.me() });
+    },
+  });
+}
+
+export function useForgotPassword() {
+  return useMutation<void, unknown, ForgotPasswordRequest>({
+    mutationFn: (payload) => requestPasswordReset(payload),
+  });
+}
+
+export function useResetPassword() {
+  return useMutation<void, unknown, ResetPasswordRequest>({
+    mutationFn: (payload) => resetPassword(payload),
+  });
+}
+
+export function useChangePassword() {
+  return useMutation<void, unknown, ChangePasswordRequest>({
+    mutationFn: (payload) => changePassword(payload),
+  });
+}

--- a/apps/web/src/i18n/index.ts
+++ b/apps/web/src/i18n/index.ts
@@ -6,6 +6,7 @@ export const DEFAULT_LANGUAGE = 'en';
 export const LANGUAGE_STORAGE_KEY = 'i18nextLng';
 export const NAMESPACES = [
   'common',
+  'auth',
   'members',
   'songs',
   'arrangements',

--- a/apps/web/src/locales/en/auth.json
+++ b/apps/web/src/locales/en/auth.json
@@ -40,6 +40,7 @@
     "title": "Choose a new password",
     "description": "Enter your new password to finish resetting your account.",
     "fields": {
+      "token": "Reset token",
       "newPassword": "New password",
       "confirmPassword": "Confirm new password"
     },

--- a/apps/web/src/locales/en/auth.json
+++ b/apps/web/src/locales/en/auth.json
@@ -1,0 +1,79 @@
+{
+  "login": {
+    "title": "Sign in",
+    "description": "Access Every Breath and Life with your account credentials.",
+    "fields": {
+      "email": "Email address",
+      "password": "Password"
+    },
+    "actions": {
+      "submit": "Sign in"
+    },
+    "links": {
+      "forgotPassword": "Forgot your password?",
+      "haveToken": "Have a reset link already?"
+    },
+    "notifications": {
+      "success": "Signed in successfully.",
+      "error": "We couldn't sign you in. Check your details and try again."
+    }
+  },
+  "forgotPassword": {
+    "title": "Reset your password",
+    "description": "Enter your email address and we'll send reset instructions if it exists in our system.",
+    "fields": {
+      "email": "Email address"
+    },
+    "actions": {
+      "submit": "Send reset email"
+    },
+    "links": {
+      "backToLogin": "Back to sign in"
+    },
+    "helpText": "We send the same message even if the address is not registered to protect your privacy.",
+    "notifications": {
+      "success": "If the address is on file, you'll receive a reset email shortly.",
+      "error": "We couldn't start the reset process right now. Please try again later."
+    }
+  },
+  "resetPassword": {
+    "title": "Choose a new password",
+    "description": "Enter your new password to finish resetting your account.",
+    "fields": {
+      "newPassword": "New password",
+      "confirmPassword": "Confirm new password"
+    },
+    "actions": {
+      "submit": "Update password"
+    },
+    "links": {
+      "backToLogin": "Return to sign in"
+    },
+    "helpText": "Use at least 8 characters and avoid reusing old passwords.",
+    "notifications": {
+      "missingToken": "This reset link is invalid or has expired. Request a new one to continue.",
+      "success": "Your password was updated. You can now sign in with it.",
+      "error": "We couldn't update your password. Try again or request a new reset email."
+    }
+  },
+  "changePassword": {
+    "title": "Change password",
+    "description": "Update your password to keep your account secure.",
+    "fields": {
+      "currentPassword": "Current password",
+      "newPassword": "New password",
+      "confirmPassword": "Confirm new password"
+    },
+    "actions": {
+      "submit": "Save password"
+    },
+    "links": {
+      "forgotPassword": "Can't remember your current password?"
+    },
+    "helpText": "Use at least 8 characters combining letters, numbers, or symbols.",
+    "notifications": {
+      "success": "Your password was updated successfully.",
+      "error": "We couldn't change your password. Confirm your current password and try again."
+    }
+  }
+}

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -7,7 +7,8 @@
     "services": "Services",
     "members": "Members",
     "groups": "Groups",
-    "songSets": "Song Sets"
+    "songSets": "Song Sets",
+    "logout": "Log out"
   },
   "actions": {
     "save": "Save",

--- a/apps/web/src/locales/en/validation.json
+++ b/apps/web/src/locales/en/validation.json
@@ -3,6 +3,7 @@
   "required": "This field is required.",
   "invalidType": "Enter a valid value.",
   "invalidEnumValue": "Please choose one of the allowed options.",
+  "passwordMismatch": "Passwords must match.",
   "email": "Enter a valid email address.",
   "minLength": "Must be at least {{count}} characters long.",
   "tooSmall": {

--- a/apps/web/src/locales/es/auth.json
+++ b/apps/web/src/locales/es/auth.json
@@ -1,0 +1,79 @@
+{
+  "login": {
+    "title": "Iniciar sesión",
+    "description": "Accede a Every Breath and Life con tus credenciales.",
+    "fields": {
+      "email": "Correo electrónico",
+      "password": "Contraseña"
+    },
+    "actions": {
+      "submit": "Iniciar sesión"
+    },
+    "links": {
+      "forgotPassword": "¿Olvidaste tu contraseña?",
+      "haveToken": "¿Ya tienes un enlace de restablecimiento?"
+    },
+    "notifications": {
+      "success": "Sesión iniciada correctamente.",
+      "error": "No pudimos iniciar sesión. Verifica tus datos e inténtalo de nuevo."
+    }
+  },
+  "forgotPassword": {
+    "title": "Restablecer contraseña",
+    "description": "Ingresa tu correo y enviaremos instrucciones si encontramos una cuenta activa.",
+    "fields": {
+      "email": "Correo electrónico"
+    },
+    "actions": {
+      "submit": "Enviar correo de restablecimiento"
+    },
+    "links": {
+      "backToLogin": "Volver a iniciar sesión"
+    },
+    "helpText": "Mostramos el mismo mensaje aunque la dirección no exista para proteger tu privacidad.",
+    "notifications": {
+      "success": "Si la dirección existe en el sistema, recibirás un correo en breve.",
+      "error": "No pudimos iniciar el proceso ahora. Intenta nuevamente más tarde."
+    }
+  },
+  "resetPassword": {
+    "title": "Elige una nueva contraseña",
+    "description": "Ingresa tu nueva contraseña para completar el restablecimiento.",
+    "fields": {
+      "newPassword": "Nueva contraseña",
+      "confirmPassword": "Confirmar contraseña"
+    },
+    "actions": {
+      "submit": "Actualizar contraseña"
+    },
+    "links": {
+      "backToLogin": "Volver a iniciar sesión"
+    },
+    "helpText": "Usa al menos 8 caracteres y evita reutilizar contraseñas anteriores.",
+    "notifications": {
+      "missingToken": "Este enlace no es válido o ha expirado. Solicita uno nuevo para continuar.",
+      "success": "La contraseña se actualizó. Ya puedes iniciar sesión con ella.",
+      "error": "No pudimos actualizar la contraseña. Intenta nuevamente o solicita un nuevo correo."
+    }
+  },
+  "changePassword": {
+    "title": "Cambiar contraseña",
+    "description": "Actualiza tu contraseña para mantener tu cuenta segura.",
+    "fields": {
+      "currentPassword": "Contraseña actual",
+      "newPassword": "Nueva contraseña",
+      "confirmPassword": "Confirmar contraseña"
+    },
+    "actions": {
+      "submit": "Guardar contraseña"
+    },
+    "links": {
+      "forgotPassword": "¿No recuerdas tu contraseña actual?"
+    },
+    "helpText": "Usa al menos 8 caracteres combinando letras, números o símbolos.",
+    "notifications": {
+      "success": "La contraseña se actualizó correctamente.",
+      "error": "No pudimos cambiar la contraseña. Confirma tu contraseña actual e inténtalo nuevamente."
+    }
+  }
+}

--- a/apps/web/src/locales/es/auth.json
+++ b/apps/web/src/locales/es/auth.json
@@ -40,6 +40,7 @@
     "title": "Elige una nueva contraseña",
     "description": "Ingresa tu nueva contraseña para completar el restablecimiento.",
     "fields": {
+      "token": "Token de restablecimiento",
       "newPassword": "Nueva contraseña",
       "confirmPassword": "Confirmar contraseña"
     },

--- a/apps/web/src/locales/es/common.json
+++ b/apps/web/src/locales/es/common.json
@@ -7,7 +7,8 @@
     "services": "Servicios",
     "members": "Miembros",
     "groups": "Grupos",
-    "songSets": "Listas de canciones"
+    "songSets": "Listas de canciones",
+    "logout": "Cerrar sesión"
   },
   "actions": {
     "save": "Guardar",

--- a/apps/web/src/locales/es/validation.json
+++ b/apps/web/src/locales/es/validation.json
@@ -3,6 +3,7 @@
   "required": "Este campo es obligatorio.",
   "invalidType": "Ingresa un valor válido.",
   "invalidEnumValue": "Elige una de las opciones permitidas.",
+  "passwordMismatch": "Las contraseñas deben coincidir.",
   "email": "Ingresa una dirección de correo válida.",
   "minLength": "Debe tener al menos {{count}} caracteres.",
   "tooSmall": {

--- a/apps/web/src/pages/auth/AuthPageLayout.tsx
+++ b/apps/web/src/pages/auth/AuthPageLayout.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+
+type AuthPageLayoutProps = {
+  title: string;
+  description?: string;
+  children: ReactNode;
+  footer?: ReactNode;
+};
+
+export function AuthPageLayout({
+  title,
+  description,
+  children,
+  footer,
+}: AuthPageLayoutProps) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center bg-gray-50 px-4 py-12">
+      <div className="w-full max-w-md space-y-6">
+        <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+          <div>
+            <h1 className="text-2xl font-semibold text-gray-900">{title}</h1>
+            {description ? (
+              <p className="mt-2 text-sm text-gray-600">{description}</p>
+            ) : null}
+          </div>
+          <div className="mt-6">{children}</div>
+        </div>
+        {footer ? (
+          <div className="text-center text-sm text-gray-600">{footer}</div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/auth/ChangePasswordPage.tsx
+++ b/apps/web/src/pages/auth/ChangePasswordPage.tsx
@@ -1,0 +1,150 @@
+import { useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { isAxiosError } from 'axios';
+import { Link, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+
+import { AuthPageLayout } from '@/pages/auth/AuthPageLayout';
+import { buildLanguagePath } from '@/pages/auth/utils';
+import { useChangePassword } from '@/features/auth/hooks';
+
+const MIN_PASSWORD_LENGTH = 8;
+
+export default function ChangePasswordPage() {
+  const { t } = useTranslation('auth');
+  const { t: tValidation } = useTranslation('validation');
+  const params = useParams();
+  const language = params.lang;
+  const changePasswordMutation = useChangePassword();
+
+  const schema = useMemo(
+    () =>
+      z
+        .object({
+          currentPassword: z
+            .string()
+            .min(1, { message: tValidation('required') }),
+          newPassword: z
+            .string()
+            .min(MIN_PASSWORD_LENGTH, {
+              message: tValidation('tooSmall.string', { minimum: MIN_PASSWORD_LENGTH }),
+            }),
+          confirmPassword: z
+            .string()
+            .min(MIN_PASSWORD_LENGTH, {
+              message: tValidation('tooSmall.string', { minimum: MIN_PASSWORD_LENGTH }),
+            }),
+        })
+        .refine((value) => value.newPassword === value.confirmPassword, {
+          path: ['confirmPassword'],
+          message: tValidation('passwordMismatch'),
+        }),
+    [tValidation],
+  );
+
+  type ChangePasswordForm = z.infer<typeof schema>;
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<ChangePasswordForm>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      currentPassword: '',
+      newPassword: '',
+      confirmPassword: '',
+    },
+  });
+
+  const onSubmit = handleSubmit(async (values) => {
+    try {
+      await changePasswordMutation.mutateAsync({
+        currentPassword: values.currentPassword,
+        newPassword: values.newPassword,
+      });
+      toast.success(t('changePassword.notifications.success'));
+      reset();
+    } catch (error) {
+      const message = isAxiosError(error)
+        ? error.response?.data?.message ?? error.response?.data?.error
+        : null;
+      toast.error(message ?? t('changePassword.notifications.error'));
+    }
+  });
+
+  return (
+    <AuthPageLayout
+      title={t('changePassword.title')}
+      description={t('changePassword.description')}
+      footer={
+        <Link
+          to={buildLanguagePath(language, 'forgot-password')}
+          className="text-sm text-gray-600 hover:text-gray-800 hover:underline"
+        >
+          {t('changePassword.links.forgotPassword')}
+        </Link>
+      }
+    >
+      <form className="space-y-4" onSubmit={onSubmit} noValidate>
+        <div>
+          <label className="block text-sm font-medium text-gray-700" htmlFor="currentPassword">
+            {t('changePassword.fields.currentPassword')}
+          </label>
+          <input
+            id="currentPassword"
+            type="password"
+            autoComplete="current-password"
+            className="mt-1 w-full rounded-md border border-gray-300 p-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            {...register('currentPassword')}
+          />
+          {errors.currentPassword ? (
+            <p className="mt-1 text-sm text-red-600">{errors.currentPassword.message}</p>
+          ) : null}
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700" htmlFor="newPassword">
+            {t('changePassword.fields.newPassword')}
+          </label>
+          <input
+            id="newPassword"
+            type="password"
+            autoComplete="new-password"
+            className="mt-1 w-full rounded-md border border-gray-300 p-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            {...register('newPassword')}
+          />
+          {errors.newPassword ? (
+            <p className="mt-1 text-sm text-red-600">{errors.newPassword.message}</p>
+          ) : null}
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700" htmlFor="confirmPassword">
+            {t('changePassword.fields.confirmPassword')}
+          </label>
+          <input
+            id="confirmPassword"
+            type="password"
+            autoComplete="new-password"
+            className="mt-1 w-full rounded-md border border-gray-300 p-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            {...register('confirmPassword')}
+          />
+          {errors.confirmPassword ? (
+            <p className="mt-1 text-sm text-red-600">{errors.confirmPassword.message}</p>
+          ) : null}
+        </div>
+        <button
+          type="submit"
+          disabled={isSubmitting || changePasswordMutation.isPending}
+          className="w-full rounded-md bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+        >
+          {t('changePassword.actions.submit')}
+        </button>
+        <p className="text-xs text-gray-500">{t('changePassword.helpText')}</p>
+      </form>
+    </AuthPageLayout>
+  );
+}

--- a/apps/web/src/pages/auth/ForgotPasswordPage.tsx
+++ b/apps/web/src/pages/auth/ForgotPasswordPage.tsx
@@ -1,0 +1,102 @@
+import { useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { isAxiosError } from 'axios';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+
+import { AuthPageLayout } from '@/pages/auth/AuthPageLayout';
+import { buildLanguagePath } from '@/pages/auth/utils';
+import { useForgotPassword } from '@/features/auth/hooks';
+
+export default function ForgotPasswordPage() {
+  const { t } = useTranslation('auth');
+  const { t: tValidation } = useTranslation('validation');
+  const params = useParams();
+  const language = params.lang;
+  const navigate = useNavigate();
+  const forgotPasswordMutation = useForgotPassword();
+
+  const schema = useMemo(
+    () =>
+      z.object({
+        email: z
+          .string()
+          .trim()
+          .min(1, { message: tValidation('required') })
+          .email({ message: tValidation('email') }),
+      }),
+    [tValidation],
+  );
+
+  type ForgotPasswordForm = z.infer<typeof schema>;
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<ForgotPasswordForm>({
+    resolver: zodResolver(schema),
+    defaultValues: { email: '' },
+  });
+
+  const onSubmit = handleSubmit(async (values) => {
+    try {
+      await forgotPasswordMutation.mutateAsync(values);
+      toast.success(t('forgotPassword.notifications.success'));
+      reset();
+      navigate(buildLanguagePath(language, 'login'));
+    } catch (error) {
+      const message = isAxiosError(error)
+        ? error.response?.data?.message ?? error.response?.data?.error
+        : null;
+      toast.error(message ?? t('forgotPassword.notifications.error'));
+    }
+  });
+
+  return (
+    <AuthPageLayout
+      title={t('forgotPassword.title')}
+      description={t('forgotPassword.description')}
+      footer={
+        <Link
+          to={buildLanguagePath(language, 'login')}
+          className="text-sm text-gray-600 hover:text-gray-800 hover:underline"
+        >
+          {t('forgotPassword.links.backToLogin')}
+        </Link>
+      }
+    >
+      <form className="space-y-4" onSubmit={onSubmit} noValidate>
+        <div>
+          <label className="block text-sm font-medium text-gray-700" htmlFor="email">
+            {t('forgotPassword.fields.email')}
+          </label>
+          <input
+            id="email"
+            type="email"
+            autoComplete="email"
+            className="mt-1 w-full rounded-md border border-gray-300 p-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            {...register('email')}
+          />
+          {errors.email ? (
+            <p className="mt-1 text-sm text-red-600">{errors.email.message}</p>
+          ) : null}
+        </div>
+        <button
+          type="submit"
+          disabled={isSubmitting || forgotPasswordMutation.isPending}
+          className="w-full rounded-md bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+        >
+          {t('forgotPassword.actions.submit')}
+        </button>
+        <p className="text-xs text-gray-500">
+          {t('forgotPassword.helpText')}
+        </p>
+      </form>
+    </AuthPageLayout>
+  );
+}

--- a/apps/web/src/pages/auth/LoginPage.tsx
+++ b/apps/web/src/pages/auth/LoginPage.tsx
@@ -1,0 +1,155 @@
+import { useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { isAxiosError } from 'axios';
+import {
+  Link,
+  Navigate,
+  type Location,
+  useLocation,
+  useNavigate,
+  useParams,
+} from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+
+import { AuthPageLayout } from '@/pages/auth/AuthPageLayout';
+import { buildLanguagePath } from '@/pages/auth/utils';
+import { useLogin } from '@/features/auth/hooks';
+import { useAuth } from '@/features/auth/useAuth';
+
+const MIN_PASSWORD_LENGTH = 8;
+
+export default function LoginPage() {
+  const { t } = useTranslation('auth');
+  const { t: tValidation } = useTranslation('validation');
+  const { isAuthenticated } = useAuth();
+  const loginMutation = useLogin();
+  const params = useParams();
+  const language = params.lang;
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const loginSchema = useMemo(
+    () =>
+      z.object({
+        email: z
+          .string()
+          .trim()
+          .min(1, { message: tValidation('required') })
+          .email({ message: tValidation('email') }),
+        password: z
+          .string()
+          .min(MIN_PASSWORD_LENGTH, {
+            message: tValidation('tooSmall.string', { minimum: MIN_PASSWORD_LENGTH }),
+          }),
+      }),
+    [tValidation],
+  );
+
+  type LoginFormValues = z.infer<typeof loginSchema>;
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<LoginFormValues>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+  });
+
+  const locationState = location.state as { from?: Location } | undefined;
+  const fromLocation = locationState?.from;
+  const fallbackPath = language ? buildLanguagePath(language, 'members') : '/';
+  const redirectTo = fromLocation
+    ? `${fromLocation.pathname}${fromLocation.search}${fromLocation.hash}`
+    : fallbackPath;
+
+  const onSubmit = handleSubmit(async (values) => {
+    try {
+      await loginMutation.mutateAsync(values);
+      toast.success(t('login.notifications.success'));
+      navigate(redirectTo, { replace: true });
+    } catch (error) {
+      const message = isAxiosError(error)
+        ? error.response?.data?.message ?? error.response?.data?.error
+        : null;
+      toast.error(message ?? t('login.notifications.error'));
+    }
+  });
+
+  if (isAuthenticated) {
+    return <Navigate to={fallbackPath} replace />;
+  }
+
+  return (
+    <AuthPageLayout
+      title={t('login.title')}
+      description={t('login.description')}
+      footer={
+        <div className="space-y-2">
+          <div>
+            <Link
+              to={buildLanguagePath(language, 'forgot-password')}
+              className="font-medium text-blue-600 hover:underline"
+            >
+              {t('login.links.forgotPassword')}
+            </Link>
+          </div>
+          <div>
+            <Link
+              to={buildLanguagePath(language, 'reset-password')}
+              className="text-sm text-gray-600 hover:text-gray-800 hover:underline"
+            >
+              {t('login.links.haveToken')}
+            </Link>
+          </div>
+        </div>
+      }
+    >
+      <form className="space-y-4" onSubmit={onSubmit} noValidate>
+        <div>
+          <label className="block text-sm font-medium text-gray-700" htmlFor="email">
+            {t('login.fields.email')}
+          </label>
+          <input
+            id="email"
+            type="email"
+            autoComplete="email"
+            className="mt-1 w-full rounded-md border border-gray-300 p-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            {...register('email')}
+          />
+          {errors.email ? (
+            <p className="mt-1 text-sm text-red-600">{errors.email.message}</p>
+          ) : null}
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700" htmlFor="password">
+            {t('login.fields.password')}
+          </label>
+          <input
+            id="password"
+            type="password"
+            autoComplete="current-password"
+            className="mt-1 w-full rounded-md border border-gray-300 p-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            {...register('password')}
+          />
+          {errors.password ? (
+            <p className="mt-1 text-sm text-red-600">{errors.password.message}</p>
+          ) : null}
+        </div>
+        <button
+          type="submit"
+          disabled={isSubmitting || loginMutation.isPending}
+          className="w-full rounded-md bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+        >
+          {t('login.actions.submit')}
+        </button>
+      </form>
+    </AuthPageLayout>
+  );
+}

--- a/apps/web/src/pages/auth/ResetPasswordPage.tsx
+++ b/apps/web/src/pages/auth/ResetPasswordPage.tsx
@@ -1,0 +1,151 @@
+import { useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { isAxiosError } from 'axios';
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+
+import { AuthPageLayout } from '@/pages/auth/AuthPageLayout';
+import { buildLanguagePath } from '@/pages/auth/utils';
+import { useResetPassword } from '@/features/auth/hooks';
+
+const MIN_PASSWORD_LENGTH = 8;
+
+export default function ResetPasswordPage() {
+  const { t } = useTranslation('auth');
+  const { t: tValidation } = useTranslation('validation');
+  const params = useParams();
+  const language = params.lang;
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token') ?? '';
+  const resetPasswordMutation = useResetPassword();
+
+  const schema = useMemo(
+    () =>
+      z
+        .object({
+          newPassword: z
+            .string()
+            .min(MIN_PASSWORD_LENGTH, {
+              message: tValidation('tooSmall.string', { minimum: MIN_PASSWORD_LENGTH }),
+            }),
+          confirmPassword: z
+            .string()
+            .min(MIN_PASSWORD_LENGTH, {
+              message: tValidation('tooSmall.string', { minimum: MIN_PASSWORD_LENGTH }),
+            }),
+        })
+        .refine((value) => value.newPassword === value.confirmPassword, {
+          path: ['confirmPassword'],
+          message: tValidation('passwordMismatch'),
+        }),
+    [tValidation],
+  );
+
+  type ResetPasswordForm = z.infer<typeof schema>;
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<ResetPasswordForm>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      newPassword: '',
+      confirmPassword: '',
+    },
+  });
+
+  const isTokenMissing = token.trim().length === 0;
+
+  const onSubmit = handleSubmit(async (values) => {
+    if (isTokenMissing) {
+      toast.error(t('resetPassword.notifications.missingToken'));
+      return;
+    }
+
+    try {
+      await resetPasswordMutation.mutateAsync({
+        token,
+        newPassword: values.newPassword,
+      });
+      toast.success(t('resetPassword.notifications.success'));
+      reset();
+      navigate(buildLanguagePath(language, 'login'));
+    } catch (error) {
+      const message = isAxiosError(error)
+        ? error.response?.data?.message ?? error.response?.data?.error
+        : null;
+      toast.error(message ?? t('resetPassword.notifications.error'));
+    }
+  });
+
+  return (
+    <AuthPageLayout
+      title={t('resetPassword.title')}
+      description={t('resetPassword.description')}
+      footer={
+        <Link
+          to={buildLanguagePath(language, 'login')}
+          className="text-sm text-gray-600 hover:text-gray-800 hover:underline"
+        >
+          {t('resetPassword.links.backToLogin')}
+        </Link>
+      }
+    >
+      {isTokenMissing ? (
+        <div className="rounded border border-yellow-300 bg-yellow-50 p-4 text-sm text-yellow-800">
+          {t('resetPassword.notifications.missingToken')}
+        </div>
+      ) : null}
+      <form className="mt-4 space-y-4" onSubmit={onSubmit} noValidate>
+        <div>
+          <label className="block text-sm font-medium text-gray-700" htmlFor="newPassword">
+            {t('resetPassword.fields.newPassword')}
+          </label>
+          <input
+            id="newPassword"
+            type="password"
+            autoComplete="new-password"
+            className="mt-1 w-full rounded-md border border-gray-300 p-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            {...register('newPassword')}
+          />
+          {errors.newPassword ? (
+            <p className="mt-1 text-sm text-red-600">{errors.newPassword.message}</p>
+          ) : null}
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700" htmlFor="confirmPassword">
+            {t('resetPassword.fields.confirmPassword')}
+          </label>
+          <input
+            id="confirmPassword"
+            type="password"
+            autoComplete="new-password"
+            className="mt-1 w-full rounded-md border border-gray-300 p-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            {...register('confirmPassword')}
+          />
+          {errors.confirmPassword ? (
+            <p className="mt-1 text-sm text-red-600">{errors.confirmPassword.message}</p>
+          ) : null}
+        </div>
+        <button
+          type="submit"
+          disabled={
+            isSubmitting ||
+            resetPasswordMutation.isPending ||
+            isTokenMissing
+          }
+          className="w-full rounded-md bg-blue-600 px-4 py-2 text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+        >
+          {t('resetPassword.actions.submit')}
+        </button>
+        <p className="text-xs text-gray-500">{t('resetPassword.helpText')}</p>
+      </form>
+    </AuthPageLayout>
+  );
+}

--- a/apps/web/src/pages/auth/utils.ts
+++ b/apps/web/src/pages/auth/utils.ts
@@ -1,0 +1,9 @@
+export const buildLanguagePath = (
+  language: string | undefined,
+  path: string,
+) => {
+  const normalizedLanguage = language ?? '';
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const combined = `/${normalizedLanguage}${normalizedPath}`;
+  return combined.replace(/\/+/g, '/');
+};

--- a/apps/web/src/routes/ChangePassword.tsx
+++ b/apps/web/src/routes/ChangePassword.tsx
@@ -1,0 +1,15 @@
+import { MissingTranslationBoundary } from '@/components/MissingTranslationBoundary';
+import ChangePasswordPage from '@/pages/auth/ChangePasswordPage';
+
+const changeNamespaces = ['auth', 'validation', 'common'] as const;
+
+export default function ChangePasswordRoute() {
+  return (
+    <MissingTranslationBoundary
+      componentName="ChangePasswordPage"
+      namespaces={changeNamespaces}
+    >
+      <ChangePasswordPage />
+    </MissingTranslationBoundary>
+  );
+}

--- a/apps/web/src/routes/ForgotPassword.tsx
+++ b/apps/web/src/routes/ForgotPassword.tsx
@@ -1,0 +1,15 @@
+import { MissingTranslationBoundary } from '@/components/MissingTranslationBoundary';
+import ForgotPasswordPage from '@/pages/auth/ForgotPasswordPage';
+
+const forgotNamespaces = ['auth', 'validation', 'common'] as const;
+
+export default function ForgotPasswordRoute() {
+  return (
+    <MissingTranslationBoundary
+      componentName="ForgotPasswordPage"
+      namespaces={forgotNamespaces}
+    >
+      <ForgotPasswordPage />
+    </MissingTranslationBoundary>
+  );
+}

--- a/apps/web/src/routes/Login.tsx
+++ b/apps/web/src/routes/Login.tsx
@@ -1,0 +1,15 @@
+import { MissingTranslationBoundary } from '@/components/MissingTranslationBoundary';
+import LoginPage from '@/pages/auth/LoginPage';
+
+const loginNamespaces = ['auth', 'validation', 'common'] as const;
+
+export default function LoginRoute() {
+  return (
+    <MissingTranslationBoundary
+      componentName="LoginPage"
+      namespaces={loginNamespaces}
+    >
+      <LoginPage />
+    </MissingTranslationBoundary>
+  );
+}

--- a/apps/web/src/routes/ResetPassword.tsx
+++ b/apps/web/src/routes/ResetPassword.tsx
@@ -1,0 +1,15 @@
+import { MissingTranslationBoundary } from '@/components/MissingTranslationBoundary';
+import ResetPasswordPage from '@/pages/auth/ResetPasswordPage';
+
+const resetNamespaces = ['auth', 'validation', 'common'] as const;
+
+export default function ResetPasswordRoute() {
+  return (
+    <MissingTranslationBoundary
+      componentName="ResetPasswordPage"
+      namespaces={resetNamespaces}
+    >
+      <ResetPasswordPage />
+    </MissingTranslationBoundary>
+  );
+}

--- a/apps/web/tests/language-switcher.spec.ts
+++ b/apps/web/tests/language-switcher.spec.ts
@@ -10,10 +10,73 @@ const ES_NAV_LABELS = [
 ];
 
 const LANGUAGE_BUTTON_NAME = /Change language|Cambiar idioma/;
+const AUTH_STORAGE_KEY = 'ebal.auth.tokens';
+
+const stubAuthMeResponse = {
+  id: 'e2e-user',
+  email: 'e2e@example.com',
+  displayName: 'E2E User',
+  roles: ['ADMIN'],
+};
+
+const emptyServicesPage = {
+  content: [],
+  totalElements: 0,
+  totalPages: 1,
+  number: 0,
+  size: 20,
+  first: true,
+  last: true,
+  numberOfElements: 0,
+  sort: { sorted: false, unsorted: true, empty: true },
+  pageable: {
+    sort: { sorted: false, unsorted: true, empty: true },
+    pageNumber: 0,
+    pageSize: 20,
+    offset: 0,
+    paged: true,
+    unpaged: false,
+  },
+  empty: true,
+};
+
+const createAuthTokens = () => ({
+  accessToken: 'e2e-access-token',
+  refreshToken: 'e2e-refresh-token',
+  expiresAt: Date.now() + 60 * 60 * 1000,
+});
 
 test('language switcher smoke: switches navigation language and persists after reload', async ({
   page,
 }) => {
+  await page.route('**/api/v1/auth/me', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(stubAuthMeResponse),
+    });
+  });
+
+  await page.route('**/api/v1/services**', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(emptyServicesPage),
+    });
+  });
+
+  await page.addInitScript(
+    ({ storageKey, tokens }) => {
+      window.localStorage.setItem(storageKey, JSON.stringify(tokens));
+    },
+    { storageKey: AUTH_STORAGE_KEY, tokens: createAuthTokens() },
+  );
+
   await page.goto('/en/services');
 
   for (const label of EN_NAV_LABELS) {


### PR DESCRIPTION
## Summary
- add auth client helpers and TanStack Query mutations for login, recovery, and password change flows
- build shared auth layout plus RHF + Zod-driven login, forgot, reset, and change password screens with toast feedback
- register the new auth routes and localization resources, including the auth namespace and validation copy updates

## Testing
- yarn lint
- yarn typecheck
- yarn test --watch=false
- yarn build

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [x] Web: Loading/error states; basic a11y; responsive layout
- [x] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68d190ec190083309e0a4c9c7f12455b