### PR TITLE
Add auth coverage and documentation

### DIFF
--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/security/SecurityAuthorizationTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/security/SecurityAuthorizationTest.java
@@ -1,0 +1,130 @@
+package com.homeputers.ebal2.api.security;
+
+import com.homeputers.ebal2.api.AbstractIntegrationTest;
+import com.homeputers.ebal2.api.TestAuthenticationHelper;
+import com.homeputers.ebal2.api.generated.model.AuthLoginRequest;
+import com.homeputers.ebal2.api.generated.model.AuthTokenPair;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class SecurityAuthorizationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private TestAuthenticationHelper authenticationHelper;
+
+    @Test
+    void adminCanAccessAdminEndpoints() {
+        authenticationHelper.ensureUser("admin@example.com", "ChangeMe123!", List.of("ADMIN"));
+        AuthTokenPair tokens = authenticate("admin@example.com", "ChangeMe123!");
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                "/api/v1/admin/users",
+                HttpMethod.GET,
+                new HttpEntity<>(bearerHeaders(tokens.getAccessToken())),
+                String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void plannerCannotAccessAdminEndpoints() {
+        authenticationHelper.ensureUser("planner@example.com", "Secret123!", List.of("PLANNER"));
+        AuthTokenPair tokens = authenticate("planner@example.com", "Secret123!");
+
+        ResponseEntity<ProblemDetail> response = restTemplate.exchange(
+                "/api/v1/admin/users",
+                HttpMethod.GET,
+                new HttpEntity<>(bearerHeaders(tokens.getAccessToken())),
+                ProblemDetail.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    void musicianHasReadOnlyAccessToDomainEndpoints() {
+        authenticationHelper.ensureUser("musician@example.com", "Secret123!", List.of("MUSICIAN"));
+        AuthTokenPair tokens = authenticate("musician@example.com", "Secret123!");
+
+        ResponseEntity<String> listResponse = restTemplate.exchange(
+                "/api/v1/services?page=0&size=5",
+                HttpMethod.GET,
+                new HttpEntity<>(bearerHeaders(tokens.getAccessToken())),
+                String.class);
+
+        assertThat(listResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        HttpHeaders headers = bearerHeaders(tokens.getAccessToken());
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        ResponseEntity<ProblemDetail> createResponse = restTemplate.exchange(
+                "/api/v1/services",
+                HttpMethod.POST,
+                new HttpEntity<>("{}", headers),
+                ProblemDetail.class);
+
+        assertThat(createResponse.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    void viewerCannotModifyDomainEndpoints() {
+        authenticationHelper.ensureUser("viewer@example.com", "Secret123!", List.of("VIEWER"));
+        AuthTokenPair tokens = authenticate("viewer@example.com", "Secret123!");
+
+        ResponseEntity<String> listResponse = restTemplate.exchange(
+                "/api/v1/services?page=0&size=5",
+                HttpMethod.GET,
+                new HttpEntity<>(bearerHeaders(tokens.getAccessToken())),
+                String.class);
+
+        assertThat(listResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        HttpHeaders headers = bearerHeaders(tokens.getAccessToken());
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        ResponseEntity<ProblemDetail> createResponse = restTemplate.exchange(
+                "/api/v1/services",
+                HttpMethod.POST,
+                new HttpEntity<>("{}", headers),
+                ProblemDetail.class);
+
+        assertThat(createResponse.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    private AuthTokenPair authenticate(String email, String password) {
+        AuthLoginRequest loginRequest = new AuthLoginRequest();
+        loginRequest.setEmail(email);
+        loginRequest.setPassword(password);
+
+        ResponseEntity<AuthTokenPair> response = restTemplate.postForEntity(
+                "/api/v1/auth/login",
+                loginRequest,
+                AuthTokenPair.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        return response.getBody();
+    }
+
+    private HttpHeaders bearerHeaders(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        return headers;
+    }
+}

--- a/apps/web/src/features/auth/__tests__/useAuth.test.ts
+++ b/apps/web/src/features/auth/__tests__/useAuth.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Mock } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { AxiosError } from 'axios';
+import { AxiosError, type InternalAxiosRequestConfig } from 'axios';
 
 import type { UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
 import type { CurrentUser, LoginRequest } from '@/api/auth';
@@ -152,10 +152,17 @@ describe('useAuth', () => {
     renderHook(() => useAuth());
 
     expect(lastQueryOptions?.retry).toBeDefined();
-    expect(lastQueryOptions?.initialData?.()).toEqual(storedUser);
+
+    const initialData = lastQueryOptions?.initialData;
+    expect(initialData).toBeDefined();
+    if (typeof initialData === 'function') {
+      expect(initialData()).toEqual(storedUser);
+    } else {
+      expect(initialData).toEqual(storedUser);
+    }
 
     const retry = lastQueryOptions?.retry;
-    if (!retry) {
+    if (typeof retry !== 'function') {
       throw new Error('retry handler not set');
     }
 
@@ -163,7 +170,7 @@ describe('useAuth', () => {
       status: 401,
       statusText: 'Unauthorized',
       headers: {},
-      config: {},
+      config: { headers: {} } as InternalAxiosRequestConfig,
       data: null,
     });
 

--- a/apps/web/src/features/auth/__tests__/useAuth.test.ts
+++ b/apps/web/src/features/auth/__tests__/useAuth.test.ts
@@ -40,10 +40,6 @@ const currentUser: CurrentUser = {
 
 const tokenSubscribers = new Set<() => void>();
 
-type QueryFn = (
-  options: UseQueryOptions<CurrentUser | undefined, unknown>,
-) => UseQueryResult<CurrentUser | undefined, unknown>;
-
 const getAuthTokensMock = mocks.getAuthTokensMock as ReturnType<typeof vi.fn>;
 const subscribeToAuthTokensMock = mocks.subscribeToAuthTokensMock as ReturnType<typeof vi.fn>;
 const getStoredCurrentUserMock = mocks.getStoredCurrentUserMock as ReturnType<typeof vi.fn>;

--- a/apps/web/src/features/auth/__tests__/useAuth.test.ts
+++ b/apps/web/src/features/auth/__tests__/useAuth.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { AxiosError } from 'axios';
+
+import type { UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
+import type { CurrentUser, LoginRequest } from '@/api/auth';
+
+const mocks = vi.hoisted(() => {
+  const removeQueriesMock = vi.fn();
+  const loginMutateAsync = vi.fn();
+
+  return {
+    getAuthTokensMock: vi.fn(),
+    subscribeToAuthTokensMock: vi.fn(),
+    getStoredCurrentUserMock: vi.fn(),
+    logoutMock: vi.fn(),
+    loginMutateAsync,
+    useLoginMock: vi.fn(() => ({ mutateAsync: loginMutateAsync })),
+    useQueryMock: vi.fn(),
+    useQueryClientMock: vi.fn(() => ({ removeQueries: removeQueriesMock })),
+    removeQueriesMock,
+  };
+});
+
+const mockTokens = { accessToken: 'access-token', refreshToken: 'refresh-token', expiresIn: 900 };
+const storedUser: CurrentUser = {
+  id: '11111111-2222-3333-4444-555555555555',
+  email: 'user@example.com',
+  displayName: 'Test User',
+  roles: ['PLANNER'],
+  isActive: true,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+};
+const currentUser: CurrentUser = {
+  ...storedUser,
+  roles: ['PLANNER', 'MUSICIAN'],
+};
+
+const tokenSubscribers = new Set<() => void>();
+
+type QueryFn = (
+  options: UseQueryOptions<CurrentUser | undefined, unknown>,
+) => UseQueryResult<CurrentUser | undefined, unknown>;
+
+const getAuthTokensMock = mocks.getAuthTokensMock as ReturnType<typeof vi.fn>;
+const subscribeToAuthTokensMock = mocks.subscribeToAuthTokensMock as ReturnType<typeof vi.fn>;
+const getStoredCurrentUserMock = mocks.getStoredCurrentUserMock as ReturnType<typeof vi.fn>;
+const logoutMock = mocks.logoutMock as ReturnType<typeof vi.fn>;
+const loginMutateAsync = mocks.loginMutateAsync as ReturnType<typeof vi.fn>;
+const useLoginMock = mocks.useLoginMock as ReturnType<typeof vi.fn>;
+const useQueryMock = mocks.useQueryMock as ReturnType<typeof vi.fn>;
+const useQueryClientMock = mocks.useQueryClientMock as ReturnType<typeof vi.fn>;
+const removeQueriesMock = mocks.removeQueriesMock as ReturnType<typeof vi.fn>;
+
+let lastQueryOptions: UseQueryOptions<CurrentUser | undefined, unknown> | undefined;
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-query')>(
+    '@tanstack/react-query',
+  );
+
+  return {
+    ...actual,
+    useQuery: mocks.useQueryMock,
+    useQueryClient: mocks.useQueryClientMock,
+  };
+});
+
+vi.mock('@/api/auth', async () => {
+  const actual = await vi.importActual<typeof import('@/api/auth')>('@/api/auth');
+
+  return {
+    ...actual,
+    getAuthTokens: mocks.getAuthTokensMock,
+    subscribeToAuthTokens: mocks.subscribeToAuthTokensMock,
+    getStoredCurrentUser: mocks.getStoredCurrentUserMock,
+    logout: mocks.logoutMock,
+  };
+});
+
+vi.mock('@/features/auth/hooks', async () => {
+  const actual = await vi.importActual<typeof import('@/features/auth/hooks')>(
+    '@/features/auth/hooks',
+  );
+
+  return {
+    ...actual,
+    useLogin: mocks.useLoginMock,
+  };
+});
+
+import { authQueryKeys } from '@/features/auth/hooks';
+import { useAuth } from '../useAuth';
+
+describe('useAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tokenSubscribers.clear();
+    lastQueryOptions = undefined;
+
+    removeQueriesMock.mockReset();
+    loginMutateAsync.mockReset();
+    useQueryMock.mockReset();
+    useQueryClientMock.mockReset();
+    useLoginMock.mockReset();
+    getAuthTokensMock.mockReset();
+    subscribeToAuthTokensMock.mockReset();
+    getStoredCurrentUserMock.mockReset();
+    logoutMock.mockReset();
+
+    useQueryClientMock.mockReturnValue({ removeQueries: removeQueriesMock });
+    useLoginMock.mockReturnValue({ mutateAsync: loginMutateAsync });
+
+    (useQueryMock as Mock<
+      [UseQueryOptions<CurrentUser | undefined, unknown>],
+      UseQueryResult<CurrentUser | undefined, unknown>
+    >).mockImplementation((options) => {
+      lastQueryOptions = options;
+      return { data: currentUser } as UseQueryResult<CurrentUser, unknown>;
+    });
+
+    getAuthTokensMock.mockImplementation(() => mockTokens);
+    getStoredCurrentUserMock.mockImplementation(() => storedUser);
+    subscribeToAuthTokensMock.mockImplementation((listener: () => void) => {
+      tokenSubscribers.add(listener);
+      return () => tokenSubscribers.delete(listener);
+    });
+  });
+
+  it('returns current user data and proxies auth helpers', async () => {
+    const { result } = renderHook(() => useAuth());
+
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.me).toEqual(currentUser);
+    expect(result.current.roles).toEqual(currentUser.roles);
+    expect(result.current.hasRole('PLANNER')).toBe(true);
+    expect(result.current.hasRole('ADMIN')).toBe(false);
+
+    await act(async () => {
+      await result.current.login({ email: 'user@example.com', password: 'secret' } as LoginRequest);
+    });
+    expect(loginMutateAsync).toHaveBeenCalledWith({ email: 'user@example.com', password: 'secret' });
+
+    act(() => {
+      result.current.logout();
+    });
+
+    expect(logoutMock).toHaveBeenCalled();
+    expect(removeQueriesMock).toHaveBeenCalledWith({ queryKey: authQueryKeys.all });
+    expect(subscribeToAuthTokensMock).toHaveBeenCalled();
+  });
+
+  it('disables query retries when the API returns 401', () => {
+    renderHook(() => useAuth());
+
+    expect(lastQueryOptions?.retry).toBeDefined();
+    expect(lastQueryOptions?.initialData?.()).toEqual(storedUser);
+
+    const retry = lastQueryOptions?.retry;
+    if (!retry) {
+      throw new Error('retry handler not set');
+    }
+
+    const axios401 = new AxiosError('Unauthorized', '401', undefined, undefined, {
+      status: 401,
+      statusText: 'Unauthorized',
+      headers: {},
+      config: {},
+      data: null,
+    });
+
+    expect(retry(1, axios401)).toBe(false);
+    expect(retry(0, new Error('other'))).toBe(true);
+    expect(retry(2, new Error('other'))).toBe(false);
+  });
+});

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,86 @@
+# Authentication & Authorization
+
+This document covers how authentication is configured, which roles can access specific APIs, and how to verify session flows end-to-end.
+
+## Environment configuration
+
+Backend and email settings are driven by the following environment variables (see `application.yaml`):
+
+| Purpose | Variable(s) | Default |
+| --- | --- | --- |
+| Enable/disable the security filter chain | `EBAL_SECURITY_ENABLED` | `true` |
+| Allowed web origins for CORS | `EBAL_WEB_ORIGIN_DEV`, `EBAL_WEB_ORIGIN_PROD` | `http://localhost:5173`, `https://app.ebal.church` |
+| JWT signing secret (min 64 chars) | `EBAL_JWT_SECRET` | Development-only random string |
+| Access token lifetime | `EBAL_JWT_ACCESS_TTL` | `PT15M` |
+| Refresh token lifetime | `EBAL_JWT_REFRESH_TTL` | `P30D` |
+| Password reset token lifetime | `EBAL_PASSWORD_RESET_TTL` | `PT1H` |
+| Login rate limiting (max attempts / window) | `EBAL_SECURITY_LOGIN_RATE_LIMIT_MAX`, `EBAL_SECURITY_LOGIN_RATE_LIMIT_WINDOW` | `10`, `PT1M` |
+| Forgot-password rate limiting | `EBAL_SECURITY_FORGOT_RATE_LIMIT_MAX`, `EBAL_SECURITY_FORGOT_RATE_LIMIT_WINDOW` | `5`, `PT15M` |
+| Frontend base URL used in reset links | `FRONTEND_BASE_URL` | `http://localhost:5173` |
+| SMTP enable flag and host credentials | `EBAL_MAIL_SMTP_ENABLED`, `EBAL_MAIL_SMTP_HOST`, `EBAL_MAIL_SMTP_PORT`, `EBAL_MAIL_SMTP_USERNAME`, `EBAL_MAIL_SMTP_PASSWORD`, `EBAL_MAIL_SMTP_STARTTLS`, `EBAL_MAIL_SMTP_AUTH`, `EBAL_MAIL_FROM` | Disabled with sensible defaults |
+
+Set `EBAL_SECURITY_ENABLED=false` to bypass auth entirely in local experiments. When SMTP is disabled, forgot-password requests are accepted but no emails are sent.
+
+## Default admin seeding
+
+When `EBAL_SEED_ENABLED=true`, the application boots an admin seeder. It creates or reactivates an administrator using:
+
+- Email: `EBAL_SEED_ADMIN_EMAIL` (default `admin@example.com`)
+- Password: `EBAL_SEED_ADMIN_PASSWORD` (default `ChangeMe123!`)
+
+If the user already exists, the seeder ensures the account is active and grants the `ADMIN` role.
+
+## Role capabilities
+
+Access control is enforced in `SecurityConfig`. The matrix below summarizes which HTTP methods are permitted per role:
+
+| Endpoint group | Admin | Planner | Musician | Viewer |
+| --- | --- | --- | --- | --- |
+| `/api/v1/admin/**` (all methods) | ✅ | ❌ | ❌ | ❌ |
+| `/api/v1/auth/change-password`, `/api/v1/auth/me` | ✅ | ✅ | ✅ | ✅ |
+| `/api/v1/me/**` (self-service) | ✅ | ✅ | ✅ | ✅ |
+| Domain reads (`GET` on members, groups, songs, services, song sets, plan items, search) | ✅ | ✅ | ✅ | ✅ |
+| Domain mutations (`POST`, `PUT`, `PATCH`, `DELETE` on the endpoints above) | ✅ | ✅ | ❌ | ❌ |
+| Public unauthenticated endpoints (`/api/v1/auth/login`, `/api/v1/auth/refresh`, `/api/v1/auth/forgot-password`, `/api/v1/auth/reset-password`, `/api/v1/health`, `/api/v1/services/ical`, `/api/v1/storage/health`, Swagger) | Anyone |
+
+Session behaviour highlights:
+
+- Refresh tokens are rotated on every `/auth/refresh` call. A reused or revoked refresh token is rejected.
+- Password changes and successful password resets revoke all outstanding refresh tokens for the user, forcing new logins on other sessions.
+- Expired or malformed password-reset tokens are rejected before any password update occurs.
+
+## Manual verification checklist
+
+Use the following checklist when validating environments or releases:
+
+- [ ] Start with a fresh database: default admin should seed, login succeeds with seeded credentials.
+- [ ] Planner user can authenticate but receives HTTP 403 when visiting `/admin/*` routes.
+- [ ] Musician user can sign in and view assigned plans (GET endpoints) but cannot mutate planning data.
+- [ ] Viewer user only sees published plans (GET endpoints) and cannot create or edit planning data.
+- [ ] Forgot/reset password flow invalidates existing sessions (refresh tokens no longer work).
+- [ ] Changing a password via `/auth/change-password` invalidates other sessions for that user.
+- [ ] Refresh tokens rotate while valid and stop working immediately after revocation.
+
+## Promote a user to admin via SQL
+
+If all admins are locked out, promote another account directly in PostgreSQL:
+
+```sql
+-- Replace with the email that should become admin
+WITH target AS (
+  SELECT id
+  FROM users
+  WHERE email = lower('user@example.com')
+)
+UPDATE users
+SET is_active = TRUE,
+    updated_at = now()
+WHERE id IN (SELECT id FROM target);
+
+INSERT INTO user_roles (user_id, role, created_at)
+SELECT id, 'ADMIN', now()
+FROM target
+ON CONFLICT (user_id, role) DO NOTHING;
+```
+
+After running the statements, the promoted user can log in (or request a password reset) and access `/api/v1/admin/**` endpoints immediately.


### PR DESCRIPTION
## Summary
- extend backend auth integration tests to cover invalid login, refresh edge cases, and role-based access control
- add frontend `useAuth` hook tests validating happy path behaviour and refresh retry guardrails
- document auth configuration, role matrix, manual verification checklist, and admin promotion SQL in `docs/auth.md`

## Testing
- `yarn install --frozen-lockfile`
- `yarn test`
- `mvn verify` *(fails: unable to reach Maven Central from container)*

------
https://chatgpt.com/codex/tasks/task_e_68d415b770108330984baf517846d4dd