### PR TITLE
fix: add missing song set form label translations

### DIFF
--- a/apps/web/src/locales/en/songSets.json
+++ b/apps/web/src/locales/en/songSets.json
@@ -14,6 +14,9 @@
     "createTitle": "New Set",
     "editTitle": "Edit Set"
   },
+  "form": {
+    "nameLabel": "Name"
+  },
   "list": {
     "searchPlaceholder": "Search by name...",
     "empty": "No song sets found"

--- a/apps/web/src/locales/es/songSets.json
+++ b/apps/web/src/locales/es/songSets.json
@@ -14,6 +14,9 @@
     "createTitle": "Nuevo conjunto",
     "editTitle": "Editar conjunto"
   },
+  "form": {
+    "nameLabel": "Nombre"
+  },
   "list": {
     "searchPlaceholder": "Buscar por nombre...",
     "empty": "No se encontraron conjuntos de canciones"


### PR DESCRIPTION
## Summary
- add the missing song set form name label translation in English
- add the corresponding Spanish translation for the song set form label

## Testing
- not run (not requested)

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)

Closes #123

------
https://chatgpt.com/codex/tasks/task_e_68db583de3388330bc54ac42b53430a6