### PR TITLE
ci: automate release tagging

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -135,14 +135,42 @@ jobs:
             const repo = context.repo.repo;
             const head = `${owner}:${process.env.RELEASE_BRANCH}`;
             const base = process.env.BASE_BRANCH;
+            const releaseLabel = 'release';
+
+            async function ensureLabelExists() {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: releaseLabel });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: releaseLabel,
+                  color: '0e8a16',
+                  description: 'Automated release preparation'
+                });
+                core.info(`Created label '${releaseLabel}'`);
+              }
+            }
+
             const { data: prs } = await github.rest.pulls.list({
               owner,
               repo,
               head,
               state: 'open'
             });
+            await ensureLabelExists();
             if (prs.length > 0) {
               core.info(`Pull request already exists: ${prs[0].html_url}`);
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: prs[0].number,
+                labels: [releaseLabel]
+              });
+              core.info(`Ensured label '${releaseLabel}' is applied to PR #${prs[0].number}`);
               return;
             }
             const { data: pr } = await github.rest.pulls.create({
@@ -154,3 +182,10 @@ jobs:
               body: `Automated release preparation for v${process.env.RELEASE_VERSION}.`
             });
             core.info(`Created PR: ${pr.html_url}`);
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: pr.number,
+              labels: [releaseLabel]
+            });
+            core.info(`Applied label '${releaseLabel}' to PR #${pr.number}`);

--- a/.github/workflows/release-complete.yml
+++ b/.github/workflows/release-complete.yml
@@ -1,0 +1,72 @@
+name: Release Complete
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  tag-release:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Determine tag name
+        id: tag
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          BRANCH="${PR_HEAD_REF}"
+          if [[ -z "${BRANCH}" ]]; then
+            echo "Pull request head ref is empty" >&2
+            exit 1
+          fi
+          if [[ "${BRANCH}" != release/* ]]; then
+            echo "Pull request head ref '${BRANCH}' does not follow expected pattern 'release/v*'" >&2
+            exit 1
+          fi
+          VERSION_PART="${BRANCH#release/}"
+          VERSION_PART="${VERSION_PART#v}"
+          if [[ -z "${VERSION_PART}" ]]; then
+            echo "Unable to extract version from branch '${BRANCH}'" >&2
+            exit 1
+          fi
+          if ! [[ "${VERSION_PART}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*$ ]]; then
+            echo "Extracted version '${VERSION_PART}' does not look like semver" >&2
+            exit 1
+          fi
+          TAG_NAME="v${VERSION_PART}"
+          echo "tag_name=${TAG_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch merge commit
+        env:
+          MERGE_COMMIT: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${MERGE_COMMIT}" ]]; then
+            echo "Merge commit SHA is not available" >&2
+            exit 1
+          fi
+          git fetch origin "${MERGE_COMMIT}"
+
+      - name: Create and push tag
+        env:
+          TAG_NAME: ${{ steps.tag.outputs.tag_name }}
+          MERGE_COMMIT: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+          if git rev-parse "refs/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists. Skipping creation."
+            exit 0
+          fi
+          git tag -a "${TAG_NAME}" "${MERGE_COMMIT}" -m "Release ${TAG_NAME}"
+          git push origin "${TAG_NAME}"


### PR DESCRIPTION
## Summary
- ensure the prepare release workflow applies a reusable `release` label to the generated pull request
- add a release completion workflow that tags merged release pull requests so Docker publishing triggers automatically

## Testing
- not run (workflow updates)

- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68db5626bde4833088407b733082b32a