### PR TITLE
Fix release tagging workflow and tolerate missing git metadata

### DIFF
--- a/.github/workflows/release-complete.yml
+++ b/.github/workflows/release-complete.yml
@@ -19,6 +19,11 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.base.ref }}
 
+      - name: Configure Git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Determine tag name
         id: tag
         env:

--- a/apps/api-java/pom.xml
+++ b/apps/api-java/pom.xml
@@ -179,6 +179,7 @@
                         <includeOnlyProperty>^git.tags$</includeOnlyProperty>
                         <includeOnlyProperty>^git.dirty$</includeOnlyProperty>
                     </includeOnlyProperties>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
                     <verbose>true</verbose>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## Summary
- configure the release-complete workflow to set the Git user before creating tags
- allow the git-commit-id Maven plugin to continue when the .git directory is not available during Docker builds

## Testing
- `./mvnw -q -DskipTests package` *(fails: network is unreachable in container)*

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68db5f1ecc30833098d514f4550d630a