### PR TITLE
fix: restrict members access for non-planner roles

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -34,22 +34,22 @@ export default function App() {
         <Routes>
           <Route element={<LanguageGuard />}> 
             <Route path=":lang"> 
-              <Route index element={<Navigate to="members" replace />} /> 
+              <Route index element={<Navigate to="services" replace />} />
               <Route path="login" element={<Login />} /> 
               <Route path="forgot-password" element={<ForgotPassword />} /> 
               <Route path="reset-password" element={<ResetPassword />} /> 
               <Route element={<ProtectedRoute redirectTo="../login" />}> 
                 <Route path="change-password" element={<ChangePassword />} /> 
-                <Route path="members" element={<Members />} /> 
-                <Route path="groups" element={<Groups />} /> 
-                <Route path="groups/:id" element={<GroupDetail />} /> 
-                <Route element={<RequireRole roles={['ADMIN', 'PLANNER']} />}> 
-                  <Route path="songs" element={<Songs />} /> 
-                  <Route path="songs/:id" element={<SongDetail />} /> 
-                  <Route path="song-sets" element={<SongSets />} /> 
-                  <Route path="song-sets/:id" element={<SongSetDetail />} /> 
-                  <Route path="services/:id" element={<ServiceDetail />} /> 
-                </Route> 
+                <Route element={<RequireRole roles={['ADMIN', 'PLANNER']} />}>
+                  <Route path="members" element={<Members />} />
+                  <Route path="groups" element={<Groups />} />
+                  <Route path="groups/:id" element={<GroupDetail />} />
+                  <Route path="songs" element={<Songs />} />
+                  <Route path="songs/:id" element={<SongDetail />} />
+                  <Route path="song-sets" element={<SongSets />} />
+                  <Route path="song-sets/:id" element={<SongSetDetail />} />
+                  <Route path="services/:id" element={<ServiceDetail />} />
+                </Route>
                 <Route path="services" element={<Services />} /> 
                 <Route path="services/:id/print" element={<ServicePrint />} /> 
                 <Route path="services/:id/plan" element={<ServicePlanView />} />
@@ -58,7 +58,7 @@ export default function App() {
                   <Route path="admin/users/new" element={<AdminUserCreate />} />
                   <Route path="admin/users/:id" element={<AdminUserDetail />} />
                 </Route>
-                <Route path="*" element={<Navigate to="members" replace />} />
+                <Route path="*" element={<Navigate to="services" replace />} />
               </Route>
             </Route>
           </Route> 

--- a/apps/web/src/components/__tests__/LanguageSwitcher.test.tsx
+++ b/apps/web/src/components/__tests__/LanguageSwitcher.test.tsx
@@ -87,7 +87,7 @@ describe('LanguageSwitcher', () => {
   }) => {
     await changeLanguage(language);
 
-    renderLanguageSwitcher(language, `/${language}/members`);
+    renderLanguageSwitcher(language, `/${language}/services`);
 
     const button = screen.getByRole('button', { name: ariaLabel });
 

--- a/apps/web/src/pages/auth/LoginPage.tsx
+++ b/apps/web/src/pages/auth/LoginPage.tsx
@@ -64,7 +64,7 @@ export default function LoginPage() {
 
   const locationState = location.state as { from?: Location } | undefined;
   const fromLocation = locationState?.from;
-  const fallbackPath = language ? buildLanguagePath(language, 'members') : '/';
+  const fallbackPath = language ? buildLanguagePath(language, 'services') : '/';
   const redirectTo = fromLocation
     ? `${fromLocation.pathname}${fromLocation.search}${fromLocation.hash}`
     : fallbackPath;


### PR DESCRIPTION
## Summary
- redirect the default locale route to services so limited roles avoid the members page
- require ADMIN/PLANNER for the members and groups routes to match navbar visibility
- update auth redirect fallback and language switcher test to use the services path

## Testing
- yarn test
- yarn build

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68d2dafd28088330a065d9ced4cb744e