### PR TITLE
feat: expose git build metadata endpoint

### DIFF
--- a/apps/api-java/pom.xml
+++ b/apps/api-java/pom.xml
@@ -26,6 +26,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
         <dependency>
@@ -149,6 +153,34 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>4.9.10</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <gitPropertiesPath>${project.build.outputDirectory}</gitPropertiesPath>
+                    <includeOnlyProperties>
+                        <includeOnlyProperty>^git.branch$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.id$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.id.abbrev$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.time$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.id.describe$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.id.describe-short$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.closest.tag.name$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.tags$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.dirty$</includeOnlyProperty>
+                    </includeOnlyProperties>
+                    <verbose>true</verbose>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/SecurityConfig.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/config/SecurityConfig.java
@@ -49,7 +49,8 @@ public class SecurityConfig {
     private static final String[] PUBLIC_GET_ENDPOINTS = {
             "/api/v1/health",
             "/api/v1/storage/health",
-            "/api/v1/services/ical"
+            "/api/v1/services/ical",
+            "/api/v1/meta/git"
     };
 
     private static final String[] SWAGGER_ENDPOINTS = {

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/meta/GitInfoController.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/meta/GitInfoController.java
@@ -1,0 +1,92 @@
+package com.homeputers.ebal2.api.meta;
+
+import com.homeputers.ebal2.api.generated.MetaApi;
+import com.homeputers.ebal2.api.generated.model.GitInfo;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.info.GitProperties;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/v1")
+public class GitInfoController implements MetaApi {
+
+    private final ObjectProvider<GitProperties> gitPropertiesProvider;
+
+    public GitInfoController(ObjectProvider<GitProperties> gitPropertiesProvider) {
+        this.gitPropertiesProvider = gitPropertiesProvider;
+    }
+
+    @Override
+    public ResponseEntity<GitInfo> getGitInformation() {
+        GitInfo response = new GitInfo();
+        gitPropertiesProvider.ifAvailable(properties -> populateResponse(response, properties));
+        return ResponseEntity.ok(response);
+    }
+
+    private void populateResponse(GitInfo response, GitProperties properties) {
+        response.setBranch(nullIfBlank(properties.getBranch()));
+        response.setCommitId(nullIfBlank(properties.getCommitId()));
+        response.setAbbreviatedCommitId(nullIfBlank(properties.getShortCommitId()));
+
+        String commitTime = properties.get("commit.time");
+        if (StringUtils.hasText(commitTime)) {
+            try {
+                response.setCommitTime(OffsetDateTime.parse(commitTime));
+            } catch (DateTimeParseException ignored) {
+                // ignore invalid format
+            }
+        }
+
+        String dirty = properties.get("dirty");
+        if (StringUtils.hasText(dirty)) {
+            response.setDirty(Boolean.parseBoolean(dirty));
+        }
+
+        String tags = properties.get("tags");
+        if (StringUtils.hasText(tags)) {
+            List<String> tagList = Arrays.stream(tags.split(","))
+                    .map(String::trim)
+                    .filter(StringUtils::hasText)
+                    .collect(Collectors.toList());
+            if (!tagList.isEmpty()) {
+                response.setTags(tagList);
+            }
+        }
+
+        String closestTag = properties.get("closest.tag.name");
+        if (StringUtils.hasText(closestTag)) {
+            response.setClosestTag(closestTag);
+        }
+
+        String describe = firstNonBlank(properties.get("commit.id.describe"),
+                properties.get("commit.id.describe-short"));
+        if (StringUtils.hasText(describe)) {
+            response.setDescribe(describe);
+        }
+    }
+
+    private String nullIfBlank(String value) {
+        return StringUtils.hasText(value) ? value : null;
+    }
+
+    private String firstNonBlank(String... values) {
+        if (values == null) {
+            return null;
+        }
+        for (String value : values) {
+            if (StringUtils.hasText(value)) {
+                return value;
+            }
+        }
+        return null;
+    }
+}

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/meta/GitInfoControllerTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/meta/GitInfoControllerTest.java
@@ -1,0 +1,56 @@
+package com.homeputers.ebal2.api.meta;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.info.GitProperties;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.Properties;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = GitInfoController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class GitInfoControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void returnsGitMetadataFromConfiguredProperties() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/meta/git"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.branch").value("test-branch"))
+                .andExpect(jsonPath("$.commitId").value("0123456789abcdef0123456789abcdef01234567"))
+                .andExpect(jsonPath("$.abbreviatedCommitId").value("0123456"))
+                .andExpect(jsonPath("$.commitTime").value("2024-01-15T12:34:56Z"))
+                .andExpect(jsonPath("$.dirty").value(true))
+                .andExpect(jsonPath("$.tags[0]").value("v1.0.0"))
+                .andExpect(jsonPath("$.tags[1]").value("latest"))
+                .andExpect(jsonPath("$.closestTag").value("v1.0.0"))
+                .andExpect(jsonPath("$.describe").value("v1.0.0-1-g0123456"));
+    }
+
+    @TestConfiguration
+    static class GitPropertiesTestConfiguration {
+        @Bean
+        GitProperties gitProperties() {
+            Properties properties = new Properties();
+            properties.put("branch", "test-branch");
+            properties.put("commit.id", "0123456789abcdef0123456789abcdef01234567");
+            properties.put("commit.id.abbrev", "0123456");
+            properties.put("commit.time", "2024-01-15T12:34:56Z");
+            properties.put("dirty", "true");
+            properties.put("tags", "v1.0.0,latest");
+            properties.put("closest.tag.name", "v1.0.0");
+            properties.put("commit.id.describe", "v1.0.0-1-g0123456");
+            return new GitProperties(properties);
+        }
+    }
+}

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -31,6 +31,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StorageHealth'
+  /meta/git:
+    get:
+      tags:
+        - Meta
+      summary: Retrieve git build metadata
+      description: Provides information about the git revision used to build the service for debugging and triage.
+      operationId: getGitInformation
+      responses:
+        '200':
+          description: Git metadata for the running service
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GitInfo'
   /auth/login:
     post:
       tags:
@@ -1312,6 +1326,36 @@ components:
       properties:
         status:
           type: string
+    GitInfo:
+      type: object
+      properties:
+        branch:
+          type: string
+          description: Current branch used for the build.
+        commitId:
+          type: string
+          description: Full git commit SHA for the build.
+        abbreviatedCommitId:
+          type: string
+          description: Abbreviated git commit SHA.
+        commitTime:
+          type: string
+          format: date-time
+          description: Commit timestamp in ISO-8601 format.
+        dirty:
+          type: boolean
+          description: Indicates if the working tree had uncommitted changes when built.
+        tags:
+          type: array
+          description: Tags that point to the current commit.
+          items:
+            type: string
+        closestTag:
+          type: string
+          description: Closest annotated tag in the commit history.
+        describe:
+          type: string
+          description: Output of `git describe --always --dirty` if available.
     StorageHealth:
       type: object
       required: [status]


### PR DESCRIPTION
## Summary
- extend the OpenAPI contract with a `/meta/git` endpoint backed by a `GitInfo` schema
- add a Spring MVC controller that reads `GitProperties` and expose the endpoint publicly
- configure the API build to generate `git.properties` via git-commit-id-plugin and cover the endpoint with a WebMvc slice test

## Testing
- `mvn -q generate-sources`
- `mvn -q -DskipTests verify`
- `mvn -q verify` *(fails: requires Docker for Testcontainers)*

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [x] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [x] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)

Closes #113


------
https://chatgpt.com/codex/tasks/task_e_68d9f35211608330853afb9493bbbc33