### PR TITLE
feat(web): add skip link and footer landmark

### DIFF
--- a/apps/web/src/components/__tests__/AppShell.test.tsx
+++ b/apps/web/src/components/__tests__/AppShell.test.tsx
@@ -173,6 +173,23 @@ describe('AppShell', () => {
     expect(activeLink).toHaveAttribute('aria-current', 'page');
   });
 
+  it('allows skipping directly to the main content', async () => {
+    await renderAppShell('en');
+
+    const user = userEvent.setup();
+
+    await user.tab();
+    const skipLink = screen.getByRole('link', { name: 'Skip to main content' });
+    expect(skipLink).toHaveFocus();
+    expect(skipLink).toHaveAttribute('href', '#main-content');
+
+    await user.keyboard('{Enter}');
+
+    const main = screen.getByRole('main');
+    expect(main).toHaveAttribute('id', 'main-content');
+    expect(main).toHaveFocus();
+  });
+
   it('opens the account menu from the header when authenticated', async () => {
     setIsAuthenticated(true);
     mockUseAuth.mockClear();

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -1,5 +1,14 @@
-import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  type MouseEvent,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useLocation } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
 import { AppHeader } from '@/components/layout/AppHeader';
 import { AppSideNav } from '@/components/layout/AppSideNav';
@@ -18,6 +27,8 @@ export function AppShell({ currentLanguage, children }: AppShellProps) {
   const { hasRole } = useAuth();
   const location = useLocation();
   const [isNavigationOpen, setNavigationOpen] = useState(false);
+  const { t } = useTranslation('common');
+  const mainRef = useRef<HTMLElement | null>(null);
 
   const navigationLinks: AppNavigationLink[] = useMemo(
     () => filterNavigationLinks(hasRole),
@@ -59,8 +70,25 @@ export function AppShell({ currentLanguage, children }: AppShellProps) {
     setNavigationOpen((value) => !value);
   };
 
+  const handleSkipToContent = useCallback(
+    (event: MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault();
+      mainRef.current?.focus();
+    },
+    [],
+  );
+
+  const currentYear = new Date().getFullYear();
+
   return (
     <div className="min-h-screen bg-background">
+      <a
+        href="#main-content"
+        onClick={handleSkipToContent}
+        className="absolute left-4 top-4 z-50 -translate-y-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition focus:translate-y-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      >
+        {t('layout.skipToMainContent')}
+      </a>
       <div className="flex min-h-screen">
         <AppSideNav
           currentLanguage={currentLanguage}
@@ -75,7 +103,17 @@ export function AppShell({ currentLanguage, children }: AppShellProps) {
             onToggleNavigation={handleToggleNavigation}
             isNavigationOpen={isNavigationOpen}
           />
-          <main className="flex-1">{children}</main>
+          <main
+            ref={mainRef}
+            id="main-content"
+            tabIndex={-1}
+            className="flex-1 focus:outline-none"
+          >
+            {children}
+          </main>
+          <footer className="border-t border-border/60 bg-card/40 px-6 py-4 text-xs text-muted-foreground">
+            <p>{t('layout.footer.copyright', { year: currentYear, app: t('app.title') })}</p>
+          </footer>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -85,7 +85,7 @@ export function AppShell({ currentLanguage, children }: AppShellProps) {
       <a
         href="#main-content"
         onClick={handleSkipToContent}
-        className="absolute left-4 top-4 z-50 -translate-y-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition focus:translate-y-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-primary-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
       >
         {t('layout.skipToMainContent')}
       </a>

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -87,5 +87,11 @@
       "title": "Please fix the highlighted fields",
       "description": "Select a link below to jump to the problem field."
     }
+  },
+  "layout": {
+    "skipToMainContent": "Skip to main content",
+    "footer": {
+      "copyright": "© {{year}} {{app}}"
+    }
   }
 }

--- a/apps/web/src/locales/es/common.json
+++ b/apps/web/src/locales/es/common.json
@@ -87,5 +87,11 @@
       "title": "Corrige los campos resaltados",
       "description": "Selecciona un enlace para ir al campo con el problema."
     }
+  },
+  "layout": {
+    "skipToMainContent": "Saltar al contenido principal",
+    "footer": {
+      "copyright": "© {{year}} {{app}}"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add a skip to main content link that focuses the primary region when activated
- ensure the shell layout exposes footer landmarks and localized copy for the skip link
- cover the new accessibility behavior with unit tests

## Testing
- yarn test AppShell

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68dd86b2d2308330bcbc297ffa45e9bf