### PR TITLE
fix: ensure logo loads when hosted under a sub-path

### DIFF
--- a/apps/web/src/components/layout/AppBrandLink.tsx
+++ b/apps/web/src/components/layout/AppBrandLink.tsx
@@ -41,10 +41,14 @@ export function AppBrandLink({
     textClassName,
   );
 
+  const baseUrl = import.meta.env.BASE_URL ?? '/';
+  const normalizedBaseUrl = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  const logoSrc = `${normalizedBaseUrl}logo.png`;
+
   return (
     <Link to={to} className={mergedClassName} aria-label={label} onClick={onClick}>
       <span className="sr-only">{label}</span>
-      <img src="/logo.png" alt="" aria-hidden="true" className={mergedImageClassName} />
+      <img src={logoSrc} alt="" aria-hidden="true" className={mergedImageClassName} />
       {showText ? (
         <span aria-hidden="true" className={mergedTextClassName}>
           EBaL


### PR DESCRIPTION
## Summary
- update the AppBrandLink logo source to respect the configured Vite base URL so the image loads when the portal is served from a sub-path

## Testing
- yarn build
- yarn tsc -p .

- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68dc1ff936c48330b3c77c0f6678fcd7