### PR TITLE
feat: add self-service profile endpoints

### DIFF
--- a/apps/web/src/api/types.d.ts
+++ b/apps/web/src/api/types.d.ts
@@ -160,6 +160,114 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Retrieve the signed-in user's profile
+         * @description Returns profile details for the currently authenticated user.
+         */
+        get: operations["getMyProfile"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update the signed-in user's profile
+         * @description Updates the display name or avatar preferences for the authenticated user.
+         */
+        patch: operations["updateMyProfile"];
+        trace?: never;
+    };
+    "/me/avatar": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Upload a new avatar for the signed-in user
+         * @description Accepts a square image up to 2MB in PNG, JPEG, or WebP format. The server may crop or resize the image.
+         */
+        post: operations["uploadMyAvatar"];
+        /**
+         * Remove the signed-in user's avatar
+         * @description Deletes the current avatar image for the authenticated user.
+         */
+        delete: operations["deleteMyAvatar"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/me/change-password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Change the signed-in user's password
+         * @description Alias of the change password flow requiring the current password.
+         */
+        post: operations["changeMyPassword"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/me/change-email": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Request an email change for the signed-in user
+         * @description Sends a confirmation link to the new email address after validating the current password.
+         */
+        post: operations["requestMyEmailChange"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/me/confirm-email": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Confirm a pending email change for the signed-in user
+         * @description Consumes the confirmation token, applies the new email, and revokes existing refresh tokens.
+         */
+        post: operations["confirmMyEmail"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/users": {
         parameters: {
             query?: never;
@@ -608,6 +716,21 @@ export interface components {
             /** @description High level status string for the storage module. */
             status: string;
         };
+        /** @description RFC 7807 problem details with optional application-specific fields. */
+        ProblemDetail: {
+            /** Format: uri */
+            type?: string;
+            title?: string;
+            /** Format: int32 */
+            status?: number;
+            detail?: string;
+            /** Format: uri */
+            instance?: string;
+            errors?: {
+                [key: string]: string;
+            };
+            code?: string;
+        };
         /**
          * @description Role assigned to a user determining access level.
          * @enum {string}
@@ -621,6 +744,21 @@ export interface components {
             displayName: string;
             roles: components["schemas"]["Role"][];
             isActive: boolean;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+        };
+        MyProfile: {
+            /** Format: uuid */
+            id: string;
+            /** Format: email */
+            email: string;
+            displayName: string;
+            roles: components["schemas"]["Role"][];
+            isActive: boolean;
+            /** Format: uri */
+            avatarUrl?: string;
             /** Format: date-time */
             createdAt: string;
             /** Format: date-time */
@@ -651,6 +789,27 @@ export interface components {
         ChangePasswordRequest: {
             currentPassword: string;
             newPassword: string;
+        };
+        UpdateMyProfileRequest: {
+            displayName?: string;
+            /**
+             * @description Action to take for the current avatar image.
+             * @default KEEP
+             * @enum {string}
+             */
+            avatarAction: "KEEP" | "REMOVE";
+        };
+        ChangeMyEmailRequest: {
+            currentPassword: string;
+            /** Format: email */
+            newEmail: string;
+        };
+        ConfirmMyEmailRequest: {
+            token: string;
+        };
+        UploadAvatarResponse: {
+            /** Format: uri */
+            avatarUrl: string;
         };
         ForgotPasswordRequest: {
             /** Format: email */
@@ -923,7 +1082,10 @@ export interface operations {
     requestPasswordReset: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Preferred language for the password reset email content. */
+                "Accept-Language"?: string;
+            };
             path?: never;
             cookie?: never;
         };
@@ -1010,6 +1172,290 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    getMyProfile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Current profile information */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MyProfile"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+        };
+    };
+    updateMyProfile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateMyProfileRequest"];
+            };
+        };
+        responses: {
+            /** @description Updated profile information */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MyProfile"];
+                };
+            };
+            /** @description Invalid profile update */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+        };
+    };
+    uploadMyAvatar: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": {
+                    /**
+                     * Format: binary
+                     * @description Avatar image file (PNG, JPEG, or WebP, up to 2MB).
+                     */
+                    file: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Avatar uploaded successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UploadAvatarResponse"];
+                };
+            };
+            /** @description Invalid avatar upload */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+        };
+    };
+    deleteMyAvatar: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Avatar removed */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+        };
+    };
+    changeMyPassword: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ChangePasswordRequest"];
+            };
+        };
+        responses: {
+            /** @description Password updated successfully */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid password change request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+        };
+    };
+    requestMyEmailChange: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ChangeMyEmailRequest"];
+            };
+        };
+        responses: {
+            /** @description Email change initiated */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid email change request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Email already in use */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+        };
+    };
+    confirmMyEmail: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConfirmMyEmailRequest"];
+            };
+        };
+        responses: {
+            /** @description Email change confirmed */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid confirmation token */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Email already in use */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
             };
         };
     };

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -146,6 +146,220 @@ paths:
                 $ref: '#/components/schemas/User'
         '401':
           description: Unauthorized
+  /me:
+    get:
+      tags:
+        - Profile
+      summary: Retrieve the signed-in user's profile
+      description: Returns profile details for the currently authenticated user.
+      operationId: getMyProfile
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Current profile information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MyProfile'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+    patch:
+      tags:
+        - Profile
+      summary: Update the signed-in user's profile
+      description: Updates the display name or avatar preferences for the authenticated user.
+      operationId: updateMyProfile
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateMyProfileRequest'
+      responses:
+        '200':
+          description: Updated profile information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MyProfile'
+        '400':
+          description: Invalid profile update
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+  /me/avatar:
+    post:
+      tags:
+        - Profile
+      summary: Upload a new avatar for the signed-in user
+      description: Accepts a square image up to 2MB in PNG, JPEG, or WebP format. The server may crop or resize the image.
+      operationId: uploadMyAvatar
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: Avatar image file (PNG, JPEG, or WebP, up to 2MB).
+      responses:
+        '200':
+          description: Avatar uploaded successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UploadAvatarResponse'
+        '400':
+          description: Invalid avatar upload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+    delete:
+      tags:
+        - Profile
+      summary: Remove the signed-in user's avatar
+      description: Deletes the current avatar image for the authenticated user.
+      operationId: deleteMyAvatar
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Avatar removed
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+  /me/change-password:
+    post:
+      tags:
+        - Profile
+      summary: Change the signed-in user's password
+      description: Alias of the change password flow requiring the current password.
+      operationId: changeMyPassword
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangePasswordRequest'
+      responses:
+        '204':
+          description: Password updated successfully
+        '400':
+          description: Invalid password change request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+  /me/change-email:
+    post:
+      tags:
+        - Profile
+      summary: Request an email change for the signed-in user
+      description: Sends a confirmation link to the new email address after validating the current password.
+      operationId: requestMyEmailChange
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangeMyEmailRequest'
+      responses:
+        '204':
+          description: Email change initiated
+        '400':
+          description: Invalid email change request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '409':
+          description: Email already in use
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+  /me/confirm-email:
+    post:
+      tags:
+        - Profile
+      summary: Confirm a pending email change for the signed-in user
+      description: Consumes the confirmation token, applies the new email, and revokes existing refresh tokens.
+      operationId: confirmMyEmail
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConfirmMyEmailRequest'
+      responses:
+        '204':
+          description: Email change confirmed
+        '400':
+          description: Invalid confirmation token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '409':
+          description: Email already in use
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
   /admin/users:
     get:
       tags:
@@ -1109,6 +1323,29 @@ components:
           description: High level status string for the storage module.
       example:
         status: enabled
+    ProblemDetail:
+      type: object
+      description: RFC 7807 problem details with optional application-specific fields.
+      properties:
+        type:
+          type: string
+          format: uri
+        title:
+          type: string
+        status:
+          type: integer
+          format: int32
+        detail:
+          type: string
+        instance:
+          type: string
+          format: uri
+        errors:
+          type: object
+          additionalProperties:
+            type: string
+        code:
+          type: string
     Role:
       type: string
       description: Role assigned to a user determining access level.
@@ -1131,6 +1368,33 @@ components:
             $ref: '#/components/schemas/Role'
         isActive:
           type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    MyProfile:
+      type: object
+      required: [id, email, displayName, roles, isActive, createdAt, updatedAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+        email:
+          type: string
+          format: email
+        displayName:
+          type: string
+        roles:
+          type: array
+          items:
+            $ref: '#/components/schemas/Role'
+        isActive:
+          type: boolean
+        avatarUrl:
+          type: string
+          format: uri
         createdAt:
           type: string
           format: date-time
@@ -1187,6 +1451,40 @@ components:
           type: string
         newPassword:
           type: string
+    UpdateMyProfileRequest:
+      type: object
+      properties:
+        displayName:
+          type: string
+          minLength: 1
+          maxLength: 120
+        avatarAction:
+          type: string
+          description: Action to take for the current avatar image.
+          enum: [KEEP, REMOVE]
+          default: KEEP
+    ChangeMyEmailRequest:
+      type: object
+      required: [currentPassword, newEmail]
+      properties:
+        currentPassword:
+          type: string
+        newEmail:
+          type: string
+          format: email
+    ConfirmMyEmailRequest:
+      type: object
+      required: [token]
+      properties:
+        token:
+          type: string
+    UploadAvatarResponse:
+      type: object
+      required: [avatarUrl]
+      properties:
+        avatarUrl:
+          type: string
+          format: uri
     ForgotPasswordRequest:
       type: object
       required: [email]


### PR DESCRIPTION
## Summary
- add authenticated /me endpoints for profile, avatar, and credential management to the OpenAPI spec
- define supporting ProblemDetail, profile, email, and avatar schemas with bearer authentication on self-service routes
- regenerate the TypeScript API client definitions

## Testing
- `yarn generate:api`
- `mvn -q generate-sources` *(fails: Network is unreachable while resolving Spring Boot parent POM)*

## PR Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [x] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68d2e53300708330bc3a57d5cdb450bb