### PR TITLE
feat(web): add async status live announcer

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,7 +5,7 @@ import {
   Routes,
   useLocation,
 } from 'react-router-dom';
-import { lazy } from 'react';
+import { lazy, useEffect } from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { LanguageGuard } from '@/components/LanguageGuard';
 import { queryClient } from '@/lib/queryClient';
@@ -13,6 +13,8 @@ import { Toaster } from 'sonner';
 import { ProtectedRoute } from '@/features/auth/components/ProtectedRoute';
 import { RequireRole } from '@/features/auth/components/RequireRole';
 import { DEFAULT_LANGUAGE } from '@/i18n';
+import { LiveAnnouncer } from '@/components/a11y/LiveAnnouncer';
+import { setupAsyncStatusAnnouncements } from '@/lib/asyncStatusAnnouncements';
 
 const Members = lazy(() => import('@/routes/Members'));
 const Groups = lazy(() => import('@/routes/Groups'));
@@ -46,6 +48,12 @@ function ResetPasswordDeepLinkRedirect() {
 }
 
 export default function App() {
+  useEffect(() => {
+    const teardown = setupAsyncStatusAnnouncements(queryClient);
+
+    return teardown;
+  }, []);
+
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
@@ -97,6 +105,7 @@ export default function App() {
         </Routes>
       </BrowserRouter>
       <Toaster />
+      <LiveAnnouncer />
     </QueryClientProvider>
   );
 }

--- a/apps/web/src/components/a11y/LiveAnnouncer.tsx
+++ b/apps/web/src/components/a11y/LiveAnnouncer.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+
+import {
+  subscribeToAnnouncements,
+  type Announcement,
+} from '@/lib/announcer';
+
+const defaultMessages = {
+  polite: '',
+  assertive: '',
+};
+
+type LiveMessages = typeof defaultMessages;
+
+export function LiveAnnouncer() {
+  const [messages, setMessages] = useState<LiveMessages>(() => ({ ...defaultMessages }));
+
+  useEffect(() => {
+    const unsubscribe = subscribeToAnnouncements((announcement: Announcement) => {
+      setMessages((previous) =>
+        announcement.politeness === 'assertive'
+          ? { ...previous, assertive: announcement.message }
+          : { ...previous, polite: announcement.message },
+      );
+    });
+
+    return unsubscribe;
+  }, []);
+
+  return (
+    <>
+      <div className="sr-only" aria-live="polite" aria-atomic="true" role="status">
+        {messages.polite}
+      </div>
+      <div className="sr-only" aria-live="assertive" aria-atomic="true" role="alert">
+        {messages.assertive}
+      </div>
+    </>
+  );
+}
+
+export default LiveAnnouncer;

--- a/apps/web/src/lib/announcer.ts
+++ b/apps/web/src/lib/announcer.ts
@@ -1,0 +1,47 @@
+export type PolitenessSetting = 'polite' | 'assertive';
+
+export type Announcement = {
+  id: number;
+  message: string;
+  politeness: PolitenessSetting;
+};
+
+type AnnouncementListener = (announcement: Announcement) => void;
+
+const listeners = new Set<AnnouncementListener>();
+const lastMessages = new Map<PolitenessSetting, string>();
+let counter = 0;
+
+export function subscribeToAnnouncements(listener: AnnouncementListener) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function announce(
+  rawMessage: string,
+  politeness: PolitenessSetting = 'polite',
+) {
+  const message = rawMessage.trim();
+
+  if (!message) {
+    return;
+  }
+
+  const lastMessage = lastMessages.get(politeness);
+
+  if (lastMessage === message) {
+    return;
+  }
+
+  lastMessages.set(politeness, message);
+
+  const announcement: Announcement = {
+    id: ++counter,
+    message,
+    politeness,
+  };
+
+  listeners.forEach((listener) => listener(announcement));
+}

--- a/apps/web/src/lib/asyncStatusAnnouncements.ts
+++ b/apps/web/src/lib/asyncStatusAnnouncements.ts
@@ -1,0 +1,116 @@
+import type { QueryClient } from '@tanstack/react-query';
+
+import i18n from '@/i18n';
+import { announce } from './announcer';
+
+const fallbackMessages = {
+  loading: 'Loading data…',
+  loaded: 'Finished loading.',
+  error: 'Failed to load data.',
+  submitting: 'Submitting form…',
+  submitted: 'Form submitted.',
+  submitError: 'Form submission failed.',
+} as const;
+
+type FallbackKey = keyof typeof fallbackMessages;
+
+type QueryStatus = 'pending' | 'error' | 'success';
+type FetchStatus = 'idle' | 'fetching' | 'paused';
+type MutationStatus = 'idle' | 'pending' | 'success' | 'error';
+
+type QuerySnapshot = {
+  status: QueryStatus;
+  fetchStatus: FetchStatus;
+};
+
+type MutationSnapshot = {
+  status: MutationStatus;
+};
+
+type QueryLike = {
+  state: QuerySnapshot;
+};
+
+type MutationLike = {
+  state: MutationSnapshot;
+};
+
+type QueryCacheEvent = {
+  type: string;
+  query?: QueryLike;
+};
+
+type MutationCacheEvent = {
+  type: string;
+  mutation?: MutationLike;
+};
+
+const querySnapshots = new WeakMap<QueryLike, QuerySnapshot>();
+const mutationSnapshots = new WeakMap<MutationLike, MutationSnapshot>();
+
+function getMessage(key: FallbackKey) {
+  return i18n.t(`common:announcements.${key}`, {
+    defaultValue: fallbackMessages[key],
+  });
+}
+
+function handleQueryUpdate(query: QueryLike) {
+  const state = query.state;
+  const previous = querySnapshots.get(query);
+
+  if (state.fetchStatus === 'fetching' && previous?.fetchStatus !== 'fetching') {
+    announce(getMessage('loading'));
+  }
+
+  if (previous?.fetchStatus === 'fetching' && state.fetchStatus !== 'fetching') {
+    const message = state.status === 'error' ? 'error' : 'loaded';
+    announce(getMessage(message));
+  }
+
+  querySnapshots.set(query, {
+    status: state.status,
+    fetchStatus: state.fetchStatus,
+  });
+}
+
+function handleMutationUpdate(mutation: MutationLike) {
+  const state = mutation.state;
+  const previous = mutationSnapshots.get(mutation);
+
+  if (state.status === 'pending' && previous?.status !== 'pending') {
+    announce(getMessage('submitting'));
+  }
+
+  if (previous?.status === 'pending') {
+    if (state.status === 'success') {
+      announce(getMessage('submitted'));
+    } else if (state.status === 'error') {
+      announce(getMessage('submitError'));
+    }
+  }
+
+  mutationSnapshots.set(mutation, { status: state.status });
+}
+
+export function setupAsyncStatusAnnouncements(queryClient: QueryClient) {
+  const unsubscribeQuery = queryClient.getQueryCache().subscribe(
+    (event: QueryCacheEvent) => {
+      if (event.type === 'updated' && event.query) {
+        handleQueryUpdate(event.query);
+      }
+    },
+  );
+
+  const unsubscribeMutation = queryClient.getMutationCache().subscribe(
+    (event: MutationCacheEvent) => {
+      if (event.type === 'updated' && event.mutation) {
+        handleMutationUpdate(event.mutation);
+      }
+    },
+  );
+
+  return () => {
+    unsubscribeQuery();
+    unsubscribeMutation();
+  };
+}

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -38,6 +38,14 @@
     "loading": "Loading…",
     "loadFailed": "Failed to load"
   },
+  "announcements": {
+    "loading": "Loading data…",
+    "loaded": "Finished loading.",
+    "error": "Failed to load data.",
+    "submitting": "Submitting form…",
+    "submitted": "Form submitted.",
+    "submitError": "Form submission failed."
+  },
   "pagination": {
     "previous": "Previous",
     "next": "Next",

--- a/apps/web/src/locales/es/common.json
+++ b/apps/web/src/locales/es/common.json
@@ -38,6 +38,14 @@
     "loading": "Cargando…",
     "loadFailed": "No se pudo cargar"
   },
+  "announcements": {
+    "loading": "Cargando datos…",
+    "loaded": "Carga completada.",
+    "error": "Error al cargar datos.",
+    "submitting": "Enviando formulario…",
+    "submitted": "Formulario enviado.",
+    "submitError": "Error al enviar el formulario."
+  },
   "pagination": {
     "previous": "Anterior",
     "next": "Siguiente",


### PR DESCRIPTION
## Summary
- Added a global live announcer component and helper to broadcast short polite updates.
- Hooked TanStack Query query/mutation lifecycle into the announcer for loading, success, and error messaging.
- Localized the announcement strings in English and Spanish for consistency.

## Testing
- yarn build
- yarn typecheck

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [x] Web: Loading/error states; basic a11y; responsive layout
- [x] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68dd78a594a08330b2e28bb39f924b06