### PR TITLE
feat(web): improve focus handling for pages and modals

### DIFF
--- a/apps/web/src/components/Modal.tsx
+++ b/apps/web/src/components/Modal.tsx
@@ -57,6 +57,17 @@ export default function Modal({
       return;
     }
 
+    const autoFocusCandidate = dialog.querySelector<HTMLElement>('[data-autofocus]');
+
+    if (
+      autoFocusCandidate &&
+      !autoFocusCandidate.hasAttribute('disabled') &&
+      autoFocusCandidate.tabIndex !== -1
+    ) {
+      autoFocusCandidate.focus({ preventScroll: true });
+      return;
+    }
+
     const focusable = Array.from(
       dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS.join(',')),
     ).filter(

--- a/apps/web/src/components/__tests__/Modal.test.tsx
+++ b/apps/web/src/components/__tests__/Modal.test.tsx
@@ -36,6 +36,27 @@ describe('Modal', () => {
     expect(results.violations).toHaveLength(0);
   });
 
+  it('focuses the element marked with data-autofocus when opening', async () => {
+    render(
+      <Modal
+        open
+        onClose={() => undefined}
+        closeLabel="Close dialog"
+        titleId="modal-title"
+      >
+        <h2 id="modal-title">Focus target</h2>
+        <button type="button" data-autofocus>
+          Preferred
+        </button>
+        <button type="button">Secondary</button>
+      </Modal>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Preferred' })).toHaveFocus(),
+    );
+  });
+
   it('traps focus within the modal', async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();

--- a/apps/web/src/components/layout/PageHeading.tsx
+++ b/apps/web/src/components/layout/PageHeading.tsx
@@ -1,0 +1,88 @@
+import { ComponentPropsWithoutRef, ReactNode, forwardRef, useCallback, useEffect, useRef } from 'react';
+
+type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
+type PageHeadingProps = {
+  /**
+   * Heading level (h1-h6). Defaults to `h1`.
+   */
+  level?: HeadingLevel;
+  /**
+   * When `true`, focus moves to the heading after mount. Opt-in to avoid focus churn.
+   */
+  autoFocus?: boolean;
+  children: ReactNode;
+} & Omit<ComponentPropsWithoutRef<'h1'>, 'children'>;
+
+const createHeadingTag = (level: HeadingLevel) => `h${level}` as const;
+
+export const PageHeading = forwardRef<HTMLHeadingElement, PageHeadingProps>(
+  function PageHeading(
+    { level = 1, autoFocus = false, className, tabIndex, children, ...rest },
+    forwardedRef,
+  ) {
+    const elementRef = useRef<HTMLHeadingElement | null>(null);
+
+    const assignRef = useCallback(
+      (node: HTMLHeadingElement | null) => {
+        elementRef.current = node;
+
+        if (typeof forwardedRef === 'function') {
+          forwardedRef(node);
+        } else if (forwardedRef) {
+          forwardedRef.current = node;
+        }
+      },
+      [forwardedRef],
+    );
+
+    useEffect(() => {
+      if (!autoFocus) {
+        return;
+      }
+
+      if (typeof window === 'undefined') {
+        return;
+      }
+
+      const node = elementRef.current;
+
+      if (!node) {
+        return;
+      }
+
+      const frame = window.requestAnimationFrame(() => {
+        if (!node.isConnected) {
+          return;
+        }
+
+        try {
+          node.focus({ preventScroll: true });
+        } catch {
+          node.focus();
+        }
+      });
+
+      return () => {
+        window.cancelAnimationFrame(frame);
+      };
+    }, [autoFocus]);
+
+    const HeadingTag = createHeadingTag(level);
+    const resolvedTabIndex = tabIndex ?? (autoFocus ? -1 : undefined);
+
+    return (
+      <HeadingTag
+        {...rest}
+        ref={assignRef}
+        className={className}
+        tabIndex={resolvedTabIndex}
+        data-page-heading={autoFocus ? 'true' : undefined}
+      >
+        {children}
+      </HeadingTag>
+    );
+  },
+);
+
+export default PageHeading;

--- a/apps/web/src/features/groups/GroupForm.tsx
+++ b/apps/web/src/features/groups/GroupForm.tsx
@@ -11,15 +11,19 @@ const schema = z.object({
 
 export type GroupFormValues = z.infer<typeof schema>;
 
+type GroupFormProps = {
+  defaultValues?: GroupFormValues;
+  onSubmit: (values: GroupFormValues) => void;
+  onCancel?: () => void;
+  autoFocusFirstField?: boolean;
+};
+
 export function GroupForm({
   defaultValues,
   onSubmit,
   onCancel,
-}: {
-  defaultValues?: GroupFormValues;
-  onSubmit: (values: GroupFormValues) => void;
-  onCancel?: () => void;
-}) {
+  autoFocusFirstField = false,
+}: GroupFormProps) {
   const { t } = useTranslation('groups');
   const { t: tCommon } = useTranslation('common');
   const {
@@ -51,6 +55,7 @@ export function GroupForm({
         <input
           id="name"
           {...register('name')}
+          data-autofocus={autoFocusFirstField ? 'true' : undefined}
           className="border p-2 rounded w-full"
           aria-invalid={Boolean(errors.name)}
           aria-describedby={describedBy('name', { includeError: Boolean(errors.name) })}

--- a/apps/web/src/features/members/MemberForm.tsx
+++ b/apps/web/src/features/members/MemberForm.tsx
@@ -59,15 +59,19 @@ const baseResolver = zodResolver(schema);
 const resolver: typeof baseResolver = async (values, context, options) =>
   withFieldErrorPrefix('members', () => baseResolver(values, context, options));
 
+type MemberFormProps = {
+  defaultValues?: MemberFormValues;
+  onSubmit: (values: components['schemas']['MemberRequest']) => void;
+  onCancel?: () => void;
+  autoFocusFirstField?: boolean;
+};
+
 export function MemberForm({
   defaultValues,
   onSubmit,
   onCancel,
-}: {
-  defaultValues?: MemberFormValues;
-  onSubmit: (values: components['schemas']['MemberRequest']) => void;
-  onCancel?: () => void;
-}) {
+  autoFocusFirstField = false,
+}: MemberFormProps) {
   const { t } = useTranslation('members');
   const { t: tCommon } = useTranslation('common');
 
@@ -121,6 +125,7 @@ export function MemberForm({
         <input
           id="displayName"
           {...register('displayName')}
+          data-autofocus={autoFocusFirstField ? 'true' : undefined}
           className="border p-2 rounded w-full"
           aria-invalid={Boolean(errors.displayName)}
           aria-describedby={describedBy('displayName', {

--- a/apps/web/src/features/services/ServiceForm.tsx
+++ b/apps/web/src/features/services/ServiceForm.tsx
@@ -19,15 +19,19 @@ const baseResolver = zodResolver(schema);
 const resolver: typeof baseResolver = async (values, context, options) =>
   withFieldErrorPrefix('services', () => baseResolver(values, context, options));
 
+type ServiceFormProps = {
+  defaultValues?: ServiceFormValues;
+  onSubmit: (values: components['schemas']['ServiceRequest']) => void;
+  onCancel?: () => void;
+  autoFocusFirstField?: boolean;
+};
+
 export function ServiceForm({
   defaultValues,
   onSubmit,
   onCancel,
-}: {
-  defaultValues?: ServiceFormValues;
-  onSubmit: (values: components['schemas']['ServiceRequest']) => void;
-  onCancel?: () => void;
-}) {
+  autoFocusFirstField = false,
+}: ServiceFormProps) {
   const { t } = useTranslation('services');
   const { t: tCommon } = useTranslation('common');
 
@@ -65,6 +69,7 @@ export function ServiceForm({
           id="startsAt"
           type="datetime-local"
           {...register('startsAt')}
+          data-autofocus={autoFocusFirstField ? 'true' : undefined}
           className="border p-2 rounded w-full"
           aria-invalid={Boolean(errors.startsAt)}
           aria-describedby={describedBy('startsAt', { includeError: Boolean(errors.startsAt) })}

--- a/apps/web/src/features/sets/SetForm.tsx
+++ b/apps/web/src/features/sets/SetForm.tsx
@@ -15,9 +15,15 @@ type SetFormProps = {
   defaultValues?: Partial<SetFormValues>;
   onSubmit: (values: SetFormValues) => void;
   onCancel?: () => void;
+  autoFocusFirstField?: boolean;
 };
 
-export function SetForm({ defaultValues, onSubmit, onCancel }: SetFormProps) {
+export function SetForm({
+  defaultValues,
+  onSubmit,
+  onCancel,
+  autoFocusFirstField = false,
+}: SetFormProps) {
   const { t } = useTranslation('songSets');
   const { t: tCommon } = useTranslation('common');
   const {
@@ -52,6 +58,7 @@ export function SetForm({ defaultValues, onSubmit, onCancel }: SetFormProps) {
         <input
           id="name"
           {...register('name')}
+          data-autofocus={autoFocusFirstField ? 'true' : undefined}
           className="border p-2 rounded w-full"
           aria-invalid={Boolean(errors.name)}
           aria-describedby={describedBy('name', { includeError: Boolean(errors.name) })}

--- a/apps/web/src/features/songs/ArrangementForm.tsx
+++ b/apps/web/src/features/songs/ArrangementForm.tsx
@@ -21,15 +21,19 @@ const schema = z.object({
 
 export type ArrangementFormValues = z.infer<typeof schema>;
 
+type ArrangementFormProps = {
+  defaultValues?: ArrangementFormValues;
+  onSubmit: (values: components['schemas']['ArrangementRequest']) => void;
+  onCancel?: () => void;
+  autoFocusFirstField?: boolean;
+};
+
 export function ArrangementForm({
   defaultValues,
   onSubmit,
   onCancel,
-}: {
-  defaultValues?: ArrangementFormValues;
-  onSubmit: (values: components['schemas']['ArrangementRequest']) => void;
-  onCancel?: () => void;
-}) {
+  autoFocusFirstField = false,
+}: ArrangementFormProps) {
   const { t } = useTranslation('arrangements');
   const { t: tCommon } = useTranslation('common');
 
@@ -84,6 +88,7 @@ export function ArrangementForm({
             <input
               id="key"
               {...register('key')}
+              data-autofocus={autoFocusFirstField ? 'true' : undefined}
               className="border p-2 rounded w-full"
               aria-invalid={Boolean(errors.key)}
               aria-describedby={describedBy('key', { includeError: Boolean(errors.key) })}

--- a/apps/web/src/features/songs/SongForm.tsx
+++ b/apps/web/src/features/songs/SongForm.tsx
@@ -23,15 +23,19 @@ export type SongFormValues = z.infer<typeof schema>;
 
 type FieldName = keyof SongFormValues;
 
+type SongFormProps = {
+  defaultValues?: SongFormValues;
+  onSubmit: (values: components['schemas']['SongRequest']) => void;
+  onCancel?: () => void;
+  autoFocusFirstField?: boolean;
+};
+
 export function SongForm({
   defaultValues,
   onSubmit,
   onCancel,
-}: {
-  defaultValues?: SongFormValues;
-  onSubmit: (values: components['schemas']['SongRequest']) => void;
-  onCancel?: () => void;
-}) {
+  autoFocusFirstField = false,
+}: SongFormProps) {
   const { t } = useTranslation('songs');
   const { t: tCommon } = useTranslation('common');
 
@@ -103,6 +107,7 @@ export function SongForm({
           })}
           placeholder={titleField.placeholder}
           {...register('title')}
+          data-autofocus={autoFocusFirstField ? 'true' : undefined}
           className="border p-2 rounded w-full"
         />
         {titleField.helpText ? (

--- a/apps/web/src/features/users/UserForm.tsx
+++ b/apps/web/src/features/users/UserForm.tsx
@@ -43,6 +43,7 @@ type EditFormValues = z.infer<typeof editSchema>;
 type BaseFormProps = {
   onCancel?: () => void;
   isSubmitting?: boolean;
+  autoFocusFirstField?: boolean;
 };
 
 type UserCreateFormProps = BaseFormProps & {
@@ -81,6 +82,7 @@ export function UserCreateForm({
   onSubmit,
   onCancel,
   isSubmitting,
+  autoFocusFirstField = false,
 }: UserCreateFormProps) {
   const { t } = useTranslation('adminUsers');
   const { t: tCommon } = useTranslation('common');
@@ -141,6 +143,7 @@ export function UserCreateForm({
           id="email"
           type="email"
           {...register('email')}
+          data-autofocus={autoFocusFirstField ? 'true' : undefined}
           className="mt-1 w-full rounded border p-2"
           aria-invalid={Boolean(errors.email)}
           aria-describedby={describedBy('email', { includeError: Boolean(errors.email) })}
@@ -224,6 +227,7 @@ export function UserEditForm({
   onSubmit,
   onCancel,
   isSubmitting,
+  autoFocusFirstField = false,
 }: UserEditFormProps) {
   const { t } = useTranslation('adminUsers');
   const { t: tCommon } = useTranslation('common');
@@ -285,6 +289,7 @@ export function UserEditForm({
         <input
           id="displayName"
           {...register('displayName')}
+          data-autofocus={autoFocusFirstField ? 'true' : undefined}
           className="mt-1 w-full rounded border p-2"
           aria-invalid={Boolean(errors.displayName)}
           aria-describedby={describedBy('displayName', {

--- a/apps/web/src/pages/admin/users/UserCreatePage.tsx
+++ b/apps/web/src/pages/admin/users/UserCreatePage.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { PageHeading } from '@/components/layout/PageHeading';
 import { toast } from 'sonner';
 
 import type { CreateUserBody } from '@/api/users';
@@ -26,7 +27,9 @@ export default function UserCreatePage() {
     <div className="space-y-6 p-6">
       <div className="flex items-center justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-semibold">{t('page.createTitle')}</h1>
+          <PageHeading autoFocus className="text-2xl font-semibold">
+            {t('page.createTitle')}
+          </PageHeading>
           <p className="text-sm text-gray-600">{t('create.heading')}</p>
         </div>
         <button
@@ -42,6 +45,7 @@ export default function UserCreatePage() {
         onSubmit={handleSubmit}
         onCancel={() => navigate('..')}
         isSubmitting={createMutation.isPending}
+        autoFocusFirstField
       />
     </div>
   );

--- a/apps/web/src/pages/admin/users/UserDetailPage.tsx
+++ b/apps/web/src/pages/admin/users/UserDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { PageHeading } from '@/components/layout/PageHeading';
 import { toast } from 'sonner';
 
 import type { UpdateUserBody } from '@/api/users';
@@ -94,7 +95,9 @@ export default function UserDetailPage() {
     <div className="space-y-6 p-6">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-semibold">{t('page.detailTitle')}</h1>
+          <PageHeading autoFocus className="text-2xl font-semibold">
+            {t('page.detailTitle')}
+          </PageHeading>
           <p className="text-sm text-gray-600">{user.email}</p>
         </div>
         <div className="flex flex-wrap gap-2">
@@ -134,6 +137,7 @@ export default function UserDetailPage() {
         onSubmit={handleSubmit}
         onCancel={() => navigate('..', { relative: 'path' })}
         isSubmitting={updateMutation.isPending}
+        autoFocusFirstField
       />
     </div>
   );

--- a/apps/web/src/pages/admin/users/UsersListPage.tsx
+++ b/apps/web/src/pages/admin/users/UsersListPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { PageHeading } from '@/components/layout/PageHeading';
 import { toast } from 'sonner';
 
 import type { components } from '@/api/types';
@@ -151,7 +152,9 @@ export default function UsersListPage() {
     <div className="space-y-4 p-6">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-semibold">{t('page.title')}</h1>
+          <PageHeading autoFocus className="text-2xl font-semibold">
+            {t('page.title')}
+          </PageHeading>
           {hasCount ? (
             <p className="text-sm text-gray-600">
               {t('list.count', { count: totalElements ?? 0 })}

--- a/apps/web/src/pages/auth/AuthPageLayout.tsx
+++ b/apps/web/src/pages/auth/AuthPageLayout.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { PageHeading } from '@/components/layout/PageHeading';
 
 type AuthPageLayoutProps = {
   title: string;
@@ -18,7 +19,9 @@ export function AuthPageLayout({
       <div className="w-full max-w-md space-y-6">
         <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
           <div>
-            <h1 className="text-2xl font-semibold text-gray-900">{title}</h1>
+            <PageHeading autoFocus className="text-2xl font-semibold text-gray-900">
+              {title}
+            </PageHeading>
             {description ? (
               <p className="mt-2 text-sm text-gray-600">{description}</p>
             ) : null}

--- a/apps/web/src/pages/groups/GroupDetailPage.tsx
+++ b/apps/web/src/pages/groups/GroupDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useParams } from 'react-router-dom';
 import { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { PageHeading } from '@/components/layout/PageHeading';
 import GroupForm from '../../features/groups/GroupForm';
 import {
   useGroup,
@@ -45,7 +46,9 @@ export default function GroupDetailPage() {
   return (
     <div className="p-4 flex flex-col md:flex-row gap-6">
       <div className="md:w-1/2">
-        <h1 className="text-xl font-semibold mb-4">{t('detail.infoTitle')}</h1>
+        <PageHeading autoFocus className="text-xl font-semibold mb-4">
+          {t('detail.infoTitle')}
+        </PageHeading>
         {groupQuery.isLoading && <div>{tCommon('status.loading')}</div>}
         {groupQuery.isError && <div>{tCommon('status.loadFailed')}</div>}
         {groupQuery.data && (

--- a/apps/web/src/pages/groups/GroupsPage.tsx
+++ b/apps/web/src/pages/groups/GroupsPage.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useId, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { PageHeading } from '@/components/layout/PageHeading';
+import type { GroupFormValues } from '../../features/groups/GroupForm';
 import {
   useGroupsList,
   useCreateGroup,
   useUpdateGroup,
   useDeleteGroup,
 } from '../../features/groups/hooks';
-import GroupForm, { GroupFormValues } from '../../features/groups/GroupForm';
+import GroupForm from '../../features/groups/GroupForm';
 import Modal from '../../components/Modal';
 
 export default function GroupsPage() {
@@ -72,7 +74,9 @@ export default function GroupsPage() {
 
   return (
     <div className="p-4">
-      <h1 className="text-xl font-semibold mb-4">{t('page.title')}</h1>
+      <PageHeading autoFocus className="text-xl font-semibold mb-4">
+        {t('page.title')}
+      </PageHeading>
       <div className="flex items-center gap-2 mb-4">
         <input
           value={search}
@@ -186,7 +190,11 @@ export default function GroupsPage() {
         <h2 id={createTitleId} className="text-lg font-semibold mb-2">
           {t('modals.createTitle')}
         </h2>
-        <GroupForm onSubmit={handleCreate} onCancel={() => setCreating(false)} />
+        <GroupForm
+          onSubmit={handleCreate}
+          onCancel={() => setCreating(false)}
+          autoFocusFirstField
+        />
       </Modal>
     </div>
   );

--- a/apps/web/src/pages/me/ProfilePage.tsx
+++ b/apps/web/src/pages/me/ProfilePage.tsx
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { isAxiosError } from 'axios';
 import { useTranslation } from 'react-i18next';
+import { PageHeading } from '@/components/layout/PageHeading';
 import { Link, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
 
@@ -115,7 +116,9 @@ export default function ProfilePage() {
     <div className="space-y-8 p-6">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-semibold">{t('profile.title')}</h1>
+          <PageHeading autoFocus className="text-2xl font-semibold">
+            {t('profile.title')}
+          </PageHeading>
           <p className="text-sm text-gray-600">{t('profile.subtitle')}</p>
         </div>
         <Link

--- a/apps/web/src/pages/me/SecurityPage.tsx
+++ b/apps/web/src/pages/me/SecurityPage.tsx
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { isAxiosError } from 'axios';
 import { useTranslation } from 'react-i18next';
+import { PageHeading } from '@/components/layout/PageHeading';
 import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
 
@@ -193,7 +194,9 @@ export default function SecurityPage() {
   return (
     <div className="space-y-8 p-6">
       <div>
-        <h1 className="text-2xl font-semibold">{t('security.title')}</h1>
+        <PageHeading autoFocus className="text-2xl font-semibold">
+          {t('security.title')}
+        </PageHeading>
         <p className="text-sm text-gray-600">{t('security.subtitle')}</p>
       </div>
 

--- a/apps/web/src/pages/members/MembersPage.tsx
+++ b/apps/web/src/pages/members/MembersPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { PageHeading } from '@/components/layout/PageHeading';
 import type { components } from '../../api/types';
 import {
   useMembersList,
@@ -75,7 +76,9 @@ export default function MembersPage() {
     <div className="p-4">
       <div className="mb-4">
         <div className="flex items-baseline justify-between gap-2">
-          <h1 className="text-xl font-semibold">{t('page.title')}</h1>
+          <PageHeading autoFocus className="text-xl font-semibold">
+            {t('page.title')}
+          </PageHeading>
           {shouldShowCount ? (
             <span className="text-sm text-gray-600">
               {t('count', { count: memberCount })}
@@ -177,7 +180,11 @@ export default function MembersPage() {
         <h2 id={createTitleId} className="text-lg font-semibold mb-2">
           {t('modals.createTitle')}
         </h2>
-        <MemberForm onSubmit={handleCreate} onCancel={() => setCreating(false)} />
+        <MemberForm
+          onSubmit={handleCreate}
+          onCancel={() => setCreating(false)}
+          autoFocusFirstField
+        />
       </Modal>
       <Modal
         open={!!editing}
@@ -200,6 +207,7 @@ export default function MembersPage() {
             }}
             onSubmit={(vals) => handleUpdate(editing.id!, vals)}
             onCancel={() => setEditing(null)}
+            autoFocusFirstField
           />
         )}
       </Modal>

--- a/apps/web/src/pages/services/ServiceDetailPage.tsx
+++ b/apps/web/src/pages/services/ServiceDetailPage.tsx
@@ -4,6 +4,7 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useTranslation } from 'react-i18next';
+import { PageHeading } from '@/components/layout/PageHeading';
 import { toast } from 'sonner';
 import { useQuery } from '@tanstack/react-query';
 import type { components } from '../../api/types';
@@ -151,11 +152,11 @@ export default function ServiceDetailPage() {
     <div className="p-4 space-y-4">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-xl font-semibold">
+          <PageHeading autoFocus className="text-xl font-semibold">
             {service.startsAt
               ? formatDate(service.startsAt, i18n.language)
               : t('fallback.title')}
-          </h1>
+          </PageHeading>
           {service.location && <div>{service.location}</div>}
         </div>
         <div className="flex gap-2">
@@ -375,6 +376,7 @@ export default function ServiceDetailPage() {
           }}
           onSubmit={handleServiceUpdate}
           onCancel={() => setEditingService(false)}
+          autoFocusFirstField
         />
       </Modal>
     </div>

--- a/apps/web/src/pages/services/ServicePlanViewPage.tsx
+++ b/apps/web/src/pages/services/ServicePlanViewPage.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { PageHeading } from '@/components/layout/PageHeading';
 import { usePlanItems, useService } from '@/features/services/hooks';
 import { usePlanArrangementInfo } from '@/features/services/usePlanArrangementInfo';
 import { formatArrangementLine, formatKeyTransform } from '@/lib/arrangement-labels';
@@ -43,7 +44,9 @@ export default function ServicePlanViewPage() {
     return (
       <div className="plan-view px-4 py-10">
         <div className="mx-auto max-w-3xl rounded border border-dashed border-red-200 bg-red-50 p-6 text-center text-red-700">
-          <h1 className="text-lg font-semibold">{t('planView.shareRequiredTitle')}</h1>
+          <PageHeading autoFocus className="text-lg font-semibold">
+            {t('planView.shareRequiredTitle')}
+          </PageHeading>
           <p className="mt-2 text-sm">{t('planView.shareRequiredDescription')}</p>
         </div>
       </div>
@@ -64,7 +67,9 @@ export default function ServicePlanViewPage() {
     return (
       <div className="plan-view px-4 py-10">
         <div className="mx-auto max-w-3xl rounded border border-red-100 bg-red-50 p-6 text-center text-red-700">
-          <h1 className="text-lg font-semibold">{t('planView.unavailableTitle')}</h1>
+          <PageHeading autoFocus className="text-lg font-semibold">
+            {t('planView.unavailableTitle')}
+          </PageHeading>
           <p className="mt-2 text-sm">{t('planView.unavailableDescription')}</p>
         </div>
       </div>
@@ -79,11 +84,14 @@ export default function ServicePlanViewPage() {
         <header className="flex flex-col gap-4 border-b border-gray-200 pb-4 print:border-0 print:pb-0">
           <div>
             <p className="text-sm uppercase tracking-wide text-muted-foreground">{t('planView.title')}</p>
-            <h1 className="mt-1 text-2xl font-semibold text-gray-900">
+            <PageHeading
+              autoFocus
+              className="mt-1 text-2xl font-semibold text-gray-900"
+            >
               {service.startsAt
                 ? new Date(service.startsAt).toLocaleString()
                 : t('fallback.title')}
-            </h1>
+            </PageHeading>
             {service.location ? (
               <p className="mt-1 text-base text-gray-600">{service.location}</p>
             ) : null}

--- a/apps/web/src/pages/services/ServicePrintPage.tsx
+++ b/apps/web/src/pages/services/ServicePrintPage.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { PageHeading } from '@/components/layout/PageHeading';
 import { useService, usePlanItems } from '../../features/services/hooks';
 import { usePlanArrangementInfo } from '@/features/services/usePlanArrangementInfo';
 import { formatArrangementLine, formatKeyTransform } from '@/lib/arrangement-labels';
@@ -50,7 +51,9 @@ export default function ServicePrintPage() {
             <p className="text-sm uppercase tracking-wide text-muted-foreground">
               {t('print.title')}
             </p>
-            <h1 className="text-xl font-semibold">{headerTitle}</h1>
+            <PageHeading autoFocus className="text-xl font-semibold">
+              {headerTitle}
+            </PageHeading>
           </div>
           <button
             onClick={handlePrint}

--- a/apps/web/src/pages/services/ServicesPage.tsx
+++ b/apps/web/src/pages/services/ServicesPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { PageHeading } from '@/components/layout/PageHeading';
 import {
   useServicesList,
   useCreateService,
@@ -90,7 +91,9 @@ export default function ServicesPage() {
 
   return (
     <div className="p-4">
-      <h1 className="text-xl font-semibold mb-4">{t('page.title')}</h1>
+      <PageHeading autoFocus className="text-xl font-semibold mb-4">
+        {t('page.title')}
+      </PageHeading>
       <div className="flex flex-wrap items-end gap-2 mb-4">
         <input
           value={search}
@@ -219,6 +222,7 @@ export default function ServicesPage() {
             <ServiceForm
               onSubmit={handleCreate}
               onCancel={() => setCreating(false)}
+              autoFocusFirstField
             />
           </Modal>
 
@@ -241,6 +245,7 @@ export default function ServicesPage() {
                 }}
                 onSubmit={(vals) => handleUpdate(editing.id!, vals)}
                 onCancel={() => setEditing(null)}
+                autoFocusFirstField
               />
             )}
           </Modal>

--- a/apps/web/src/pages/sets/SongSetDetailPage.tsx
+++ b/apps/web/src/pages/sets/SongSetDetailPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useId, useMemo, useState } from 'react';
 import type { CSSProperties, FormEvent } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { PageHeading } from '@/components/layout/PageHeading';
 import {
   DndContext,
   PointerSensor,
@@ -372,7 +373,9 @@ export default function SongSetDetailPage() {
     <div className="p-4 space-y-4">
       <div className="flex items-center justify-between gap-4">
         <div>
-          <h1 className="text-xl font-semibold">{songSet.name ?? t('fallback.title')}</h1>
+          <PageHeading autoFocus className="text-xl font-semibold">
+            {songSet.name ?? t('fallback.title')}
+          </PageHeading>
         </div>
         <div className="flex gap-2">
           <button
@@ -512,6 +515,7 @@ export default function SongSetDetailPage() {
           defaultValues={{ name: songSet.name ?? '' }}
           onSubmit={handleSetUpdate}
           onCancel={() => setEditingSet(false)}
+          autoFocusFirstField
         />
       </Modal>
     </div>

--- a/apps/web/src/pages/sets/SongSetsPage.tsx
+++ b/apps/web/src/pages/sets/SongSetsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { PageHeading } from '@/components/layout/PageHeading';
 import {
   useSongSetsList,
   useCreateSet,
@@ -102,7 +103,9 @@ export default function SongSetsPage() {
 
   return (
     <div className="p-4">
-      <h1 className="text-xl font-semibold mb-4">{t('page.title')}</h1>
+      <PageHeading autoFocus className="text-xl font-semibold mb-4">
+        {t('page.title')}
+      </PageHeading>
       <div className="flex items-center gap-2 mb-4">
         <input
           value={search}
@@ -214,7 +217,11 @@ export default function SongSetsPage() {
         <h2 id={createTitleId} className="text-lg font-semibold mb-2">
           {t('modals.createTitle')}
         </h2>
-        <SetForm onSubmit={handleCreate} onCancel={() => setCreating(false)} />
+        <SetForm
+          onSubmit={handleCreate}
+          onCancel={() => setCreating(false)}
+          autoFocusFirstField
+        />
       </Modal>
 
       <Modal
@@ -231,6 +238,7 @@ export default function SongSetsPage() {
             defaultValues={{ name: editing.name }}
             onSubmit={(values) => handleUpdate(editing.id, values)}
             onCancel={() => setEditing(null)}
+            autoFocusFirstField
           />
         )}
       </Modal>

--- a/apps/web/src/pages/songs/SongDetailPage.tsx
+++ b/apps/web/src/pages/songs/SongDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useId, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { PageHeading } from '@/components/layout/PageHeading';
 import type { components } from '../../api/types';
 import {
   useSong,
@@ -76,7 +77,9 @@ export default function SongDetailPage() {
   return (
     <div className="p-4">
       <div className="flex items-center justify-between mb-4">
-        <h1 className="text-xl font-semibold">{song.title}</h1>
+        <PageHeading autoFocus className="text-xl font-semibold">
+          {song.title}
+        </PageHeading>
         {canManageSongs && (
           <button
             className="px-2 py-1 text-sm bg-gray-200 rounded"
@@ -188,6 +191,7 @@ export default function SongDetailPage() {
               }}
               onSubmit={handleSongUpdate}
               onCancel={() => setEditingSong(false)}
+              autoFocusFirstField
             />
           </Modal>
           <Modal
@@ -203,6 +207,7 @@ export default function SongDetailPage() {
             <ArrangementForm
               onSubmit={handleCreateArr}
               onCancel={() => setCreatingArr(false)}
+              autoFocusFirstField
             />
           </Modal>
           <Modal
@@ -225,6 +230,7 @@ export default function SongDetailPage() {
                 }}
                 onSubmit={(vals) => handleUpdateArr(editingArr.id!, vals)}
                 onCancel={() => setEditingArr(null)}
+                autoFocusFirstField
               />
             )}
           </Modal>

--- a/apps/web/src/pages/songs/SongsPage.tsx
+++ b/apps/web/src/pages/songs/SongsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { PageHeading } from '@/components/layout/PageHeading';
 import type { components } from '../../api/types';
 import {
   useSongsList,
@@ -85,7 +86,9 @@ export default function SongsPage() {
 
   return (
     <div className="p-4">
-      <h1 className="text-xl font-semibold mb-4">{t('page.title')}</h1>
+      <PageHeading autoFocus className="text-xl font-semibold mb-4">
+        {t('page.title')}
+      </PageHeading>
       <div className="flex items-center gap-2 mb-4">
         <input
           value={search}
@@ -223,6 +226,7 @@ export default function SongsPage() {
             <SongForm
               onSubmit={handleCreate}
               onCancel={() => setCreating(false)}
+              autoFocusFirstField
             />
           </Modal>
           <Modal
@@ -245,6 +249,7 @@ export default function SongsPage() {
                 }}
                 onSubmit={(vals) => handleUpdate(editing.id!, vals)}
                 onCancel={() => setEditing(null)}
+                autoFocusFirstField
               />
             )}
           </Modal>


### PR DESCRIPTION
## Summary
- add a PageHeading component that can optionally auto-focus headings for smoother route changes
- update page modules to adopt PageHeading and expose autoFocusFirstField on modal forms so meaningful controls receive focus
- teach Modal to honor elements marked with data-autofocus and cover the flow with tests

## Testing
- yarn test Modal.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dd71245b38833082bf39208303c29a