### PR TITLE
fix(web): localize literal strings

### DIFF
--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -1,5 +1,7 @@
 import { Component, ReactNode } from 'react';
 
+import i18n from '@/i18n';
+
 interface Props {
   children: ReactNode;
 }
@@ -21,7 +23,7 @@ export class ErrorBoundary extends Component<Props, State> {
 
   render() {
     if (this.state.hasError) {
-      return <div>Something went wrong.</div>;
+      return <div>{i18n.t('common:errors.generic')}</div>;
     }
     return this.props.children;
   }

--- a/apps/web/src/components/LanguageSwitcher.tsx
+++ b/apps/web/src/components/LanguageSwitcher.tsx
@@ -148,7 +148,7 @@ export function LanguageSwitcher({
           {getLanguageLabel(currentLanguage)}
         </span>
         <span aria-hidden="true" className="text-xs">
-          ▼
+          {t('language.dropdownIndicator')}
         </span>
       </button>
       {isOpen ? (
@@ -172,7 +172,7 @@ export function LanguageSwitcher({
               >
                 <span>{getLanguageLabel(language)}</span>
                 {language === currentLanguage ? (
-                  <span aria-hidden="true">✓</span>
+                  <span aria-hidden="true">{t('language.selectedIndicator')}</span>
                 ) : null}
               </button>
             </li>

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -87,8 +87,8 @@ export function Navbar({ currentLanguage }: NavbarProps) {
                 className="flex cursor-pointer list-none items-center gap-2 rounded-md border border-white/30 bg-white/10 px-3 py-1 text-sm font-medium text-white hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
               >
                 <span>{menuLabel}</span>
-                <span aria-hidden className="text-xs">
-                  ▾
+                <span aria-hidden="true" className="text-xs">
+                  {t('nav.menuIndicator')}
                 </span>
               </summary>
               <div className="absolute right-0 mt-2 w-48 overflow-hidden rounded-md border border-gray-200 bg-white text-sm text-gray-700 shadow-lg">

--- a/apps/web/src/components/pickers/SongPicker.tsx
+++ b/apps/web/src/components/pickers/SongPicker.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
 import { listSongs } from '@/api/songs';
 import type { components } from '@/api/types';
 import { withLangKey } from '@/lib/queryClient';
@@ -20,6 +21,8 @@ interface Props {
 }
 
 export function SongPicker({ value, onChange, placeholder }: Props) {
+  const { t } = useTranslation('songs');
+  const { t: tCommon } = useTranslation('common');
   const [search, setSearch] = useState('');
   const [open, setOpen] = useState(false);
   const [active, setActive] = useState(0);
@@ -87,10 +90,14 @@ export function SongPicker({ value, onChange, placeholder }: Props) {
           className="absolute z-10 mt-1 bg-white border rounded max-h-60 overflow-auto w-full"
           role="listbox"
         >
-          {isLoading && <li className="p-2 text-sm">Loading…</li>}
-          {isError && <li className="p-2 text-sm text-red-500">Failed to load</li>}
+          {isLoading && (
+            <li className="p-2 text-sm">{tCommon('status.loading')}</li>
+          )}
+          {isError && (
+            <li className="p-2 text-sm text-red-500">{tCommon('status.loadFailed')}</li>
+          )}
           {!isLoading && !isError && options.length === 0 && (
-            <li className="p-2 text-sm">No songs</li>
+            <li className="p-2 text-sm">{t('pickers.empty')}</li>
           )}
           {options.map((song, idx) => (
             <li

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -11,7 +11,8 @@
     "adminUsers": "User Management",
     "profile": "Profile",
     "changePassword": "Change password",
-    "logout": "Log out"
+    "logout": "Log out",
+    "menuIndicator": "▾"
   },
   "actions": {
     "save": "Save",
@@ -50,9 +51,14 @@
   "language": {
     "change": "Change language",
     "select": "Select language",
+    "dropdownIndicator": "▼",
+    "selectedIndicator": "✓",
     "labels": {
       "en": "English",
       "es": "Español"
     }
+  },
+  "errors": {
+    "generic": "Something went wrong."
   }
 }

--- a/apps/web/src/locales/en/songSets.json
+++ b/apps/web/src/locales/en/songSets.json
@@ -39,6 +39,7 @@
     "loadFailed": "Failed to load items.",
     "empty": "No items",
     "dragHandle": "Drag to reorder",
+    "dragHandleIcon": "☰",
     "drag": {
       "grab": "Grab to drag",
       "dragging": "Dragging {{title}}",
@@ -62,7 +63,8 @@
   },
   "controls": {
     "showSharps": "Show sharps (♯)",
-    "showFlats": "Show flats (♭)"
+    "showFlats": "Show flats (♭)",
+    "toggleAccidentals": "♯ / ♭"
   },
   "validation": {
     "nameMin": "Name must be at least 2 characters"

--- a/apps/web/src/locales/en/songs.json
+++ b/apps/web/src/locales/en/songs.json
@@ -64,6 +64,7 @@
   },
   "lastUpdated": "Last updated {{date}}",
   "pickers": {
-    "searchPlaceholder": "Search songs..."
+    "searchPlaceholder": "Search songs...",
+    "empty": "No songs"
   }
 }

--- a/apps/web/src/locales/es/common.json
+++ b/apps/web/src/locales/es/common.json
@@ -11,7 +11,8 @@
     "adminUsers": "Gestión de usuarios",
     "profile": "Perfil",
     "changePassword": "Cambiar contraseña",
-    "logout": "Cerrar sesión"
+    "logout": "Cerrar sesión",
+    "menuIndicator": "▾"
   },
   "actions": {
     "save": "Guardar",
@@ -50,9 +51,14 @@
   "language": {
     "change": "Cambiar idioma",
     "select": "Seleccionar idioma",
+    "dropdownIndicator": "▼",
+    "selectedIndicator": "✓",
     "labels": {
       "en": "Inglés",
       "es": "Español"
     }
+  },
+  "errors": {
+    "generic": "Algo salió mal."
   }
 }

--- a/apps/web/src/locales/es/songSets.json
+++ b/apps/web/src/locales/es/songSets.json
@@ -39,6 +39,7 @@
     "loadFailed": "No se pudieron cargar los elementos.",
     "empty": "Sin elementos",
     "dragHandle": "Arrastrar para reordenar",
+    "dragHandleIcon": "☰",
     "drag": {
       "grab": "Sujetar para arrastrar",
       "dragging": "Arrastrando {{title}}",
@@ -62,7 +63,8 @@
   },
   "controls": {
     "showSharps": "Mostrar sostenidos (♯)",
-    "showFlats": "Mostrar bemoles (♭)"
+    "showFlats": "Mostrar bemoles (♭)",
+    "toggleAccidentals": "♯ / ♭"
   },
   "validation": {
     "nameMin": "El nombre debe tener al menos 2 caracteres"

--- a/apps/web/src/locales/es/songs.json
+++ b/apps/web/src/locales/es/songs.json
@@ -64,6 +64,7 @@
   },
   "lastUpdated": "Última actualización {{date}}",
   "pickers": {
-    "searchPlaceholder": "Buscar canciones..."
+    "searchPlaceholder": "Buscar canciones...",
+    "empty": "Sin canciones"
   }
 }

--- a/apps/web/src/pages/sets/SongSetDetailPage.tsx
+++ b/apps/web/src/pages/sets/SongSetDetailPage.tsx
@@ -146,7 +146,7 @@ function SortableSetItem({
           {...attributes}
           {...listeners}
         >
-          ☰
+          <span aria-hidden="true">{t('items.dragHandleIcon')}</span>
         </button>
       </div>
       <div className="mt-3 flex flex-wrap items-center gap-4">
@@ -406,7 +406,7 @@ export default function SongSetDetailPage() {
             aria-pressed={useFlats}
             title={useFlats ? t('controls.showSharps') : t('controls.showFlats')}
           >
-            ♯ / ♭
+            {t('controls.toggleAccidentals')}
           </button>
           <button
             type="button"


### PR DESCRIPTION
## Summary
- replace hard-coded UI strings in the error boundary, navbar, language switcher, song picker, and song set detail view with translated copies
- extend the English and Spanish locale bundles with the symbols and fallback messages referenced by those components

## Testing
- yarn lint

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [x] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68d423301c588330b6cd96fd39f6beaa