### PR TITLE
feat(web): add focus management utilities

### DIFF
--- a/apps/web/src/lib/a11y.test.tsx
+++ b/apps/web/src/lib/a11y.test.tsx
@@ -1,0 +1,171 @@
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { focusFirst, focusLast, trapFocus, useFocusReturn } from './a11y';
+import { useRef } from 'react';
+
+function createFocusableContainer() {
+  const container = document.createElement('div');
+
+  container.innerHTML = `
+    <button type="button">Alpha</button>
+    <input type="text" value="bravo" />
+    <a href="#charlie">Charlie</a>
+  `;
+
+  document.body.appendChild(container);
+
+  return container;
+}
+
+describe('focus utilities', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe('focusFirst', () => {
+    it('moves focus to the first focusable descendant', () => {
+      const container = createFocusableContainer();
+
+      const result = focusFirst(container);
+
+      expect(result).toBe(container.querySelector('button'));
+      expect(document.activeElement).toBe(result);
+    });
+
+    it('falls back to the container when it is focusable and empty', () => {
+      const container = document.createElement('div');
+      container.tabIndex = 0;
+      document.body.appendChild(container);
+
+      const result = focusFirst(container);
+
+      expect(result).toBe(container);
+      expect(document.activeElement).toBe(container);
+    });
+  });
+
+  describe('focusLast', () => {
+    it('moves focus to the last focusable descendant', () => {
+      const container = createFocusableContainer();
+
+      const result = focusLast(container);
+
+      const link = container.querySelector('a');
+      expect(result).toBe(link);
+      expect(document.activeElement).toBe(link);
+    });
+  });
+
+  describe('trapFocus', () => {
+    beforeEach(() => {
+      document.body.innerHTML = '';
+    });
+
+    it('cycles focus within the container when tabbing forward and backward', () => {
+      const container = document.createElement('div');
+      container.innerHTML = `
+        <button type="button">First</button>
+        <button type="button">Second</button>
+        <button type="button">Third</button>
+      `;
+
+      document.body.appendChild(container);
+
+      const [first, second, third] = Array.from(
+        container.querySelectorAll<HTMLButtonElement>('button'),
+      );
+
+      const release = trapFocus(container);
+
+      first.focus();
+
+      fireEvent.keyDown(first, { key: 'Tab' });
+      expect(document.activeElement).toBe(second);
+
+      fireEvent.keyDown(second, { key: 'Tab' });
+      expect(document.activeElement).toBe(third);
+
+      fireEvent.keyDown(third, { key: 'Tab' });
+      expect(document.activeElement).toBe(first);
+
+      fireEvent.keyDown(first, { key: 'Tab', shiftKey: true });
+      expect(document.activeElement).toBe(third);
+
+      release();
+    });
+
+    it('restores previously focused element when released', () => {
+      const trigger = document.createElement('button');
+      trigger.type = 'button';
+      trigger.textContent = 'Open';
+      document.body.appendChild(trigger);
+      trigger.focus();
+
+      const container = createFocusableContainer();
+
+      const release = trapFocus(container);
+
+      expect(document.activeElement).not.toBe(trigger);
+
+      release();
+
+      expect(document.activeElement).toBe(trigger);
+    });
+  });
+
+  describe('useFocusReturn', () => {
+    const TestComponent = () => {
+      const ref = useRef<HTMLDivElement>(null);
+      useFocusReturn(ref);
+
+      return (
+        <div ref={ref}>
+          <button type="button">One</button>
+          <button type="button">Two</button>
+        </div>
+      );
+    };
+
+    it('focuses the first focusable element on mount and restores focus on unmount', () => {
+      const outside = document.createElement('button');
+      outside.type = 'button';
+      outside.textContent = 'Outside';
+      document.body.appendChild(outside);
+      outside.focus();
+
+      const { unmount } = render(<TestComponent />);
+
+      expect(document.activeElement?.textContent).toBe('One');
+
+      unmount();
+
+      expect(document.activeElement).toBe(outside);
+    });
+
+    it('allows disabling via options', () => {
+      const outside = document.createElement('button');
+      outside.type = 'button';
+      outside.textContent = 'Outside';
+      document.body.appendChild(outside);
+      outside.focus();
+
+      const Component = () => {
+        const ref = useRef<HTMLDivElement>(null);
+        useFocusReturn(ref, { enabled: false });
+
+        return (
+          <div ref={ref}>
+            <button type="button">One</button>
+          </div>
+        );
+      };
+
+      const { unmount } = render(<Component />);
+
+      expect(document.activeElement).toBe(outside);
+
+      unmount();
+      expect(document.activeElement).toBe(outside);
+    });
+  });
+});

--- a/apps/web/src/lib/a11y.ts
+++ b/apps/web/src/lib/a11y.ts
@@ -1,0 +1,231 @@
+import { RefObject, useEffect, useRef } from 'react';
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]:not([tabindex="-1"])',
+  'area[href]:not([tabindex="-1"])',
+  'button:not([disabled]):not([aria-hidden="true"]):not([tabindex="-1"])',
+  'input:not([disabled]):not([type="hidden"]):not([aria-hidden="true"]):not([tabindex="-1"])',
+  'select:not([disabled]):not([aria-hidden="true"]):not([tabindex="-1"])',
+  'textarea:not([disabled]):not([aria-hidden="true"]):not([tabindex="-1"])',
+  'iframe:not([tabindex="-1"])',
+  '[contenteditable="true"]:not([tabindex="-1"])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+const isBrowser = typeof window !== 'undefined' && typeof document !== 'undefined';
+
+type FocusContainer = ParentNode & EventTarget;
+
+function focusElement(element: HTMLElement | null) {
+  if (!element) return;
+
+  try {
+    element.focus({ preventScroll: true });
+  } catch (error) {
+    element.focus();
+  }
+}
+
+function isHidden(element: HTMLElement): boolean {
+  return (
+    element.hasAttribute('hidden') ||
+    element.getAttribute('aria-hidden') === 'true' ||
+    element.style.display === 'none' ||
+    element.style.visibility === 'hidden'
+  );
+}
+
+function getFocusableElements(container: FocusContainer | null): HTMLElement[] {
+  if (!container || !('querySelectorAll' in container)) {
+    return [];
+  }
+
+  const elements = Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+  );
+
+  return elements.filter((element) => !isHidden(element));
+}
+
+function isFocusable(element: HTMLElement): boolean {
+  if (element.hasAttribute('disabled')) return false;
+  if (element.getAttribute('aria-hidden') === 'true') return false;
+
+  if (typeof element.tabIndex === 'number' && element.tabIndex >= 0) {
+    return true;
+  }
+
+  if (element.matches(FOCUSABLE_SELECTOR)) {
+    return true;
+  }
+
+  return false;
+}
+
+export function focusFirst(container?: FocusContainer | null): HTMLElement | null {
+  if (!isBrowser) {
+    return null;
+  }
+
+  const focusTarget =
+    getFocusableElements(container ?? document).at(0) ??
+    (container instanceof HTMLElement && isFocusable(container) ? container : null);
+
+  focusElement(focusTarget ?? null);
+
+  return focusTarget ?? null;
+}
+
+export function focusLast(container?: FocusContainer | null): HTMLElement | null {
+  if (!isBrowser) {
+    return null;
+  }
+
+  const focusable = getFocusableElements(container ?? document);
+  const focusTarget =
+    focusable.at(-1) ??
+    (container instanceof HTMLElement && isFocusable(container) ? container : null);
+
+  focusElement(focusTarget ?? null);
+
+  return focusTarget ?? null;
+}
+
+type TrapFocusOptions = {
+  initialFocus?: HTMLElement | null;
+};
+
+export function trapFocus(
+  container: HTMLElement | null,
+  options: TrapFocusOptions = {},
+): () => void {
+  if (!isBrowser || !container) {
+    return () => {};
+  }
+
+  const { initialFocus } = options;
+  const previouslyFocused = document.activeElement as HTMLElement | null;
+  let lastDirection: 'forward' | 'backward' = 'forward';
+
+  const ensureFocus = () => {
+    const active = document.activeElement;
+
+    if (!container.contains(active)) {
+      if (lastDirection === 'backward') {
+        focusLast(container);
+      } else {
+        focusFirst(container);
+      }
+    }
+  };
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key !== 'Tab') {
+      return;
+    }
+
+    const focusable = getFocusableElements(container);
+
+    if (focusable.length === 0) {
+      if (!isFocusable(container)) {
+        container.setAttribute('tabindex', '-1');
+      }
+
+      focusElement(container);
+      event.preventDefault();
+      return;
+    }
+
+    const activeElement = document.activeElement as HTMLElement | null;
+    const currentIndex = activeElement ? focusable.indexOf(activeElement) : -1;
+    lastDirection = event.shiftKey ? 'backward' : 'forward';
+
+    if (event.shiftKey) {
+      const previousIndex = currentIndex <= 0 ? focusable.length - 1 : currentIndex - 1;
+      focusElement(focusable[previousIndex]);
+      event.preventDefault();
+      return;
+    }
+
+    const nextIndex = currentIndex === focusable.length - 1 ? 0 : currentIndex + 1;
+    focusElement(focusable[nextIndex]);
+    event.preventDefault();
+  };
+
+  const handleFocusIn = (event: FocusEvent) => {
+    if (!container.contains(event.target as Node)) {
+      ensureFocus();
+    }
+  };
+
+  const doc = container.ownerDocument ?? document;
+
+  doc.addEventListener('focusin', handleFocusIn);
+  container.addEventListener('keydown', handleKeyDown);
+
+  let initialTarget: HTMLElement | null = null;
+
+  if (initialFocus && container.contains(initialFocus)) {
+    initialTarget = initialFocus;
+    focusElement(initialTarget);
+  } else {
+    initialTarget = focusFirst(container);
+  }
+
+  return () => {
+    doc.removeEventListener('focusin', handleFocusIn);
+    container.removeEventListener('keydown', handleKeyDown);
+
+    if (previouslyFocused && previouslyFocused.isConnected) {
+      focusElement(previouslyFocused);
+    }
+  };
+}
+
+type FocusReturnOptions = {
+  enabled?: boolean;
+};
+
+export function useFocusReturn<T extends HTMLElement>(
+  ref: RefObject<T>,
+  options: FocusReturnOptions = {},
+) {
+  const { enabled = true } = options;
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!isBrowser || !enabled) {
+      return;
+    }
+
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+
+    return () => {
+      const previous = previousFocusRef.current;
+
+      if (previous && previous.isConnected) {
+        focusElement(previous);
+      }
+    };
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!isBrowser || !enabled) {
+      return;
+    }
+
+    const node = ref.current;
+
+    if (!node) {
+      return;
+    }
+
+    const active = node.ownerDocument?.activeElement as HTMLElement | null;
+
+    if (!active || !node.contains(active)) {
+      focusFirst(node);
+    }
+  }, [enabled, ref]);
+}
+
+export { getFocusableElements };


### PR DESCRIPTION
## Summary
- add shared focus helpers for trapping focus, cycling to the first/last element, and restoring focus when a container unmounts
- cover the new focus utilities with unit tests to lock expected keyboard behavior

## Testing
- yarn test

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68dc6a9353408330928de58d087d7946