### PR TITLE
feat(web): unify navigation theming

### DIFF
--- a/apps/web/src/components/LanguageSwitcher.tsx
+++ b/apps/web/src/components/LanguageSwitcher.tsx
@@ -112,7 +112,7 @@ export function LanguageSwitcher({
         aria-haspopup="listbox"
         aria-expanded={isOpen}
         aria-label={t('language.change')}
-        className="inline-flex items-center gap-2 rounded-md border border-white/30 bg-white/10 px-3 py-1 text-sm font-medium text-white hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+        className="inline-flex items-center gap-2 rounded-md border border-border/60 bg-muted px-3 py-1 text-sm font-medium text-foreground transition-colors hover:bg-muted/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         onClick={toggle}
       >
         <span className="uppercase tracking-wide">
@@ -127,7 +127,7 @@ export function LanguageSwitcher({
           ref={popoverRef}
           role="listbox"
           aria-label={t('language.select')}
-          className="absolute right-0 z-50 mt-2 w-40 overflow-hidden rounded-md border border-gray-200 bg-white py-1 shadow-lg focus:outline-none"
+          className="absolute right-0 z-50 mt-2 w-40 overflow-hidden rounded-md border border-border bg-card py-1 shadow-lg focus:outline-none"
         >
           {languages.map((language) => (
             <li key={language} className="px-1">
@@ -138,8 +138,8 @@ export function LanguageSwitcher({
                 onClick={() => handleSelect(language)}
                 className={`flex w-full items-center justify-between rounded px-2 py-2 text-left text-sm ${
                   language === currentLanguage
-                    ? 'bg-gray-100 font-semibold text-gray-900'
-                    : 'text-gray-700 hover:bg-gray-100'
+                    ? 'bg-muted font-medium text-foreground'
+                    : 'text-muted-foreground hover:bg-muted hover:text-foreground'
                 }`}
               >
                 <span>{getLanguageLabel(language)}</span>

--- a/apps/web/src/components/layout/AppHeader.tsx
+++ b/apps/web/src/components/layout/AppHeader.tsx
@@ -52,13 +52,13 @@ export function AppHeader({
   const hasNavigation = navigationLinks.length > 0;
 
   return (
-    <header className="sticky top-0 z-40 border-b border-gray-800 bg-gray-900 text-white shadow-sm print:hidden">
+    <header className="sticky top-0 z-40 border-b border-border/60 bg-background/95 text-foreground shadow-sm backdrop-blur supports-[backdrop-filter]:bg-background/80 print:hidden">
       <div className="mx-auto flex w-full max-w-6xl items-center gap-4 px-4 py-3">
         <div className="flex flex-1 items-center gap-3">
           {hasNavigation ? (
             <button
               type="button"
-              className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-white/20 bg-white/10 text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 lg:hidden"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-border/60 bg-muted text-foreground transition hover:bg-muted/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background lg:hidden"
               aria-controls="app-navigation"
               aria-expanded={isNavigationOpen}
               aria-label={
@@ -94,7 +94,7 @@ export function AppHeader({
           ) : null}
           <Link
             to={brandHref}
-            className="text-lg font-semibold tracking-tight hover:text-white/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+            className="text-lg font-semibold tracking-tight text-foreground transition-colors hover:text-muted-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           >
             <span aria-hidden="true">EBaL</span>
             <span className="sr-only">{t('app.title')}</span>
@@ -115,7 +115,7 @@ export function AppHeader({
                   value: accountLabelValue,
                   defaultValue: accountLabelValue,
                 })}
-                className="flex items-center gap-2 rounded-md border border-white/30 bg-white/10 px-3 py-1 text-sm font-medium text-white hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                className="flex items-center gap-2 rounded-md border border-border/60 bg-muted px-3 py-1 text-sm font-medium text-foreground transition-colors hover:bg-muted/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                 onClick={accountMenu.toggle}
               >
                 <span className="max-w-[10rem] truncate" title={menuLabel}>
@@ -131,12 +131,12 @@ export function AppHeader({
                   role="menu"
                   id={`${accountMenuButtonId}-menu`}
                   aria-labelledby={accountMenuButtonId}
-                  className="absolute right-0 z-50 mt-2 w-56 overflow-hidden rounded-md border border-gray-200 bg-white text-sm text-gray-700 shadow-lg"
+                  className="absolute right-0 z-50 mt-2 w-56 overflow-hidden rounded-md border border-border bg-card text-sm text-foreground shadow-lg"
                 >
                   <Link
                     to={profileHref}
                     role="menuitem"
-                    className="block px-4 py-2 hover:bg-gray-100 focus:bg-gray-100 focus:outline-none"
+                    className="block px-4 py-2 transition-colors hover:bg-muted focus:bg-muted focus:outline-none"
                     onClick={() => accountMenu.close()}
                   >
                     {t('nav.profile')}
@@ -144,7 +144,7 @@ export function AppHeader({
                   <Link
                     to={changePasswordHref}
                     role="menuitem"
-                    className="block px-4 py-2 hover:bg-gray-100 focus:bg-gray-100 focus:outline-none"
+                    className="block px-4 py-2 transition-colors hover:bg-muted focus:bg-muted focus:outline-none"
                     onClick={() => accountMenu.close()}
                   >
                     {t('nav.changePassword')}
@@ -153,7 +153,7 @@ export function AppHeader({
                     type="button"
                     role="menuitem"
                     onClick={handleLogout}
-                    className="block w-full px-4 py-2 text-left text-red-600 hover:bg-red-50 focus:bg-red-50 focus:outline-none"
+                    className="block w-full px-4 py-2 text-left text-destructive transition-colors hover:bg-destructive/10 focus:bg-destructive/10 focus:outline-none"
                   >
                     {t('nav.logout')}
                   </button>

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -51,7 +51,7 @@ export function AppShell({ currentLanguage, children }: AppShellProps) {
   };
 
   return (
-    <div className="min-h-screen bg-gray-100">
+    <div className="min-h-screen bg-background">
       <div className="flex min-h-screen">
         <AppSideNav
           currentLanguage={currentLanguage}

--- a/apps/web/src/components/layout/AppSideNav.tsx
+++ b/apps/web/src/components/layout/AppSideNav.tsx
@@ -14,8 +14,10 @@ type AppSideNavProps = {
 
 const navLinkClassName = ({ isActive }: { isActive: boolean }) =>
   [
-    'block rounded-md px-3 py-2 text-sm font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60',
-    isActive ? 'bg-white/15 text-white' : 'text-white/80 hover:bg-white/10 hover:text-white',
+    'flex w-full items-center rounded-md border border-transparent px-3 py-2 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+    isActive
+      ? 'bg-primary text-primary-foreground shadow-sm'
+      : 'text-muted-foreground hover:bg-muted hover:text-foreground',
   ].join(' ');
 
 export function AppSideNav({
@@ -51,32 +53,32 @@ export function AppSideNav({
 
   return (
     <Fragment>
-      <aside className="hidden w-64 shrink-0 bg-gray-950 px-4 py-6 text-white shadow-lg lg:flex lg:flex-col">
+      <aside className="hidden w-64 shrink-0 border-r border-border bg-card px-4 py-6 text-foreground shadow-sm lg:flex lg:flex-col">
         {navContent}
       </aside>
       {isOpen ? (
         <div className="lg:hidden">
           <div
-            className="fixed inset-0 z-40 bg-black/50"
+            className="fixed inset-0 z-40 bg-foreground/30"
             role="presentation"
             onClick={onClose}
           />
           <div
-            className="fixed inset-y-0 left-0 z-50 w-full max-w-xs overflow-y-auto bg-gray-950 px-4 py-6 text-white shadow-xl"
+            className="fixed inset-y-0 left-0 z-50 w-full max-w-xs overflow-y-auto border-r border-border bg-card px-4 py-6 text-foreground shadow-xl"
             role="dialog"
             aria-modal="true"
           >
             <div className="flex items-center justify-between">
               <Link
                 to={brandHref}
-                className="text-base font-semibold tracking-tight text-white hover:text-white/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                className="text-base font-semibold tracking-tight text-foreground transition-colors hover:text-muted-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                 onClick={onClose}
               >
                 {t('app.title')}
               </Link>
               <button
                 type="button"
-                className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-white/20 bg-white/10 text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border/60 bg-muted text-foreground transition hover:bg-muted/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                 aria-label={t('nav.closeMenu')}
                 onClick={onClose}
               >

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2,6 +2,39 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  :root {
+    --background: 210 36% 96%;
+    --foreground: 222.2 47.4% 11.2%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 47.4% 11.2%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 47.4% 11.2%;
+    --primary: 221.2 83.2% 53.3%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 94%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 94%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent: 210 40% 92%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 221.2 83.2% 53.3%;
+    --radius: 0.75rem;
+  }
+
+  * {
+    @apply border-border;
+  }
+
+  body {
+    @apply bg-background text-foreground;
+  }
+}
+
 .chordpro-view {
   white-space: pre-wrap;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -1,7 +1,48 @@
 module.exports = {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- align the header, language switcher, and side navigation with shared theme tokens for consistent styling
- expose theme CSS variables through Tailwind so navigation states can use primary, muted, and destructive palettes
- update navigation links with clear active and hover treatments while keeping layout stable across breakpoints

## Testing
- yarn test LanguageSwitcher

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68db1472b21883309cba80f08d6bf92f