### PR TITLE
feat: capture member contact details

### DIFF
--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/member/Member.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/member/Member.java
@@ -9,7 +9,15 @@ public record Member(
 
         String displayName,
 
-        List<String> instruments
+        List<String> instruments,
+
+        String email,
+
+        String phoneNumber,
+
+        Integer birthdayMonth,
+
+        Integer birthdayDay
 ) {
     public Member {
         if (id == null) {

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/member/MemberMapper.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/domain/member/MemberMapper.java
@@ -19,9 +19,23 @@ public interface MemberMapper {
 
     int count(@Param("query") String query);
 
-    void insert(@Param("id") UUID id, @Param("displayName") String displayName, @Param("instruments") List<String> instruments);
+    void insert(
+            @Param("id") UUID id,
+            @Param("displayName") String displayName,
+            @Param("instruments") List<String> instruments,
+            @Param("email") String email,
+            @Param("phoneNumber") String phoneNumber,
+            @Param("birthdayMonth") Integer birthdayMonth,
+            @Param("birthdayDay") Integer birthdayDay);
 
-    void update(@Param("id") UUID id, @Param("displayName") String displayName, @Param("instruments") List<String> instruments);
+    void update(
+            @Param("id") UUID id,
+            @Param("displayName") String displayName,
+            @Param("instruments") List<String> instruments,
+            @Param("email") String email,
+            @Param("phoneNumber") String phoneNumber,
+            @Param("birthdayMonth") Integer birthdayMonth,
+            @Param("birthdayDay") Integer birthdayDay);
 
     void delete(@Param("id") UUID id);
 }

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/group/GroupService.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/group/GroupService.java
@@ -84,7 +84,10 @@ public class GroupService {
     private Group attachMembers(Group group) {
         var ids = groupMemberMapper.findMemberIds(group.id());
         var members = ids.stream()
-                .map(id -> new GroupMember(new GroupMemberId(group.id(), id), group, new Member(id, null, null)))
+                .map(id -> new GroupMember(
+                        new GroupMemberId(group.id(), id),
+                        group,
+                        new Member(id, null, null, null, null, null, null)))
                 .collect(java.util.stream.Collectors.toSet());
         return new Group(group.id(), group.name(), members);
     }

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/member/MemberMapper.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/member/MemberMapper.java
@@ -8,7 +8,14 @@ import org.springframework.data.domain.Page;
 
 public class MemberMapper {
     public static Member toEntity(MemberRequest request) {
-        return new Member(null, request.getDisplayName(), request.getInstruments());
+        return new Member(
+                null,
+                request.getDisplayName(),
+                request.getInstruments(),
+                request.getEmail(),
+                request.getPhoneNumber(),
+                request.getBirthdayMonth(),
+                request.getBirthdayDay());
     }
 
     public static MemberResponse toResponse(Member member) {
@@ -16,6 +23,10 @@ public class MemberMapper {
         response.setId(member.id());
         response.setDisplayName(member.displayName());
         response.setInstruments(member.instruments());
+        response.setEmail(member.email());
+        response.setPhoneNumber(member.phoneNumber());
+        response.setBirthdayMonth(member.birthdayMonth());
+        response.setBirthdayDay(member.birthdayDay());
         return response;
     }
 

--- a/apps/api-java/src/main/java/com/homeputers/ebal2/api/member/MemberService.java
+++ b/apps/api-java/src/main/java/com/homeputers/ebal2/api/member/MemberService.java
@@ -38,15 +38,36 @@ public class MemberService {
     @Transactional
     public Member create(MemberRequest request) {
         Member member = MemberMapper.toEntity(request);
-        mapper.insert(member.id(), member.displayName(), member.instruments());
+        mapper.insert(
+                member.id(),
+                member.displayName(),
+                member.instruments(),
+                member.email(),
+                member.phoneNumber(),
+                member.birthdayMonth(),
+                member.birthdayDay());
         return member;
     }
 
     @Transactional
     public Member update(UUID id, MemberRequest request) {
         get(id);
-        Member updated = new Member(id, request.getDisplayName(), request.getInstruments());
-        mapper.update(id, request.getDisplayName(), request.getInstruments());
+        Member updated = new Member(
+                id,
+                request.getDisplayName(),
+                request.getInstruments(),
+                request.getEmail(),
+                request.getPhoneNumber(),
+                request.getBirthdayMonth(),
+                request.getBirthdayDay());
+        mapper.update(
+                id,
+                request.getDisplayName(),
+                request.getInstruments(),
+                request.getEmail(),
+                request.getPhoneNumber(),
+                request.getBirthdayMonth(),
+                request.getBirthdayDay());
         return updated;
     }
 

--- a/apps/api-java/src/main/resources/db/migration/V7__members_contact_fields.sql
+++ b/apps/api-java/src/main/resources/db/migration/V7__members_contact_fields.sql
@@ -1,0 +1,5 @@
+ALTER TABLE members
+    ADD COLUMN email TEXT,
+    ADD COLUMN phone_number TEXT,
+    ADD COLUMN birthday_month INTEGER CHECK (birthday_month BETWEEN 1 AND 12),
+    ADD COLUMN birthday_day INTEGER CHECK (birthday_day BETWEEN 1 AND 31);

--- a/apps/api-java/src/main/resources/mappers/MemberMapper.xml
+++ b/apps/api-java/src/main/resources/mappers/MemberMapper.xml
@@ -8,17 +8,21 @@
             <arg column="display_name" javaType="java.lang.String"/>
             <arg column="instruments" javaType="java.util.List"
                  typeHandler="com.homeputers.ebal2.api.mybatis.typehandler.StringArrayTypeHandler"/>
+            <arg column="email" javaType="java.lang.String"/>
+            <arg column="phone_number" javaType="java.lang.String"/>
+            <arg column="birthday_month" javaType="java.lang.Integer"/>
+            <arg column="birthday_day" javaType="java.lang.Integer"/>
         </constructor>
     </resultMap>
 
     <select id="findById" resultMap="memberResult">
-        select id, display_name, instruments
+        select id, display_name, instruments, email, phone_number, birthday_month, birthday_day
         from members
         where id = #{id, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler}
     </select>
 
     <select id="findPage" resultMap="memberResult">
-        select id, display_name, instruments
+        select id, display_name, instruments, email, phone_number, birthday_month, birthday_day
         from members
         <where>
             <if test="query != null and query != ''">
@@ -30,7 +34,7 @@
     </select>
 
     <select id="search" resultMap="memberResult">
-        select id, display_name, instruments
+        select id, display_name, instruments, email, phone_number, birthday_month, birthday_day
         from members
         <where>
             <if test="query != null and query != ''">
@@ -51,18 +55,26 @@
     </select>
 
     <insert id="insert">
-        insert into members (id, display_name, instruments)
+        insert into members (id, display_name, instruments, email, phone_number, birthday_month, birthday_day)
         values (
             #{id, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler},
             #{displayName},
-            #{instruments, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.StringArrayTypeHandler}
+            #{instruments, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.StringArrayTypeHandler},
+            #{email},
+            #{phoneNumber},
+            #{birthdayMonth},
+            #{birthdayDay}
         )
     </insert>
 
     <update id="update">
         update members
         set display_name = #{displayName},
-            instruments = #{instruments, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.StringArrayTypeHandler}
+            instruments = #{instruments, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.StringArrayTypeHandler},
+            email = #{email},
+            phone_number = #{phoneNumber},
+            birthday_month = #{birthdayMonth},
+            birthday_day = #{birthdayDay}
         where id = #{id, typeHandler=com.homeputers.ebal2.api.mybatis.typehandler.UUIDTypeHandler}
     </update>
 

--- a/apps/api-java/src/test/java/com/homeputers/ebal2/api/member/MemberControllerTest.java
+++ b/apps/api-java/src/test/java/com/homeputers/ebal2/api/member/MemberControllerTest.java
@@ -40,6 +40,10 @@ class MemberControllerTest extends AbstractIntegrationTest {
         MemberRequest request = new MemberRequest();
         request.setDisplayName("John Doe");
         request.setInstruments(List.of("guitar"));
+        request.setEmail("john.doe@example.com");
+        request.setPhoneNumber("+1 555 123 4567");
+        request.setBirthdayMonth(5);
+        request.setBirthdayDay(14);
 
         ResponseEntity<MemberResponse> create = restTemplate.exchange(
                 "/api/v1/members",
@@ -60,6 +64,10 @@ class MemberControllerTest extends AbstractIntegrationTest {
         assertThat(get.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(get.getBody()).isNotNull();
         assertThat(get.getBody().getDisplayName()).isEqualTo("John Doe");
+        assertThat(get.getBody().getEmail()).isEqualTo("john.doe@example.com");
+        assertThat(get.getBody().getPhoneNumber()).isEqualTo("+1 555 123 4567");
+        assertThat(get.getBody().getBirthdayMonth()).isEqualTo(5);
+        assertThat(get.getBody().getBirthdayDay()).isEqualTo(14);
     }
 
     @Test
@@ -70,6 +78,10 @@ class MemberControllerTest extends AbstractIntegrationTest {
 
         MemberRequest request = new MemberRequest();
         request.setDisplayName("Jane");
+        request.setEmail("jane@example.com");
+        request.setPhoneNumber("555-0001");
+        request.setBirthdayMonth(7);
+        request.setBirthdayDay(9);
         restTemplate.exchange(
                 "/api/v1/members",
                 HttpMethod.POST,

--- a/apps/web/src/api/types.d.ts
+++ b/apps/web/src/api/types.d.ts
@@ -882,12 +882,22 @@ export interface components {
         MemberRequest: {
             displayName: string;
             instruments?: string[];
+            /** Format: email */
+            email?: string;
+            phoneNumber?: string;
+            birthdayMonth?: number;
+            birthdayDay?: number;
         };
         MemberResponse: {
             /** Format: uuid */
             id?: string;
             displayName?: string;
             instruments?: string[];
+            /** Format: email */
+            email?: string;
+            phoneNumber?: string;
+            birthdayMonth?: number;
+            birthdayDay?: number;
         };
         PageMemberResponse: {
             content?: components["schemas"]["MemberResponse"][];

--- a/apps/web/src/features/members/MemberForm.tsx
+++ b/apps/web/src/features/members/MemberForm.tsx
@@ -5,9 +5,34 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { withFieldErrorPrefix } from '../../lib/zodErrorMap';
 import type { components } from '../../api/types';
 
+const emptyToUndefined = (value: unknown) => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length === 0 ? undefined : trimmed;
+  }
+  return value ?? undefined;
+};
+
+const optionalEmail = z.preprocess(emptyToUndefined, z.string().email().optional());
+const optionalString = z.preprocess(emptyToUndefined, z.string().max(255).optional());
+const optionalMonth = z.preprocess((value) => {
+  const cleaned = emptyToUndefined(value);
+  if (cleaned === undefined) return undefined;
+  return Number(cleaned);
+}, z.number().int().min(1).max(12).optional());
+const optionalDay = z.preprocess((value) => {
+  const cleaned = emptyToUndefined(value);
+  if (cleaned === undefined) return undefined;
+  return Number(cleaned);
+}, z.number().int().min(1).max(31).optional());
+
 const schema = z.object({
   displayName: z.string().min(2),
   instruments: z.string().optional(),
+  email: optionalEmail,
+  phoneNumber: optionalString,
+  birthdayMonth: optionalMonth,
+  birthdayDay: optionalDay,
 });
 
 export type MemberFormValues = z.infer<typeof schema>;
@@ -46,6 +71,10 @@ export function MemberForm({
           instruments: vals.instruments
             ? vals.instruments.split(',').map((s) => s.trim()).filter(Boolean)
             : [],
+          email: vals.email || undefined,
+          phoneNumber: vals.phoneNumber || undefined,
+          birthdayMonth: vals.birthdayMonth ?? undefined,
+          birthdayDay: vals.birthdayDay ?? undefined,
         }),
       )}
       className="space-y-2"
@@ -75,6 +104,58 @@ export function MemberForm({
         {errors.instruments && (
           <p className="text-red-500 text-sm">{errors.instruments.message}</p>
         )}
+      </div>
+      <div>
+        <label htmlFor="email" className="block text-sm font-medium mb-1">
+          {t('form.email')}
+        </label>
+        <input id="email" type="email" {...register('email')} className="border p-2 rounded w-full" />
+        {errors.email && <p className="text-red-500 text-sm">{errors.email.message}</p>}
+      </div>
+      <div>
+        <label htmlFor="phoneNumber" className="block text-sm font-medium mb-1">
+          {t('form.phoneNumber')}
+        </label>
+        <input
+          id="phoneNumber"
+          {...register('phoneNumber')}
+          className="border p-2 rounded w-full"
+        />
+        {errors.phoneNumber && <p className="text-red-500 text-sm">{errors.phoneNumber.message}</p>}
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <div>
+          <label htmlFor="birthdayMonth" className="block text-sm font-medium mb-1">
+            {t('form.birthdayMonth')}
+          </label>
+          <input
+            id="birthdayMonth"
+            type="number"
+            min={1}
+            max={12}
+            {...register('birthdayMonth')}
+            className="border p-2 rounded w-full"
+          />
+          {errors.birthdayMonth && (
+            <p className="text-red-500 text-sm">{errors.birthdayMonth.message}</p>
+          )}
+        </div>
+        <div>
+          <label htmlFor="birthdayDay" className="block text-sm font-medium mb-1">
+            {t('form.birthdayDay')}
+          </label>
+          <input
+            id="birthdayDay"
+            type="number"
+            min={1}
+            max={31}
+            {...register('birthdayDay')}
+            className="border p-2 rounded w-full"
+          />
+          {errors.birthdayDay && (
+            <p className="text-red-500 text-sm">{errors.birthdayDay.message}</p>
+          )}
+        </div>
       </div>
       <div className="flex gap-2">
         <button type="submit" className="px-4 py-2 bg-blue-500 text-white rounded">

--- a/apps/web/src/locales/en/members.json
+++ b/apps/web/src/locales/en/members.json
@@ -11,7 +11,11 @@
   },
   "form": {
     "displayName": "Display Name",
-    "instrumentsLabel": "Instruments (comma separated)"
+    "instrumentsLabel": "Instruments (comma separated)",
+    "email": "Email",
+    "phoneNumber": "Phone number",
+    "birthdayMonth": "Birthday month",
+    "birthdayDay": "Birthday day"
   },
   "actions": {
     "new": "New Member"
@@ -22,7 +26,11 @@
   },
   "table": {
     "name": "Name",
-    "instruments": "Instruments"
+    "instruments": "Instruments",
+    "contact": "Contact",
+    "contactPlaceholder": "—",
+    "birthday": "Birthday",
+    "birthdayPlaceholder": "—"
   },
   "modals": {
     "createTitle": "New Member",

--- a/apps/web/src/locales/es/members.json
+++ b/apps/web/src/locales/es/members.json
@@ -11,7 +11,11 @@
   },
   "form": {
     "displayName": "Nombre para mostrar",
-    "instrumentsLabel": "Instrumentos (separados por comas)"
+    "instrumentsLabel": "Instrumentos (separados por comas)",
+    "email": "Correo electrónico",
+    "phoneNumber": "Número de teléfono",
+    "birthdayMonth": "Mes de cumpleaños",
+    "birthdayDay": "Día de cumpleaños"
   },
   "actions": {
     "new": "Nuevo miembro"
@@ -22,7 +26,11 @@
   },
   "table": {
     "name": "Nombre",
-    "instruments": "Instrumentos"
+    "instruments": "Instrumentos",
+    "contact": "Contacto",
+    "contactPlaceholder": "—",
+    "birthday": "Cumpleaños",
+    "birthdayPlaceholder": "—"
   },
   "modals": {
     "createTitle": "Nuevo miembro",

--- a/apps/web/src/pages/members/MembersPage.tsx
+++ b/apps/web/src/pages/members/MembersPage.tsx
@@ -92,6 +92,16 @@ export default function MembersPage() {
   const memberCount = data?.totalElements ?? data?.content?.length ?? 0;
   const shouldShowCount = data?.totalElements !== undefined || data?.content !== undefined;
 
+  const formatBirthday = (member: Member) => {
+    if (!member.birthdayMonth || !member.birthdayDay) return undefined;
+    const formatter = new Intl.DateTimeFormat(undefined, {
+      month: 'long',
+      day: 'numeric',
+    });
+    const date = new Date(Date.UTC(2000, (member.birthdayMonth || 1) - 1, member.birthdayDay || 1));
+    return formatter.format(date);
+  };
+
   return (
     <div className="p-4">
       <div className="mb-4">
@@ -129,6 +139,8 @@ export default function MembersPage() {
                   <tr className="bg-gray-50">
                     <th className="text-left p-2">{t('table.name')}</th>
                     <th className="text-left p-2">{t('table.instruments')}</th>
+                    <th className="text-left p-2">{t('table.contact')}</th>
+                    <th className="text-left p-2">{t('table.birthday')}</th>
                     <th className="p-2 text-right">{tCommon('table.actions')}</th>
                   </tr>
                 </thead>
@@ -137,6 +149,12 @@ export default function MembersPage() {
                     <tr key={m.id} className="border-t">
                       <td className="p-2">{m.displayName}</td>
                       <td className="p-2">{m.instruments?.join(', ')}</td>
+                      <td className="p-2 space-y-1">
+                        {m.email ? <div>{m.email}</div> : null}
+                        {m.phoneNumber ? <div>{m.phoneNumber}</div> : null}
+                        {!m.email && !m.phoneNumber ? <div>{t('table.contactPlaceholder')}</div> : null}
+                      </td>
+                      <td className="p-2">{formatBirthday(m) ?? t('table.birthdayPlaceholder')}</td>
                       <td className="p-2 text-right">
                         <div className="flex gap-2 justify-end">
                           <button
@@ -200,6 +218,10 @@ export default function MembersPage() {
             defaultValues={{
               displayName: editing.displayName || '',
               instruments: editing.instruments?.join(', ') || '',
+              email: editing.email || '',
+              phoneNumber: editing.phoneNumber || '',
+              birthdayMonth: editing.birthdayMonth ?? undefined,
+              birthdayDay: editing.birthdayDay ?? undefined,
             }}
             onSubmit={(vals) => handleUpdate(editing.id!, vals)}
             onCancel={() => setEditing(null)}

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1615,6 +1615,19 @@ components:
           type: array
           items:
             type: string
+        email:
+          type: string
+          format: email
+        phoneNumber:
+          type: string
+        birthdayMonth:
+          type: integer
+          minimum: 1
+          maximum: 12
+        birthdayDay:
+          type: integer
+          minimum: 1
+          maximum: 31
     MemberResponse:
       type: object
       properties:
@@ -1627,6 +1640,19 @@ components:
           type: array
           items:
             type: string
+        email:
+          type: string
+          format: email
+        phoneNumber:
+          type: string
+        birthdayMonth:
+          type: integer
+          minimum: 1
+          maximum: 12
+        birthdayDay:
+          type: integer
+          minimum: 1
+          maximum: 31
     PageMemberResponse:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- extend the member schema and database with email, phone number, and birthday columns backed by a new Flyway migration
- expose the new fields through the Java service layer, OpenAPI schema, generated types, and integration tests
- enhance the members UI to collect and display contact and birthday details with updated validation and translations

## Testing
- ./mvnw -q -DskipTests=false verify *(fails: network unreachable)*
- yarn install --frozen-lockfile
- yarn build
- yarn test --watch=false
- yarn lint

## PR Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [x] DB: New Flyway migration added (if schema changed)
- [x] API: OpenAPI spec updated; generated new sources
- [x] Web: Loading/error states; basic a11y; responsive layout
- [x] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68dbfbc1e878833095ffedffc34b6807