### PR TITLE
feat(web): redesign navbar header

### DIFF
--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -1,5 +1,11 @@
-import { useRef } from 'react';
-import { Link } from 'react-router-dom';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react';
+import { Link, NavLink, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
@@ -48,6 +54,9 @@ export function Navbar({ currentLanguage }: NavbarProps) {
   const { t } = useTranslation('common');
   const { hasRole, isAuthenticated, logout, me } = useAuth();
   const menuRef = useRef<HTMLDetailsElement | null>(null);
+  const location = useLocation();
+  const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const mobileMenuId = useId();
 
   const visibleLinks = links.filter((link) => {
     if (!link.roles || link.roles.length === 0) {
@@ -59,32 +68,139 @@ export function Navbar({ currentLanguage }: NavbarProps) {
 
   const profileHref = makeHref(currentLanguage, 'me');
   const changePasswordHref = makeHref(currentLanguage, 'change-password');
+  const brandHref = makeHref(currentLanguage, 'services');
 
   const menuLabel = me?.displayName ?? me?.email ?? t('nav.profile');
+  const accountDescriptor = me?.email
+    ? t('nav.accountLabel', { value: me.email })
+    : null;
+
+  const closeMobileMenu = useCallback(() => {
+    setMobileMenuOpen(false);
+  }, []);
+
+  useEffect(() => {
+    if (!isMobileMenuOpen) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeMobileMenu();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [closeMobileMenu, isMobileMenuOpen]);
+
+  useEffect(() => {
+    closeMobileMenu();
+  }, [closeMobileMenu, location.pathname]);
 
   const handleLogout = () => {
     logout();
     if (menuRef.current) {
       menuRef.current.open = false;
     }
+    closeMobileMenu();
   };
 
+  const navLinkClassName = ({ isActive }: { isActive: boolean }) =>
+    [
+      'block rounded-md px-3 py-2 text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60',
+      isActive
+        ? 'bg-white/20 text-white'
+        : 'text-white/80 hover:bg-white/10 hover:text-white',
+    ].join(' ');
+
+  const renderNavLinks = (onNavigate?: () => void) => (
+    <ul className="flex flex-col gap-2 lg:flex-row lg:items-center lg:gap-3">
+      {visibleLinks.map((link) => (
+        <li key={link.path}>
+          <NavLink
+            to={makeHref(currentLanguage, link.path)}
+            className={navLinkClassName}
+            onClick={onNavigate}
+          >
+            {t(link.labelKey)}
+          </NavLink>
+        </li>
+      ))}
+    </ul>
+  );
+
   return (
-    <nav className="bg-gray-800 text-white p-4 print:hidden">
-      <div className="mx-auto flex max-w-6xl items-center justify-between gap-4">
-        <ul className="flex flex-wrap items-center gap-4">
-          {visibleLinks.map((link) => (
-            <li key={link.path}>
-              <Link
-                to={makeHref(currentLanguage, link.path)}
-                className="hover:underline"
-              >
-                {t(link.labelKey)}
-              </Link>
-            </li>
-          ))}
-        </ul>
-        <div className="flex items-center gap-2">
+    <header className="bg-gray-900 text-white shadow-sm print:hidden">
+      <div className="mx-auto flex max-w-6xl items-center gap-4 px-4 py-3">
+        <div className="flex flex-1 items-center gap-3">
+          {visibleLinks.length > 0 ? (
+            <button
+              type="button"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-white/20 bg-white/10 text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 lg:hidden"
+              aria-controls={mobileMenuId}
+              aria-expanded={isMobileMenuOpen}
+              aria-label={
+                isMobileMenuOpen
+                  ? t('nav.closeMenu')
+                  : t('nav.openMenu')
+              }
+              onClick={() => {
+                setMobileMenuOpen((value) => !value);
+              }}
+            >
+              <span aria-hidden="true" className="block h-4 w-4">
+                <svg
+                  className="h-full w-full"
+                  viewBox="0 0 20 20"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  {isMobileMenuOpen ? (
+                    <path
+                      d="M4 5.5L14.5 16M15.5 5.5L5 16"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                    />
+                  ) : (
+                    <path
+                      d="M3 5h14M3 10h14M3 15h14"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                    />
+                  )}
+                </svg>
+              </span>
+            </button>
+          ) : null}
+          <Link
+            to={brandHref}
+            className="text-lg font-semibold tracking-tight hover:text-white/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+          >
+            {t('app.title')}
+          </Link>
+        </div>
+        <nav
+          aria-label={t('nav.primaryLabel')}
+          className="hidden flex-1 justify-center lg:flex"
+        >
+          {renderNavLinks()}
+        </nav>
+        <div className="flex flex-1 items-center justify-end gap-3">
+          {accountDescriptor ? (
+            <p
+              className="hidden max-w-[12rem] truncate text-xs font-medium text-white/80 sm:block"
+              title={accountDescriptor}
+            >
+              {accountDescriptor}
+            </p>
+          ) : null}
+          <LanguageSwitcher currentLanguage={currentLanguage} />
           {isAuthenticated ? (
             <details ref={menuRef} className="relative">
               <summary
@@ -128,9 +244,94 @@ export function Navbar({ currentLanguage }: NavbarProps) {
               </div>
             </details>
           ) : null}
-          <LanguageSwitcher currentLanguage={currentLanguage} />
         </div>
       </div>
-    </nav>
+      {isMobileMenuOpen ? (
+        <div
+          className="lg:hidden"
+          role="presentation"
+        >
+          <div
+            className="fixed inset-0 z-40 bg-black/50"
+            onClick={closeMobileMenu}
+          />
+          <div
+            id={mobileMenuId}
+            role="dialog"
+            aria-modal="true"
+            className="fixed inset-y-0 left-0 z-50 w-full max-w-xs overflow-y-auto bg-gray-900 px-4 py-6 shadow-xl"
+          >
+            <div className="flex items-center justify-between">
+              <Link
+                to={brandHref}
+                className="text-base font-semibold tracking-tight hover:text-white/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+              >
+                {t('app.title')}
+              </Link>
+              <button
+                type="button"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-white/20 bg-white/10 text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                aria-label={t('nav.closeMenu')}
+                onClick={closeMobileMenu}
+              >
+                <span aria-hidden="true" className="block h-4 w-4">
+                  <svg
+                    className="h-full w-full"
+                    viewBox="0 0 20 20"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M4 5.5L14.5 16M15.5 5.5L5 16"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+            <nav className="mt-6" aria-label={t('nav.primaryLabel')}>
+              {renderNavLinks(closeMobileMenu)}
+            </nav>
+            <div className="mt-6 border-t border-white/10 pt-6">
+              {accountDescriptor ? (
+                <p className="text-sm text-white/80" title={accountDescriptor}>
+                  {accountDescriptor}
+                </p>
+              ) : null}
+              <div className="mt-4">
+                <LanguageSwitcher currentLanguage={currentLanguage} />
+              </div>
+              {isAuthenticated ? (
+                <div className="mt-4 space-y-2 text-sm">
+                  <Link
+                    to={profileHref}
+                    className="block rounded-md bg-white/10 px-3 py-2 text-white hover:bg-white/20"
+                    onClick={closeMobileMenu}
+                  >
+                    {t('nav.profile')}
+                  </Link>
+                  <Link
+                    to={changePasswordHref}
+                    className="block rounded-md bg-white/10 px-3 py-2 text-white hover:bg-white/20"
+                    onClick={closeMobileMenu}
+                  >
+                    {t('nav.changePassword')}
+                  </Link>
+                  <button
+                    type="button"
+                    onClick={handleLogout}
+                    className="block w-full rounded-md bg-red-600 px-3 py-2 text-left font-medium text-white hover:bg-red-700"
+                  >
+                    {t('nav.logout')}
+                  </button>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </header>
   );
 }

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -182,7 +182,8 @@ export function Navbar({ currentLanguage }: NavbarProps) {
             to={brandHref}
             className="text-lg font-semibold tracking-tight hover:text-white/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
           >
-            {t('app.title')}
+            <span aria-hidden="true">EBaL</span>
+            <span className="sr-only">{t('app.title')}</span>
           </Link>
         </div>
         <nav

--- a/apps/web/src/components/__tests__/Navbar.test.tsx
+++ b/apps/web/src/components/__tests__/Navbar.test.tsx
@@ -65,7 +65,7 @@ const renderNavbar = async (language: string) => {
 
   return render(
     <I18nextProvider i18n={i18n}>
-      <MemoryRouter initialEntries={[`/${language}`]}>
+      <MemoryRouter initialEntries={[`/${language}/services`]}>
         <Navbar currentLanguage={language} />
       </MemoryRouter>
     </I18nextProvider>,
@@ -214,5 +214,25 @@ describe('Navbar', () => {
     });
 
     expect(screen.getByRole('link', { name: 'Profile' })).toBeInTheDocument();
+  });
+
+  it('marks the active navigation link for the current route', async () => {
+    mockUseAuth.mockClear();
+
+    await renderNavbar('en');
+
+    const servicesLink = screen.getByRole('link', { name: 'Services' });
+    expect(servicesLink).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('shows the account descriptor text when an email is available', async () => {
+    setIsAuthenticated(true);
+    mockUseAuth.mockClear();
+
+    await renderNavbar('en');
+
+    expect(
+      screen.getByText('Signed in as test@example.com'),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -12,7 +12,11 @@
     "profile": "Profile",
     "changePassword": "Change password",
     "logout": "Log out",
-    "menuIndicator": "▾"
+    "menuIndicator": "▾",
+    "primaryLabel": "Primary navigation",
+    "openMenu": "Open navigation menu",
+    "closeMenu": "Close navigation menu",
+    "accountLabel": "Signed in as {{value}}"
   },
   "actions": {
     "save": "Save",

--- a/apps/web/src/locales/es/common.json
+++ b/apps/web/src/locales/es/common.json
@@ -12,7 +12,11 @@
     "profile": "Perfil",
     "changePassword": "Cambiar contraseña",
     "logout": "Cerrar sesión",
-    "menuIndicator": "▾"
+    "menuIndicator": "▾",
+    "primaryLabel": "Navegación principal",
+    "openMenu": "Abrir menú de navegación",
+    "closeMenu": "Cerrar menú de navegación",
+    "accountLabel": "Sesión iniciada como {{value}}"
   },
   "actions": {
     "save": "Guardar",


### PR DESCRIPTION
## Summary
- redesign the navbar into a responsive header with a centered primary navigation and mobile drawer
- add translated accessibility labels and account descriptor for the new layout
- extend navbar tests to cover active route highlighting and account text

## Testing
- yarn test Navbar

## Screenshots
![Updated header](browser:/invocations/ajqebamy/artifacts/artifacts/header.png)

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [x] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68da0623703483308e5e87d24d97671e