### PR TITLE
feat(web): add profile management area

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -23,6 +23,9 @@ const Login = lazy(() => import('@/routes/Login'));
 const ForgotPassword = lazy(() => import('@/routes/ForgotPassword'));
 const ResetPassword = lazy(() => import('@/routes/ResetPassword'));
 const ChangePassword = lazy(() => import('@/routes/ChangePassword'));
+const Profile = lazy(() => import('@/routes/me/Profile'));
+const Security = lazy(() => import('@/routes/me/Security'));
+const ConfirmEmail = lazy(() => import('@/routes/ConfirmEmail'));
 const AdminUsersList = lazy(() => import('@/routes/admin/AdminUsersList'));
 const AdminUserDetail = lazy(() => import('@/routes/admin/AdminUserDetail'));
 const AdminUserCreate = lazy(() => import('@/routes/admin/AdminUserCreate'));
@@ -36,10 +39,13 @@ export default function App() {
             <Route path=":lang"> 
               <Route index element={<Navigate to="services" replace />} />
               <Route path="login" element={<Login />} /> 
-              <Route path="forgot-password" element={<ForgotPassword />} /> 
-              <Route path="reset-password" element={<ResetPassword />} /> 
-              <Route element={<ProtectedRoute redirectTo="../login" />}> 
-                <Route path="change-password" element={<ChangePassword />} /> 
+              <Route path="forgot-password" element={<ForgotPassword />} />
+              <Route path="reset-password" element={<ResetPassword />} />
+              <Route element={<ProtectedRoute redirectTo="../login" />}>
+                <Route path="change-password" element={<ChangePassword />} />
+                <Route path="confirm-email" element={<ConfirmEmail />} />
+                <Route path="me" element={<Profile />} />
+                <Route path="me/security" element={<Security />} />
                 <Route element={<RequireRole roles={['ADMIN', 'PLANNER']} />}>
                   <Route path="members" element={<Members />} />
                   <Route path="groups" element={<Groups />} />

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -177,7 +177,13 @@ export const logout = () => {
   clearAuthTokens();
 };
 
-const AUTH_ENDPOINTS = ['/auth/login', '/auth/refresh'];
+const AUTH_ENDPOINTS = [
+  '/auth/login',
+  '/auth/refresh',
+  '/me/change-password',
+  '/me/change-email',
+  '/me/confirm-email',
+];
 
 const isAuthEndpoint = (url?: string) => {
   if (!url) {

--- a/apps/web/src/api/me.ts
+++ b/apps/web/src/api/me.ts
@@ -1,0 +1,75 @@
+import type { AxiosRequestConfig, AxiosProgressEvent } from 'axios';
+
+import apiClient from './client';
+import type { paths } from './types';
+import {
+  RequestBodyOf,
+  ResponseOf,
+} from './type-helpers';
+
+type MePath = keyof paths & '/me';
+type AvatarPath = keyof paths & '/me/avatar';
+type ChangePasswordPath = keyof paths & '/me/change-password';
+type ChangeEmailPath = keyof paths & '/me/change-email';
+type ConfirmEmailPath = keyof paths & '/me/confirm-email';
+
+export type MyProfileResponse = ResponseOf<MePath, 'get', 200>;
+export type UpdateMyProfileBody = RequestBodyOf<MePath, 'patch'>;
+export type UploadAvatarResponse = ResponseOf<AvatarPath, 'post', 200>;
+export type ChangeMyPasswordBody = RequestBodyOf<ChangePasswordPath, 'post'>;
+export type ChangeMyEmailBody = RequestBodyOf<ChangeEmailPath, 'post'>;
+export type ConfirmMyEmailBody = RequestBodyOf<ConfirmEmailPath, 'post'>;
+
+export type UploadAvatarVariables = {
+  file: File;
+  config?: AxiosRequestConfig;
+  onUploadProgress?: (event: AxiosProgressEvent) => void;
+};
+
+export async function getMyProfile() {
+  const { data } = await apiClient.get<MyProfileResponse>('/me');
+  return data;
+}
+
+export async function updateMyProfile(body: UpdateMyProfileBody) {
+  const { data } = await apiClient.patch<MyProfileResponse>('/me', body);
+  return data;
+}
+
+export async function uploadAvatar({
+  file,
+  config,
+  onUploadProgress,
+}: UploadAvatarVariables) {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const { data } = await apiClient.post<UploadAvatarResponse>(
+    '/me/avatar',
+    formData,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+      onUploadProgress,
+      ...config,
+    },
+  );
+  return data;
+}
+
+export async function deleteAvatar() {
+  await apiClient.delete<void>('/me/avatar');
+}
+
+export async function changeMyPassword(body: ChangeMyPasswordBody) {
+  await apiClient.post<void>('/me/change-password', body);
+}
+
+export async function changeMyEmail(body: ChangeMyEmailBody) {
+  await apiClient.post<void>('/me/change-email', body);
+}
+
+export async function confirmMyEmail(body: ConfirmMyEmailBody) {
+  await apiClient.post<void>('/me/confirm-email', body);
+}

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
@@ -41,7 +42,8 @@ const makeHref = (language: string, path: string) =>
 
 export function Navbar({ currentLanguage }: NavbarProps) {
   const { t } = useTranslation('common');
-  const { hasRole, isAuthenticated, logout } = useAuth();
+  const { hasRole, isAuthenticated, logout, me } = useAuth();
+  const menuRef = useRef<HTMLDetailsElement | null>(null);
 
   const visibleLinks = links.filter((link) => {
     if (!link.roles || link.roles.length === 0) {
@@ -50,6 +52,17 @@ export function Navbar({ currentLanguage }: NavbarProps) {
 
     return link.roles.some((role) => hasRole(role));
   });
+
+  const profileHref = makeHref(currentLanguage, 'me');
+
+  const menuLabel = me?.displayName ?? me?.email ?? t('nav.profile');
+
+  const handleLogout = () => {
+    logout();
+    if (menuRef.current) {
+      menuRef.current.open = false;
+    }
+  };
 
   return (
     <nav className="bg-gray-800 text-white p-4 print:hidden">
@@ -68,13 +81,36 @@ export function Navbar({ currentLanguage }: NavbarProps) {
         </ul>
         <div className="flex items-center gap-2">
           {isAuthenticated ? (
-            <button
-              type="button"
-              onClick={logout}
-              className="rounded-md border border-white/30 bg-white/10 px-3 py-1 text-sm font-medium text-white hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-            >
-              {t('nav.logout')}
-            </button>
+            <details ref={menuRef} className="relative">
+              <summary
+                className="flex cursor-pointer list-none items-center gap-2 rounded-md border border-white/30 bg-white/10 px-3 py-1 text-sm font-medium text-white hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+              >
+                <span>{menuLabel}</span>
+                <span aria-hidden className="text-xs">
+                  ▾
+                </span>
+              </summary>
+              <div className="absolute right-0 mt-2 w-48 overflow-hidden rounded-md border border-gray-200 bg-white text-sm text-gray-700 shadow-lg">
+                <Link
+                  to={profileHref}
+                  className="block px-4 py-2 hover:bg-gray-100"
+                  onClick={() => {
+                    if (menuRef.current) {
+                      menuRef.current.open = false;
+                    }
+                  }}
+                >
+                  {t('nav.profile')}
+                </Link>
+                <button
+                  type="button"
+                  onClick={handleLogout}
+                  className="block w-full px-4 py-2 text-left text-red-600 hover:bg-red-50"
+                >
+                  {t('nav.logout')}
+                </button>
+              </div>
+            </details>
           ) : null}
           <LanguageSwitcher currentLanguage={currentLanguage} />
         </div>

--- a/apps/web/src/features/me/components/AvatarUploader.tsx
+++ b/apps/web/src/features/me/components/AvatarUploader.tsx
@@ -1,0 +1,214 @@
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+import { isAxiosError } from 'axios';
+
+import { useUploadAvatar } from '@/features/me/hooks';
+
+type AvatarUploaderProps = {
+  avatarUrl?: string | null;
+  onUploadSuccess?: (url: string) => void;
+  onUploadError?: (message: string) => void;
+};
+
+const ACCEPTED_FILE_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+] as const;
+
+const MAX_FILE_SIZE = 2 * 1024 * 1024;
+
+export function AvatarUploader({
+  avatarUrl,
+  onUploadError,
+  onUploadSuccess,
+}: AvatarUploaderProps) {
+  const { t } = useTranslation('me');
+  const uploadMutation = useUploadAvatar();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const inputId = useId();
+
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [progress, setProgress] = useState<number>(0);
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+      }
+    };
+  }, [previewUrl]);
+
+  const imageSrc = useMemo(() => previewUrl ?? avatarUrl ?? null, [avatarUrl, previewUrl]);
+
+  const resetInput = () => {
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] ?? null;
+
+    if (!file) {
+      setSelectedFile(null);
+      setError(null);
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+        setPreviewUrl(null);
+      }
+      return;
+    }
+
+    if (!ACCEPTED_FILE_TYPES.includes(file.type as (typeof ACCEPTED_FILE_TYPES)[number])) {
+      const message = t('profile.avatar.errors.invalidType');
+      setError(message);
+      setSelectedFile(null);
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+        setPreviewUrl(null);
+      }
+      onUploadError?.(message);
+      resetInput();
+      return;
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      const message = t('profile.avatar.errors.tooLarge');
+      setError(message);
+      setSelectedFile(null);
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+        setPreviewUrl(null);
+      }
+      onUploadError?.(message);
+      resetInput();
+      return;
+    }
+
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl);
+    }
+
+    setError(null);
+    setSelectedFile(file);
+    setPreviewUrl(URL.createObjectURL(file));
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!selectedFile) {
+      return;
+    }
+
+    setError(null);
+    setProgress(0);
+
+    try {
+      const response = await uploadMutation.mutateAsync({
+        file: selectedFile,
+        onUploadProgress: (progressEvent) => {
+          if (!progressEvent.total) {
+            return;
+          }
+
+          const percentage = Math.round(
+            (progressEvent.loaded / progressEvent.total) * 100,
+          );
+          setProgress(percentage);
+        },
+      });
+
+      onUploadSuccess?.(response.avatarUrl);
+      setSelectedFile(null);
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+      }
+      setPreviewUrl(null);
+      resetInput();
+    } catch (error) {
+      const message = isAxiosError(error)
+        ? error.response?.data?.message ?? error.response?.data?.error
+        : null;
+      const fallbackMessage =
+        message ?? t('profile.avatar.errors.uploadFailed');
+      setError(fallbackMessage);
+      onUploadError?.(fallbackMessage);
+    }
+  };
+
+  return (
+    <form className="space-y-4" onSubmit={handleSubmit} noValidate>
+      <div className="flex items-center gap-4">
+        <div className="h-20 w-20 overflow-hidden rounded-full border border-gray-200 bg-gray-100">
+          {imageSrc ? (
+            <img
+              src={imageSrc}
+              alt={t('profile.avatar.previewAlt')}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-sm text-gray-500">
+              {t('profile.avatar.emptyAlt')}
+            </div>
+          )}
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-gray-700" htmlFor={inputId}>
+            {t('profile.avatar.title')}
+          </label>
+          <p className="text-sm text-gray-500">{t('profile.avatar.description')}</p>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept={ACCEPTED_FILE_TYPES.join(',')}
+            onChange={handleFileChange}
+            className="text-sm"
+            id={inputId}
+            aria-describedby="avatar-error"
+          />
+        </div>
+      </div>
+      {selectedFile ? (
+        <div className="flex items-center gap-4">
+          <span className="text-sm text-gray-600">{selectedFile.name}</span>
+          <button
+            type="submit"
+            className="rounded bg-blue-600 px-3 py-1 text-sm text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+            disabled={uploadMutation.isPending}
+          >
+            {uploadMutation.isPending
+              ? t('profile.avatar.uploading')
+              : t('profile.avatar.upload')}
+          </button>
+        </div>
+      ) : null}
+      {uploadMutation.isPending ? (
+        <div className="h-2 w-full overflow-hidden rounded bg-gray-200">
+          <div
+            className="h-full bg-blue-600 transition-all"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      ) : null}
+      {error ? (
+        <p id="avatar-error" className="text-sm text-red-600">
+          {error}
+        </p>
+      ) : null}
+    </form>
+  );
+}
+
+export default AvatarUploader;

--- a/apps/web/src/features/me/components/__tests__/AvatarUploader.test.tsx
+++ b/apps/web/src/features/me/components/__tests__/AvatarUploader.test.tsx
@@ -1,0 +1,60 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+
+import i18n from '@/i18n';
+import { AvatarUploader } from '../AvatarUploader';
+
+const mutateAsyncMock = vi.fn();
+const originalURL = window.URL;
+
+vi.mock('@/features/me/hooks', () => ({
+  useUploadAvatar: () => ({
+    mutateAsync: mutateAsyncMock,
+    isPending: false,
+  }),
+}));
+
+describe('AvatarUploader', () => {
+  beforeEach(async () => {
+    mutateAsyncMock.mockResolvedValue({ avatarUrl: 'https://example.com/new.png' });
+    Object.defineProperty(window, 'URL', {
+      value: {
+        createObjectURL: vi.fn(() => 'blob:preview'),
+        revokeObjectURL: vi.fn(),
+      },
+      writable: true,
+    });
+
+    await act(async () => {
+      await i18n.changeLanguage('en');
+    });
+  });
+
+  afterEach(() => {
+    window.URL = originalURL;
+    vi.clearAllMocks();
+  });
+
+  it('rejects files larger than 2MB before uploading', async () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <AvatarUploader avatarUrl={null} />
+      </I18nextProvider>,
+    );
+
+    const fileInput = screen.getByLabelText('Avatar');
+
+    const largeFile = new File([new Uint8Array(2 * 1024 * 1024 + 1)], 'large.png', {
+      type: 'image/png',
+    });
+
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [largeFile] } });
+    });
+
+    expect(mutateAsyncMock).not.toHaveBeenCalled();
+    expect(
+      screen.getByText('File is too large. Maximum size is 2MB.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/me/hooks.ts
+++ b/apps/web/src/features/me/hooks.ts
@@ -1,0 +1,103 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  changeMyEmail,
+  changeMyPassword,
+  confirmMyEmail,
+  deleteAvatar,
+  getMyProfile,
+  type MyProfileResponse,
+  type UpdateMyProfileBody,
+  updateMyProfile,
+  uploadAvatar,
+  type UploadAvatarVariables,
+} from '@/api/me';
+
+const meRootKey = ['me'] as const;
+
+export const meQueryKeys = {
+  all: meRootKey,
+  profile: () => [...meRootKey, 'profile'] as const,
+} as const;
+
+export function useMyProfile() {
+  return useQuery({
+    queryKey: meQueryKeys.profile(),
+    queryFn: () => getMyProfile(),
+  });
+}
+
+export function useUpdateMyProfile() {
+  const queryClient = useQueryClient();
+
+  return useMutation<MyProfileResponse, unknown, UpdateMyProfileBody>({
+    mutationFn: (body) => updateMyProfile(body),
+    onSuccess: (data) => {
+      queryClient.setQueryData(meQueryKeys.profile(), data);
+    },
+  });
+}
+
+export function useUploadAvatar() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (variables: UploadAvatarVariables) => uploadAvatar(variables),
+    onSuccess: (data) => {
+      queryClient.setQueryData<MyProfileResponse | undefined>(
+        meQueryKeys.profile(),
+        (current) => {
+          if (!current) {
+            return current;
+          }
+
+          return {
+            ...current,
+            avatarUrl: data.avatarUrl,
+          } satisfies MyProfileResponse;
+        },
+      );
+    },
+  });
+}
+
+export function useDeleteAvatar() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => deleteAvatar(),
+    onSuccess: () => {
+      queryClient.setQueryData<MyProfileResponse | undefined>(
+        meQueryKeys.profile(),
+        (current) => {
+          if (!current) {
+            return current;
+          }
+
+          return {
+            ...current,
+            avatarUrl: undefined,
+          } satisfies MyProfileResponse;
+        },
+      );
+    },
+  });
+}
+
+export function useChangePassword() {
+  return useMutation({
+    mutationFn: changeMyPassword,
+  });
+}
+
+export function useChangeEmail() {
+  return useMutation({
+    mutationFn: changeMyEmail,
+  });
+}
+
+export function useConfirmEmail() {
+  return useMutation({
+    mutationFn: confirmMyEmail,
+  });
+}

--- a/apps/web/src/i18n/index.ts
+++ b/apps/web/src/i18n/index.ts
@@ -14,6 +14,7 @@ export const NAMESPACES = [
   'services',
   'songSets',
   'groups',
+  'me',
   'validation',
 ] as const;
 

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -9,6 +9,7 @@
     "groups": "Groups",
     "songSets": "Song Sets",
     "adminUsers": "User Management",
+    "profile": "Profile",
     "logout": "Log out"
   },
   "actions": {

--- a/apps/web/src/locales/en/me.json
+++ b/apps/web/src/locales/en/me.json
@@ -1,0 +1,71 @@
+{
+  "profile": {
+    "title": "My profile",
+    "subtitle": "Manage how others see you in Every Breath and Life.",
+    "fields": {
+      "displayName": "Display name",
+      "email": "Email",
+      "roles": "Roles"
+    },
+    "avatar": {
+      "title": "Avatar",
+      "description": "Upload a square image in PNG, JPG, or WebP format up to 2MB.",
+      "choose": "Choose image",
+      "upload": "Upload",
+      "remove": "Remove avatar",
+      "uploading": "Uploading…",
+      "previewAlt": "Avatar preview",
+      "emptyAlt": "Default avatar",
+      "errors": {
+        "tooLarge": "File is too large. Maximum size is 2MB.",
+        "invalidType": "Unsupported file type. Please upload a PNG, JPG, or WebP image.",
+        "uploadFailed": "Failed to upload avatar."
+      },
+      "success": "Avatar updated."
+    },
+    "notifications": {
+      "updateSuccess": "Profile updated.",
+      "updateError": "Failed to update profile.",
+      "removeAvatarSuccess": "Avatar removed.",
+      "removeAvatarError": "Failed to remove avatar."
+    }
+  },
+  "security": {
+    "title": "Security",
+    "subtitle": "Keep your account information up to date.",
+    "password": {
+      "title": "Change password",
+      "description": "Enter your current password and choose a new one.",
+      "fields": {
+        "currentPassword": "Current password",
+        "newPassword": "New password"
+      },
+      "submit": "Update password",
+      "success": "Password updated. Please sign in again.",
+      "error": "Unable to update password."
+    },
+    "email": {
+      "title": "Change email",
+      "description": "Use your password to request a new email address.",
+      "fields": {
+        "currentPassword": "Current password",
+        "newEmail": "New email"
+      },
+      "submit": "Request change",
+      "success": "We sent a confirmation link to {{email}}.",
+      "error": "Unable to change email."
+    },
+    "toastReauth": "Please sign in again."
+  },
+  "confirmEmail": {
+    "title": "Confirm email",
+    "loading": "Confirming your email…",
+    "success": "Email confirmed. Please sign in again.",
+    "error": "We could not confirm your email. The link may have expired.",
+    "missingToken": "This confirmation link is invalid.",
+    "goToLogin": "Go to sign-in"
+  },
+  "links": {
+    "security": "Security settings"
+  }
+}

--- a/apps/web/src/locales/es/common.json
+++ b/apps/web/src/locales/es/common.json
@@ -9,6 +9,7 @@
     "groups": "Grupos",
     "songSets": "Listas de canciones",
     "adminUsers": "Gestión de usuarios",
+    "profile": "Perfil",
     "logout": "Cerrar sesión"
   },
   "actions": {

--- a/apps/web/src/locales/es/me.json
+++ b/apps/web/src/locales/es/me.json
@@ -1,0 +1,71 @@
+{
+  "profile": {
+    "title": "Mi perfil",
+    "subtitle": "Administra cómo te ven otras personas en Every Breath and Life.",
+    "fields": {
+      "displayName": "Nombre para mostrar",
+      "email": "Correo electrónico",
+      "roles": "Roles"
+    },
+    "avatar": {
+      "title": "Avatar",
+      "description": "Sube una imagen cuadrada en formato PNG, JPG o WebP de hasta 2 MB.",
+      "choose": "Elegir imagen",
+      "upload": "Subir",
+      "remove": "Quitar avatar",
+      "uploading": "Subiendo…",
+      "previewAlt": "Vista previa del avatar",
+      "emptyAlt": "Avatar predeterminado",
+      "errors": {
+        "tooLarge": "El archivo es demasiado grande. El tamaño máximo es 2 MB.",
+        "invalidType": "Tipo de archivo no compatible. Sube una imagen PNG, JPG o WebP.",
+        "uploadFailed": "No se pudo subir el avatar."
+      },
+      "success": "Avatar actualizado."
+    },
+    "notifications": {
+      "updateSuccess": "Perfil actualizado.",
+      "updateError": "No se pudo actualizar el perfil.",
+      "removeAvatarSuccess": "Avatar eliminado.",
+      "removeAvatarError": "No se pudo eliminar el avatar."
+    }
+  },
+  "security": {
+    "title": "Seguridad",
+    "subtitle": "Mantén la información de tu cuenta al día.",
+    "password": {
+      "title": "Cambiar contraseña",
+      "description": "Ingresa tu contraseña actual y elige una nueva.",
+      "fields": {
+        "currentPassword": "Contraseña actual",
+        "newPassword": "Nueva contraseña"
+      },
+      "submit": "Actualizar contraseña",
+      "success": "Contraseña actualizada. Vuelve a iniciar sesión.",
+      "error": "No se pudo actualizar la contraseña."
+    },
+    "email": {
+      "title": "Cambiar correo",
+      "description": "Usa tu contraseña para solicitar un nuevo correo electrónico.",
+      "fields": {
+        "currentPassword": "Contraseña actual",
+        "newEmail": "Nuevo correo"
+      },
+      "submit": "Solicitar cambio",
+      "success": "Enviamos un enlace de confirmación a {{email}}.",
+      "error": "No se pudo cambiar el correo."
+    },
+    "toastReauth": "Vuelve a iniciar sesión."
+  },
+  "confirmEmail": {
+    "title": "Confirmar correo",
+    "loading": "Confirmando tu correo…",
+    "success": "Correo confirmado. Vuelve a iniciar sesión.",
+    "error": "No pudimos confirmar tu correo. El enlace puede haber expirado.",
+    "missingToken": "Este enlace de confirmación no es válido.",
+    "goToLogin": "Ir a iniciar sesión"
+  },
+  "links": {
+    "security": "Configuración de seguridad"
+  }
+}

--- a/apps/web/src/pages/auth/ConfirmEmailPage.tsx
+++ b/apps/web/src/pages/auth/ConfirmEmailPage.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { isAxiosError } from 'axios';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { toast } from 'sonner';
+
+import { useConfirmEmail } from '@/features/me/hooks';
+import { useAuth } from '@/features/auth/useAuth';
+import { AuthPageLayout } from '@/pages/auth/AuthPageLayout';
+import { buildLanguagePath } from '@/pages/auth/utils';
+import { DEFAULT_LANGUAGE } from '@/i18n';
+
+export default function ConfirmEmailPage() {
+  const { t } = useTranslation('me');
+  const navigate = useNavigate();
+  const params = useParams<{ lang?: string }>();
+  const language = params.lang ?? DEFAULT_LANGUAGE;
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token');
+  const timeoutRef = useRef<number | null>(null);
+
+  const confirmEmailMutation = useConfirmEmail();
+  const { logout } = useAuth();
+
+  const [message, setMessage] = useState<string>(t('confirmEmail.loading'));
+  const [status, setStatus] = useState<'loading' | 'success' | 'error'>(
+    token ? 'loading' : 'error',
+  );
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!token) {
+      setStatus('error');
+      setMessage(t('confirmEmail.missingToken'));
+      return;
+    }
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        await confirmEmailMutation.mutateAsync({ token });
+
+        if (cancelled) {
+          return;
+        }
+
+        setStatus('success');
+        setMessage(t('confirmEmail.success'));
+        logout();
+        toast.success(t('security.toastReauth'));
+        timeoutRef.current = window.setTimeout(() => {
+          navigate(`/${language}/login`, { replace: true });
+        }, 1500);
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+
+        const message = isAxiosError(error)
+          ? error.response?.data?.message ?? error.response?.data?.error
+          : null;
+        setMessage(message ?? t('confirmEmail.error'));
+        setStatus('error');
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [confirmEmailMutation, language, logout, navigate, t, token]);
+
+  return (
+    <AuthPageLayout title={t('confirmEmail.title')}>
+      <div className="space-y-4 text-sm text-gray-700">
+        <p>{message}</p>
+        {status === 'error' ? (
+          <button
+            type="button"
+            className="text-blue-600 hover:text-blue-800 hover:underline"
+            onClick={() => navigate(buildLanguagePath(language, 'login'))}
+          >
+            {t('confirmEmail.goToLogin')}
+          </button>
+        ) : null}
+      </div>
+    </AuthPageLayout>
+  );
+}

--- a/apps/web/src/pages/me/ProfilePage.tsx
+++ b/apps/web/src/pages/me/ProfilePage.tsx
@@ -1,0 +1,203 @@
+import { useEffect, useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { isAxiosError } from 'axios';
+import { useTranslation } from 'react-i18next';
+import { Link, useParams } from 'react-router-dom';
+import { toast } from 'sonner';
+
+import { AvatarUploader } from '@/features/me/components/AvatarUploader';
+import {
+  useDeleteAvatar,
+  useMyProfile,
+  useUpdateMyProfile,
+} from '@/features/me/hooks';
+import type { UpdateMyProfileBody } from '@/api/me';
+import { DEFAULT_LANGUAGE } from '@/i18n';
+
+type ProfileFormValues = {
+  displayName: string;
+};
+
+export default function ProfilePage() {
+  const { t } = useTranslation('me');
+  const { t: tCommon } = useTranslation('common');
+  const { t: tValidation } = useTranslation('validation');
+  const { t: tRoles } = useTranslation('adminUsers');
+  const params = useParams<{ lang?: string }>();
+  const language = params.lang ?? DEFAULT_LANGUAGE;
+
+  const profileQuery = useMyProfile();
+  const updateMutation = useUpdateMyProfile();
+  const deleteAvatarMutation = useDeleteAvatar();
+
+  const schema = useMemo(
+    () =>
+      z.object({
+        displayName: z
+          .string()
+          .trim()
+          .min(1, { message: tValidation('required') })
+          .max(120, {
+            message: tValidation('tooBig.string', { maximum: 120 }),
+          }),
+      }),
+    [tValidation],
+  );
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting, isDirty },
+    reset,
+  } = useForm<ProfileFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      displayName: '',
+    },
+  });
+
+  const profile = profileQuery.data;
+
+  useEffect(() => {
+    if (profile) {
+      reset({ displayName: profile.displayName ?? '' });
+    }
+  }, [profile, reset]);
+
+  const onSubmit = handleSubmit(async (values) => {
+    try {
+      const payload: UpdateMyProfileBody = {
+        displayName: values.displayName,
+        avatarAction: 'KEEP',
+      };
+
+      await updateMutation.mutateAsync(payload);
+      toast.success(t('profile.notifications.updateSuccess'));
+    } catch (error) {
+      const message = isAxiosError(error)
+        ? error.response?.data?.message ?? error.response?.data?.error
+        : null;
+      toast.error(message ?? t('profile.notifications.updateError'));
+    }
+  });
+
+  const handleRemoveAvatar = async () => {
+    try {
+      await deleteAvatarMutation.mutateAsync();
+      toast.success(t('profile.notifications.removeAvatarSuccess'));
+    } catch (error) {
+      const message = isAxiosError(error)
+        ? error.response?.data?.message ?? error.response?.data?.error
+        : null;
+      toast.error(message ?? t('profile.notifications.removeAvatarError'));
+    }
+  };
+
+  if (profileQuery.isLoading) {
+    return <div className="p-6">{tCommon('status.loading')}</div>;
+  }
+
+  if (profileQuery.isError || !profile) {
+    return <div className="p-6">{tCommon('status.loadFailed')}</div>;
+  }
+
+  return (
+    <div className="space-y-8 p-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">{t('profile.title')}</h1>
+          <p className="text-sm text-gray-600">{t('profile.subtitle')}</p>
+        </div>
+        <Link
+          to={`/${language}/me/security`}
+          className="text-sm font-medium text-blue-600 hover:text-blue-800 hover:underline"
+        >
+          {t('links.security')}
+        </Link>
+      </div>
+
+      <div className="grid gap-8 lg:grid-cols-[300px_1fr]">
+        <div className="space-y-4">
+          <AvatarUploader
+            avatarUrl={profile.avatarUrl}
+            onUploadSuccess={() => {
+              toast.success(t('profile.avatar.success'));
+            }}
+            onUploadError={(message) => {
+              toast.error(message);
+            }}
+          />
+          <button
+            type="button"
+            onClick={handleRemoveAvatar}
+            className="text-sm text-red-600 hover:text-red-700 disabled:cursor-not-allowed disabled:text-red-300"
+            disabled={!profile.avatarUrl || deleteAvatarMutation.isPending}
+          >
+            {t('profile.avatar.remove')}
+          </button>
+        </div>
+        <form className="space-y-6" onSubmit={onSubmit} noValidate>
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-gray-700" htmlFor="displayName">
+              {t('profile.fields.displayName')}
+            </label>
+            <input
+              id="displayName"
+              type="text"
+              className="w-full rounded border border-gray-300 p-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              {...register('displayName')}
+            />
+            {errors.displayName ? (
+              <p className="text-sm text-red-600">{errors.displayName.message}</p>
+            ) : null}
+          </div>
+
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-gray-700">
+              {t('profile.fields.email')}
+            </label>
+            <input
+              value={profile.email}
+              readOnly
+              className="w-full cursor-not-allowed rounded border border-gray-200 bg-gray-100 p-2 text-gray-600"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <span className="block text-sm font-medium text-gray-700">
+              {t('profile.fields.roles')}
+            </span>
+            <div className="flex flex-wrap gap-2">
+              {profile.roles.length > 0 ? (
+                profile.roles.map((role) => (
+                  <span
+                    key={role}
+                    className="rounded-full bg-gray-200 px-3 py-1 text-xs font-medium text-gray-700"
+                  >
+                    {tRoles(`roles.${role}`)}
+                  </span>
+                ))
+              ) : (
+                <span className="text-sm text-gray-500">
+                  {tCommon('labels.notAvailable')}
+                </span>
+              )}
+            </div>
+          </div>
+
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+              disabled={isSubmitting || updateMutation.isPending || !isDirty}
+            >
+              {tCommon('actions.save')}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/me/SecurityPage.tsx
+++ b/apps/web/src/pages/me/SecurityPage.tsx
@@ -1,0 +1,236 @@
+import { useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { isAxiosError } from 'axios';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useParams } from 'react-router-dom';
+import { toast } from 'sonner';
+
+import { useAuth } from '@/features/auth/useAuth';
+import { useChangeEmail, useChangePassword } from '@/features/me/hooks';
+import { DEFAULT_LANGUAGE } from '@/i18n';
+
+const MIN_PASSWORD_LENGTH = 8;
+
+type PasswordFormValues = {
+  currentPassword: string;
+  newPassword: string;
+};
+
+type EmailFormValues = {
+  currentPassword: string;
+  newEmail: string;
+};
+
+export default function SecurityPage() {
+  const { t } = useTranslation('me');
+  const { t: tValidation } = useTranslation('validation');
+  const navigate = useNavigate();
+  const params = useParams<{ lang?: string }>();
+  const language = params.lang ?? DEFAULT_LANGUAGE;
+  const { logout } = useAuth();
+
+  const changePasswordMutation = useChangePassword();
+  const changeEmailMutation = useChangeEmail();
+
+  const [emailNotice, setEmailNotice] = useState<string | null>(null);
+
+  const passwordSchema = useMemo(
+    () =>
+      z.object({
+        currentPassword: z
+          .string()
+          .trim()
+          .min(1, { message: tValidation('required') }),
+        newPassword: z
+          .string()
+          .trim()
+          .min(MIN_PASSWORD_LENGTH, {
+            message: tValidation('tooSmall.string', { minimum: MIN_PASSWORD_LENGTH }),
+          }),
+      }),
+    [tValidation],
+  );
+
+  const emailSchema = useMemo(
+    () =>
+      z.object({
+        currentPassword: z
+          .string()
+          .trim()
+          .min(1, { message: tValidation('required') }),
+        newEmail: z
+          .string()
+          .trim()
+          .email({ message: tValidation('email') })
+          .transform((value) => value.toLowerCase()),
+      }),
+    [tValidation],
+  );
+
+  const {
+    register: registerPassword,
+    handleSubmit: handlePasswordSubmit,
+    formState: { errors: passwordErrors, isSubmitting: isPasswordSubmitting },
+    reset: resetPasswordForm,
+  } = useForm<PasswordFormValues>({
+    resolver: zodResolver(passwordSchema),
+    defaultValues: {
+      currentPassword: '',
+      newPassword: '',
+    },
+  });
+
+  const {
+    register: registerEmail,
+    handleSubmit: handleEmailSubmit,
+    formState: { errors: emailErrors, isSubmitting: isEmailSubmitting },
+    reset: resetEmailForm,
+  } = useForm<EmailFormValues>({
+    resolver: zodResolver(emailSchema),
+    defaultValues: {
+      currentPassword: '',
+      newEmail: '',
+    },
+  });
+
+  const onPasswordSubmit = handlePasswordSubmit(async (values) => {
+    try {
+      await changePasswordMutation.mutateAsync({
+        currentPassword: values.currentPassword,
+        newPassword: values.newPassword,
+      });
+      resetPasswordForm();
+      toast.success(t('security.password.success'));
+      logout();
+      navigate(`/${language}/login`, { replace: true });
+    } catch (error) {
+      const message = isAxiosError(error)
+        ? error.response?.data?.message ?? error.response?.data?.error
+        : null;
+      toast.error(message ?? t('security.password.error'));
+    }
+  });
+
+  const onEmailSubmit = handleEmailSubmit(async (values) => {
+    setEmailNotice(null);
+    try {
+      await changeEmailMutation.mutateAsync({
+        currentPassword: values.currentPassword,
+        newEmail: values.newEmail,
+      });
+      resetEmailForm();
+      setEmailNotice(t('security.email.success', { email: values.newEmail }));
+    } catch (error) {
+      const message = isAxiosError(error)
+        ? error.response?.data?.message ?? error.response?.data?.error
+        : null;
+      toast.error(message ?? t('security.email.error'));
+    }
+  });
+
+  return (
+    <div className="space-y-8 p-6">
+      <div>
+        <h1 className="text-2xl font-semibold">{t('security.title')}</h1>
+        <p className="text-sm text-gray-600">{t('security.subtitle')}</p>
+      </div>
+
+      <div className="grid gap-8 lg:grid-cols-2">
+        <form className="space-y-4 rounded border border-gray-200 p-6 shadow-sm" onSubmit={onPasswordSubmit} noValidate>
+          <div>
+            <h2 className="text-lg font-semibold">{t('security.password.title')}</h2>
+            <p className="text-sm text-gray-600">{t('security.password.description')}</p>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700" htmlFor="currentPassword">
+              {t('security.password.fields.currentPassword')}
+            </label>
+            <input
+              id="currentPassword"
+              type="password"
+              autoComplete="current-password"
+              className="mt-1 w-full rounded border border-gray-300 p-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              {...registerPassword('currentPassword')}
+            />
+            {passwordErrors.currentPassword ? (
+              <p className="mt-1 text-sm text-red-600">{passwordErrors.currentPassword.message}</p>
+            ) : null}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700" htmlFor="newPassword">
+              {t('security.password.fields.newPassword')}
+            </label>
+            <input
+              id="newPassword"
+              type="password"
+              autoComplete="new-password"
+              className="mt-1 w-full rounded border border-gray-300 p-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              {...registerPassword('newPassword')}
+            />
+            {passwordErrors.newPassword ? (
+              <p className="mt-1 text-sm text-red-600">{passwordErrors.newPassword.message}</p>
+            ) : null}
+          </div>
+          <button
+            type="submit"
+            className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+            disabled={
+              isPasswordSubmitting || changePasswordMutation.isPending
+            }
+          >
+            {t('security.password.submit')}
+          </button>
+        </form>
+
+        <form className="space-y-4 rounded border border-gray-200 p-6 shadow-sm" onSubmit={onEmailSubmit} noValidate>
+          <div>
+            <h2 className="text-lg font-semibold">{t('security.email.title')}</h2>
+            <p className="text-sm text-gray-600">{t('security.email.description')}</p>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700" htmlFor="currentEmailPassword">
+              {t('security.email.fields.currentPassword')}
+            </label>
+            <input
+              id="currentEmailPassword"
+              type="password"
+              autoComplete="current-password"
+              className="mt-1 w-full rounded border border-gray-300 p-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              {...registerEmail('currentPassword')}
+            />
+            {emailErrors.currentPassword ? (
+              <p className="mt-1 text-sm text-red-600">{emailErrors.currentPassword.message}</p>
+            ) : null}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700" htmlFor="newEmail">
+              {t('security.email.fields.newEmail')}
+            </label>
+            <input
+              id="newEmail"
+              type="email"
+              autoComplete="email"
+              className="mt-1 w-full rounded border border-gray-300 p-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              {...registerEmail('newEmail')}
+            />
+            {emailErrors.newEmail ? (
+              <p className="mt-1 text-sm text-red-600">{emailErrors.newEmail.message}</p>
+            ) : null}
+          </div>
+          <button
+            type="submit"
+            className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+            disabled={isEmailSubmitting || changeEmailMutation.isPending}
+          >
+            {t('security.email.submit')}
+          </button>
+          {emailNotice ? (
+            <p className="text-sm text-green-700">{emailNotice}</p>
+          ) : null}
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/me/__tests__/ProfilePage.test.tsx
+++ b/apps/web/src/pages/me/__tests__/ProfilePage.test.tsx
@@ -1,0 +1,79 @@
+import { act, render, screen } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import { MemoryRouter } from 'react-router-dom';
+
+import i18n from '@/i18n';
+import ProfilePage from '@/pages/me/ProfilePage';
+
+const profileFixture = {
+  id: 'user-id',
+  displayName: 'Jane Doe',
+  email: 'jane@example.com',
+  roles: ['ADMIN', 'MUSICIAN'] as const,
+  isActive: true,
+  avatarUrl: 'https://example.com/avatar.png',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const useMyProfileMock = vi.fn();
+const useUpdateMyProfileMock = vi.fn();
+const useDeleteAvatarMock = vi.fn();
+
+vi.mock('@/features/me/hooks', () => ({
+  useMyProfile: () => useMyProfileMock(),
+  useUpdateMyProfile: () => useUpdateMyProfileMock(),
+  useDeleteAvatar: () => useDeleteAvatarMock(),
+}));
+
+vi.mock('@/features/me/components/AvatarUploader', () => ({
+  AvatarUploader: ({ avatarUrl }: { avatarUrl?: string | null }) => (
+    <div data-testid="avatar-uploader">{avatarUrl ?? 'none'}</div>
+  ),
+}));
+
+describe('ProfilePage', () => {
+  beforeEach(async () => {
+    await act(async () => {
+      await i18n.changeLanguage('en');
+    });
+
+    useMyProfileMock.mockReturnValue({
+      data: profileFixture,
+      isLoading: false,
+      isError: false,
+    });
+
+    useUpdateMyProfileMock.mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    });
+
+    useDeleteAvatarMock.mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the current user profile information', async () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <MemoryRouter initialEntries={[`/en/me`]}> 
+          <ProfilePage />
+        </MemoryRouter>
+      </I18nextProvider>,
+    );
+
+    expect(await screen.findByDisplayValue('Jane Doe')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('jane@example.com')).toBeInTheDocument();
+    expect(screen.getByText('Administrator')).toBeInTheDocument();
+    expect(screen.getByText('Musician')).toBeInTheDocument();
+    expect(screen.getByTestId('avatar-uploader')).toHaveTextContent(
+      profileFixture.avatarUrl,
+    );
+  });
+});

--- a/apps/web/src/pages/me/__tests__/SecurityPage.test.tsx
+++ b/apps/web/src/pages/me/__tests__/SecurityPage.test.tsx
@@ -1,0 +1,120 @@
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import { MemoryRouter } from 'react-router-dom';
+
+import i18n from '@/i18n';
+import SecurityPage from '@/pages/me/SecurityPage';
+
+const changePasswordMock = vi.fn();
+const changeEmailMock = vi.fn();
+const logoutMock = vi.fn();
+
+vi.mock('@/features/me/hooks', () => ({
+  useChangePassword: () => ({
+    mutateAsync: changePasswordMock,
+    isPending: false,
+  }),
+  useChangeEmail: () => ({
+    mutateAsync: changeEmailMock,
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/features/auth/useAuth', () => ({
+  useAuth: () => ({
+    login: vi.fn(),
+    logout: logoutMock,
+    me: null,
+    isAuthenticated: true,
+    roles: [],
+    hasRole: () => false,
+  }),
+}));
+
+describe('SecurityPage', () => {
+  beforeEach(async () => {
+    changePasswordMock.mockResolvedValue(undefined);
+    changeEmailMock.mockResolvedValue(undefined);
+    logoutMock.mockClear();
+
+    await act(async () => {
+      await i18n.changeLanguage('en');
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderPage = () =>
+    render(
+      <I18nextProvider i18n={i18n}>
+        <MemoryRouter initialEntries={[`/en/me/security`]}> 
+          <SecurityPage />
+        </MemoryRouter>
+      </I18nextProvider>,
+    );
+
+  it('logs out after changing the password successfully', async () => {
+    renderPage();
+
+    const passwordForm = screen
+      .getByRole('heading', { name: 'Change password' })
+      .closest('form');
+    expect(passwordForm).not.toBeNull();
+
+    const currentPassword = within(passwordForm!).getByLabelText('Current password', {
+      selector: 'input',
+    });
+    const newPassword = within(passwordForm!).getByLabelText('New password', {
+      selector: 'input',
+    });
+    const submitButton = within(passwordForm!).getByRole('button', {
+      name: 'Update password',
+    });
+
+    fireEvent.change(currentPassword, { target: { value: 'OldPassword123!' } });
+    fireEvent.change(newPassword, { target: { value: 'NewPassword123!' } });
+
+    await act(async () => {
+      submitButton.click();
+    });
+
+    expect(changePasswordMock).toHaveBeenCalledWith({
+      currentPassword: 'OldPassword123!',
+      newPassword: 'NewPassword123!',
+    });
+    expect(logoutMock).toHaveBeenCalled();
+  });
+
+  it('shows confirmation notice after requesting email change', async () => {
+    renderPage();
+
+    const emailForm = screen
+      .getByRole('heading', { name: 'Change email' })
+      .closest('form');
+    expect(emailForm).not.toBeNull();
+
+    const currentPassword = within(emailForm!).getByLabelText('Current password', {
+      selector: 'input',
+    });
+    const newEmail = within(emailForm!).getByLabelText('New email', { selector: 'input' });
+    const submitButton = within(emailForm!).getByRole('button', { name: 'Request change' });
+
+    fireEvent.change(currentPassword, { target: { value: 'SecurePass1!' } });
+    fireEvent.change(newEmail, { target: { value: 'new@example.com' } });
+
+    await act(async () => {
+      submitButton.click();
+    });
+
+    expect(changeEmailMock).toHaveBeenCalledWith({
+      currentPassword: 'SecurePass1!',
+      newEmail: 'new@example.com',
+    });
+
+    expect(
+      await screen.findByText('We sent a confirmation link to new@example.com.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/ConfirmEmail.tsx
+++ b/apps/web/src/routes/ConfirmEmail.tsx
@@ -1,0 +1,15 @@
+import { MissingTranslationBoundary } from '@/components/MissingTranslationBoundary';
+import ConfirmEmailPage from '@/pages/auth/ConfirmEmailPage';
+
+const confirmEmailNamespaces = ['me', 'common'] as const;
+
+export default function ConfirmEmailRoute() {
+  return (
+    <MissingTranslationBoundary
+      componentName="ConfirmEmailPage"
+      namespaces={confirmEmailNamespaces}
+    >
+      <ConfirmEmailPage />
+    </MissingTranslationBoundary>
+  );
+}

--- a/apps/web/src/routes/me/Profile.tsx
+++ b/apps/web/src/routes/me/Profile.tsx
@@ -1,0 +1,15 @@
+import { MissingTranslationBoundary } from '@/components/MissingTranslationBoundary';
+import ProfilePage from '@/pages/me/ProfilePage';
+
+const profileNamespaces = ['me', 'common', 'adminUsers', 'validation'] as const;
+
+export default function ProfileRoute() {
+  return (
+    <MissingTranslationBoundary
+      componentName="ProfilePage"
+      namespaces={profileNamespaces}
+    >
+      <ProfilePage />
+    </MissingTranslationBoundary>
+  );
+}

--- a/apps/web/src/routes/me/Security.tsx
+++ b/apps/web/src/routes/me/Security.tsx
@@ -1,0 +1,15 @@
+import { MissingTranslationBoundary } from '@/components/MissingTranslationBoundary';
+import SecurityPage from '@/pages/me/SecurityPage';
+
+const securityNamespaces = ['me', 'validation'] as const;
+
+export default function SecurityRoute() {
+  return (
+    <MissingTranslationBoundary
+      componentName="SecurityPage"
+      namespaces={securityNamespaces}
+    >
+      <SecurityPage />
+    </MissingTranslationBoundary>
+  );
+}


### PR DESCRIPTION
## Summary
- add a typed /me API surface with TanStack Query hooks to manage profile, avatar, and credential operations
- build profile, security, and confirm-email pages with avatar upload UX, form validation, and logout flows after sensitive updates
- update navigation, routes, translations, and tests to expose the new profile area and cover client-side guards

## Testing
- yarn test
- yarn lint
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d33fdcec2483309b70c29687f307a5