### PR TITLE
feat: add accessible tabs component

### DIFF
--- a/apps/web/src/components/Tabs.tsx
+++ b/apps/web/src/components/Tabs.tsx
@@ -1,0 +1,343 @@
+import {
+  KeyboardEvent,
+  ReactNode,
+  useCallback,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+export type TabDefinition = {
+  id: string;
+  label: ReactNode;
+  content: ReactNode;
+  disabled?: boolean;
+};
+
+type TabState = {
+  isSelected: boolean;
+  isFocused: boolean;
+  isDisabled: boolean;
+};
+
+type TabsProps = {
+  tabs: TabDefinition[];
+  currentTabId: string;
+  onTabChange: (tabId: string) => void;
+  className?: string;
+  tabListClassName?: string;
+  tabClassName?:
+    | string
+    | ((tab: TabDefinition, state: TabState) => string);
+  tabPanelClassName?:
+    | string
+    | ((tab: TabDefinition, isSelected: boolean) => string);
+  ariaLabel?: string;
+  ariaLabelledBy?: string;
+};
+
+const defaultTabBaseClass =
+  'inline-flex items-center gap-2 rounded-t border border-b-0 border-gray-200 bg-gray-100 px-4 py-2 text-sm font-medium text-gray-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white';
+const defaultTabSelectedClass = 'bg-white text-gray-900';
+const defaultTabUnselectedClass = 'hover:text-gray-800';
+const defaultTabDisabledClass = 'cursor-not-allowed opacity-50';
+
+const defaultTabPanelClass = 'rounded-b border border-gray-200 bg-white p-4';
+
+export function Tabs({
+  tabs,
+  currentTabId,
+  onTabChange,
+  className,
+  tabListClassName,
+  tabClassName,
+  tabPanelClassName,
+  ariaLabel,
+  ariaLabelledBy,
+}: TabsProps) {
+  const generatedId = useId();
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const enabledIndexes = useMemo(() => {
+    return tabs
+      .map((tab, index) => (tab.disabled ? null : index))
+      .filter((value): value is number => value !== null);
+  }, [tabs]);
+
+  const firstEnabledIndex = enabledIndexes[0] ?? -1;
+  const lastEnabledIndex =
+    enabledIndexes.length > 0
+      ? enabledIndexes[enabledIndexes.length - 1]
+      : -1;
+
+  const selectedIndex = useMemo(() => {
+    const index = tabs.findIndex(
+      (tab) => tab.id === currentTabId && !tab.disabled,
+    );
+
+    if (index !== -1) {
+      return index;
+    }
+
+    return firstEnabledIndex;
+  }, [currentTabId, firstEnabledIndex, tabs]);
+
+  const [focusedTabId, setFocusedTabId] = useState<string | null>(() => {
+    const selectedTab = tabs[selectedIndex];
+
+    if (selectedTab && !selectedTab.disabled) {
+      return selectedTab.id;
+    }
+
+    const fallback = tabs.find((tab) => !tab.disabled);
+
+    return fallback?.id ?? null;
+  });
+
+  const resolvedFocusedTabId = useMemo(() => {
+    if (
+      focusedTabId &&
+      tabs.some((tab) => tab.id === focusedTabId && !tab.disabled)
+    ) {
+      return focusedTabId;
+    }
+
+    const selectedTab = tabs[selectedIndex];
+
+    if (selectedTab && !selectedTab.disabled) {
+      return selectedTab.id;
+    }
+
+    const fallback = tabs.find((tab) => !tab.disabled);
+
+    return fallback?.id ?? null;
+  }, [focusedTabId, selectedIndex, tabs]);
+
+  const focusedIndex = useMemo(() => {
+    if (!resolvedFocusedTabId) {
+      return -1;
+    }
+
+    return tabs.findIndex((tab) => tab.id === resolvedFocusedTabId);
+  }, [resolvedFocusedTabId, tabs]);
+
+  const focusTab = useCallback(
+    (index: number) => {
+      const nextTab = tabs[index];
+
+      if (!nextTab || nextTab.disabled) {
+        return;
+      }
+
+      setFocusedTabId(nextTab.id);
+
+      const node = tabRefs.current[index];
+
+      if (node) {
+        node.focus();
+      }
+    },
+    [tabs],
+  );
+
+  const moveFocus = useCallback(
+    (currentIndex: number, direction: 1 | -1) => {
+      if (enabledIndexes.length === 0) {
+        return null;
+      }
+
+      let nextIndex = currentIndex;
+
+      for (let i = 0; i < tabs.length; i += 1) {
+        nextIndex = (nextIndex + direction + tabs.length) % tabs.length;
+        const nextTab = tabs[nextIndex];
+
+        if (!nextTab?.disabled) {
+          return nextIndex;
+        }
+      }
+
+      return null;
+    },
+    [enabledIndexes.length, tabs],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+      let nextIndex: number | null = null;
+
+      switch (event.key) {
+        case 'ArrowRight':
+        case 'ArrowDown':
+          nextIndex = moveFocus(index, 1);
+          break;
+        case 'ArrowLeft':
+        case 'ArrowUp':
+          nextIndex = moveFocus(index, -1);
+          break;
+        case 'Home':
+          nextIndex = firstEnabledIndex !== -1 ? firstEnabledIndex : null;
+          break;
+        case 'End':
+          nextIndex = lastEnabledIndex !== -1 ? lastEnabledIndex : null;
+          break;
+        case 'Enter':
+        case ' ': {
+          const tab = tabs[index];
+
+          if (!tab?.disabled && tab.id !== currentTabId) {
+            event.preventDefault();
+            onTabChange(tab.id);
+          }
+
+          return;
+        }
+        default:
+          return;
+      }
+
+      if (nextIndex !== null) {
+        event.preventDefault();
+        focusTab(nextIndex);
+        const nextTab = tabs[nextIndex];
+
+        if (nextTab && !nextTab.disabled && nextTab.id !== currentTabId) {
+          onTabChange(nextTab.id);
+        }
+      }
+    },
+    [
+      currentTabId,
+      firstEnabledIndex,
+      focusTab,
+      lastEnabledIndex,
+      moveFocus,
+      onTabChange,
+      tabs,
+    ],
+  );
+
+  const getTabClassName = useCallback(
+    (tab: TabDefinition, state: TabState) => {
+      if (typeof tabClassName === 'function') {
+        return tabClassName(tab, state);
+      }
+
+      const pieces = [defaultTabBaseClass];
+
+      if (state.isSelected) {
+        pieces.push(defaultTabSelectedClass);
+      } else {
+        pieces.push(defaultTabUnselectedClass);
+      }
+
+      if (state.isDisabled) {
+        pieces.push(defaultTabDisabledClass);
+      }
+
+      if (typeof tabClassName === 'string' && tabClassName.trim()) {
+        pieces.push(tabClassName);
+      }
+
+      return pieces.join(' ');
+    },
+    [tabClassName],
+  );
+
+  const getPanelClassName = useCallback(
+    (tab: TabDefinition, isSelected: boolean) => {
+      if (typeof tabPanelClassName === 'function') {
+        return tabPanelClassName(tab, isSelected);
+      }
+
+      const pieces = [defaultTabPanelClass];
+
+      if (typeof tabPanelClassName === 'string' && tabPanelClassName.trim()) {
+        pieces.push(tabPanelClassName);
+      }
+
+      return pieces.join(' ');
+    },
+    [tabPanelClassName],
+  );
+
+  const wrapperClassName = `space-y-0 ${className ?? ''}`.trim();
+  const tablistClassName = `flex flex-wrap gap-1 border-b border-gray-200 ${
+    tabListClassName ?? ''
+  }`.trim();
+
+  return (
+    <div className={wrapperClassName}>
+      <div
+        role="tablist"
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        className={tablistClassName}
+      >
+        {tabs.map((tab, index) => {
+          const tabId = `${generatedId}-tab-${tab.id}`;
+          const panelId = `${generatedId}-panel-${tab.id}`;
+          const isSelected = tab.id === currentTabId;
+          const isDisabled = Boolean(tab.disabled);
+          const isFocused = tab.id === resolvedFocusedTabId;
+
+          return (
+            <button
+              key={tab.id}
+              ref={(node) => {
+                tabRefs.current[index] = node;
+              }}
+              id={tabId}
+              role="tab"
+              type="button"
+              aria-selected={isSelected}
+              aria-controls={panelId}
+              aria-disabled={isDisabled || undefined}
+              data-state={isSelected ? 'active' : 'inactive'}
+              data-disabled={isDisabled ? '' : undefined}
+              tabIndex={isDisabled ? -1 : isFocused ? 0 : -1}
+              className={getTabClassName(tab, {
+                isSelected,
+                isFocused,
+                isDisabled,
+              })}
+              onClick={() => {
+                if (isDisabled || tab.id === currentTabId) {
+                  return;
+                }
+
+                setFocusedTabId(tab.id);
+                onTabChange(tab.id);
+              }}
+              onKeyDown={(event) => handleKeyDown(event, index)}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+      <div>
+        {tabs.map((tab) => {
+          const tabId = `${generatedId}-tab-${tab.id}`;
+          const panelId = `${generatedId}-panel-${tab.id}`;
+          const isSelected = tab.id === currentTabId;
+
+          return (
+            <div
+              key={tab.id}
+              id={panelId}
+              role="tabpanel"
+              aria-labelledby={tabId}
+              hidden={!isSelected}
+              className={getPanelClassName(tab, isSelected)}
+              tabIndex={0}
+            >
+              {isSelected ? tab.content : null}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/__tests__/Tabs.test.tsx
+++ b/apps/web/src/components/__tests__/Tabs.test.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { TabDefinition, Tabs } from '../Tabs';
+
+type ExampleTabsProps = {
+  onTabChange?: (tabId: string) => void;
+};
+
+function ExampleTabs({ onTabChange }: ExampleTabsProps) {
+  const tabs: TabDefinition[] = [
+    {
+      id: 'general',
+      label: 'General',
+      content: <div>General content</div>,
+    },
+    {
+      id: 'permissions',
+      label: 'Permissions',
+      content: <div>Permissions content</div>,
+    },
+    {
+      id: 'notifications',
+      label: 'Notifications',
+      content: <div>Notifications content</div>,
+    },
+  ];
+
+  const [currentTabId, setCurrentTabId] = useState(tabs[0].id);
+
+  const handleTabChange = (tabId: string) => {
+    onTabChange?.(tabId);
+    setCurrentTabId(tabId);
+  };
+
+  return (
+    <Tabs
+      tabs={tabs}
+      currentTabId={currentTabId}
+      onTabChange={handleTabChange}
+      ariaLabel="Account sections"
+    />
+  );
+}
+
+describe('Tabs', () => {
+  it('uses roving tabindex and supports arrow key navigation', async () => {
+    const onTabChange = vi.fn();
+
+    render(<ExampleTabs onTabChange={onTabChange} />);
+
+    const tablist = screen.getByRole('tablist', { name: 'Account sections' });
+    expect(tablist).toBeInTheDocument();
+
+    const generalTab = screen.getByRole('tab', { name: 'General' });
+    const permissionsTab = screen.getByRole('tab', { name: 'Permissions' });
+    const notificationsTab = screen.getByRole('tab', { name: 'Notifications' });
+
+    expect(generalTab).toHaveAttribute('aria-selected', 'true');
+    expect(generalTab).toHaveAttribute('tabindex', '0');
+    expect(permissionsTab).toHaveAttribute('aria-selected', 'false');
+    expect(permissionsTab).toHaveAttribute('tabindex', '-1');
+    expect(notificationsTab).toHaveAttribute('aria-selected', 'false');
+    expect(notificationsTab).toHaveAttribute('tabindex', '-1');
+
+    generalTab.focus();
+    expect(generalTab).toHaveFocus();
+
+    fireEvent.keyDown(generalTab, { key: 'ArrowRight' });
+    expect(permissionsTab).toHaveFocus();
+    expect(permissionsTab).toHaveAttribute('aria-selected', 'true');
+    expect(permissionsTab).toHaveAttribute('tabindex', '0');
+    expect(generalTab).toHaveAttribute('tabindex', '-1');
+    expect(onTabChange).toHaveBeenLastCalledWith('permissions');
+
+    fireEvent.keyDown(permissionsTab, { key: 'End' });
+    expect(notificationsTab).toHaveFocus();
+    expect(notificationsTab).toHaveAttribute('aria-selected', 'true');
+    expect(notificationsTab).toHaveAttribute('tabindex', '0');
+    expect(onTabChange).toHaveBeenLastCalledWith('notifications');
+
+    fireEvent.keyDown(notificationsTab, { key: 'ArrowLeft' });
+    expect(permissionsTab).toHaveFocus();
+    expect(onTabChange).toHaveBeenLastCalledWith('permissions');
+
+    fireEvent.keyDown(permissionsTab, { key: 'Home' });
+    expect(generalTab).toHaveFocus();
+    expect(onTabChange).toHaveBeenLastCalledWith('general');
+  });
+
+  it('wires aria-controls and aria-labelledby for panels', async () => {
+    render(<ExampleTabs />);
+
+    const generalTab = screen.getByRole('tab', { name: 'General' });
+    const permissionsTab = screen.getByRole('tab', { name: 'Permissions' });
+
+    const generalPanelId = generalTab.getAttribute('aria-controls');
+    expect(generalPanelId).toBeTruthy();
+
+    const generalPanel = document.getElementById(generalPanelId!);
+    expect(generalPanel).not.toBeNull();
+    expect(generalPanel).toHaveAttribute('role', 'tabpanel');
+    expect(generalPanel).toHaveAttribute('aria-labelledby', generalTab.id);
+    expect(generalPanel).toBeVisible();
+
+    const permissionsPanelId = permissionsTab.getAttribute('aria-controls');
+    expect(permissionsPanelId).toBeTruthy();
+
+    const permissionsPanel = document.getElementById(permissionsPanelId!);
+    expect(permissionsPanel).not.toBeNull();
+    expect(permissionsPanel).toHaveAttribute('role', 'tabpanel');
+    expect(permissionsPanel).toHaveAttribute('aria-labelledby', permissionsTab.id);
+    expect(permissionsPanel).not.toBeVisible();
+
+    permissionsTab.focus();
+    fireEvent.keyDown(permissionsTab, { key: 'Enter' });
+
+    expect(permissionsPanel).toBeVisible();
+    expect(generalPanel).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add an accessible `Tabs` component that manages roving focus, arrow key navigation, and ARIA relationships between tabs and panels
- cover the tab interactions with unit tests that verify keyboard navigation and screen reader labels

## Testing
- yarn test

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [x] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68dc99a112c88330a91e17152660094a