### PR TITLE
feat(web): improve alt handling and hidden text

### DIFF
--- a/apps/web/src/components/LanguageSwitcher.tsx
+++ b/apps/web/src/components/LanguageSwitcher.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useId, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
+import { VisuallyHidden } from '@/components/a11y/VisuallyHidden';
+
 import {
   LANGUAGE_STORAGE_KEY,
   SUPPORTED_LANGUAGES,
@@ -212,12 +214,12 @@ export function LanguageSwitcher({
             <span aria-hidden="true" className="text-xl leading-none">
               {getLanguageFlag(currentLanguage)}
             </span>
-            <span className="sr-only">
+            <VisuallyHidden>
               {t('language.triggerFlagAlt', {
                 language: getLanguageLabel(currentLanguage),
                 defaultValue: getLanguageLabel(currentLanguage),
               })}
-            </span>
+            </VisuallyHidden>
           </>
         ) : (
           <>

--- a/apps/web/src/components/a11y/VisuallyHidden.tsx
+++ b/apps/web/src/components/a11y/VisuallyHidden.tsx
@@ -1,0 +1,15 @@
+import { forwardRef, type HTMLAttributes } from 'react';
+
+export type VisuallyHiddenProps = HTMLAttributes<HTMLSpanElement>;
+
+export const VisuallyHidden = forwardRef<HTMLSpanElement, VisuallyHiddenProps>(
+  ({ className, ...props }, ref) => {
+    const mergedClassName = ['sr-only', className].filter(Boolean).join(' ');
+
+    return <span ref={ref} className={mergedClassName} {...props} />;
+  },
+);
+
+VisuallyHidden.displayName = 'VisuallyHidden';
+
+export default VisuallyHidden;

--- a/apps/web/src/components/forms/FormErrorSummary.tsx
+++ b/apps/web/src/components/forms/FormErrorSummary.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 import type { FieldValues, FieldErrors } from 'react-hook-form';
 
+import { VisuallyHidden } from '@/components/a11y/VisuallyHidden';
+
 import { fieldNameToId, flattenErrors } from '@/lib/formAccessibility';
 
 type FormErrorSummaryProps<TFieldValues extends FieldValues> = {
@@ -70,7 +72,7 @@ export function FormErrorSummary<TFieldValues extends FieldValues>({
               >
                 {linkText}
                 {itemLabel ? (
-                  <span className="sr-only">{`: ${message}`}</span>
+                  <VisuallyHidden>{`: ${message}`}</VisuallyHidden>
                 ) : null}
               </a>
             </li>

--- a/apps/web/src/components/layout/AppBrandLink.tsx
+++ b/apps/web/src/components/layout/AppBrandLink.tsx
@@ -2,6 +2,8 @@ import type { ComponentProps } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
+import { VisuallyHidden } from '@/components/a11y/VisuallyHidden';
+
 type RouterLinkProps = ComponentProps<typeof Link>;
 
 type AppBrandLinkProps = {
@@ -48,7 +50,7 @@ export function AppBrandLink({
 
   return (
     <Link to={to} className={mergedClassName} aria-label={label} onClick={onClick}>
-      <span className="sr-only">{label}</span>
+      <VisuallyHidden>{label}</VisuallyHidden>
       <img src={logoSrc} alt="" aria-hidden="true" className={mergedImageClassName} />
       {showText ? (
         <span aria-hidden="true" className={mergedTextClassName}>

--- a/apps/web/src/components/layout/AppHeader.tsx
+++ b/apps/web/src/components/layout/AppHeader.tsx
@@ -11,6 +11,7 @@ import {
   type ListNavigationItem,
 } from '@/hooks/useListNavigation';
 import { MOBILE_NAVIGATION_ID } from '@/components/layout/constants';
+import { VisuallyHidden } from '@/components/a11y/VisuallyHidden';
 import { AppBrandLink } from '@/components/layout/AppBrandLink';
 
 type AppHeaderProps = {
@@ -152,6 +153,7 @@ export function AppHeader({
                   viewBox="0 0 20 20"
                   fill="none"
                   xmlns="http://www.w3.org/2000/svg"
+                  aria-hidden="true"
                 >
                   {isNavigationOpen ? (
                     <path
@@ -191,13 +193,14 @@ export function AppHeader({
                 className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-border/60 bg-muted text-foreground transition hover:bg-muted/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                 onClick={accountMenu.toggle}
               >
-                <span className="sr-only">{accountLabelValue}</span>
+                <VisuallyHidden>{accountLabelValue}</VisuallyHidden>
                 <span aria-hidden="true" className="block h-5 w-5">
                   <svg
                     className="h-full w-full"
                     viewBox="0 0 24 24"
                     fill="none"
                     xmlns="http://www.w3.org/2000/svg"
+                    aria-hidden="true"
                   >
                     <path
                       d="M12 12c2.485 0 4.5-2.015 4.5-4.5S14.485 3 12 3 7.5 5.015 7.5 7.5 9.515 12 12 12Z"

--- a/apps/web/src/components/layout/AppSideNav.tsx
+++ b/apps/web/src/components/layout/AppSideNav.tsx
@@ -259,6 +259,7 @@ export function AppSideNav({
                       viewBox="0 0 20 20"
                       fill="none"
                       xmlns="http://www.w3.org/2000/svg"
+                      aria-hidden="true"
                     >
                       <path
                         d="M4 5.5L14.5 16M15.5 5.5L5 16"


### PR DESCRIPTION
## Summary
- add a reusable VisuallyHidden component for hiding text visually while keeping it available to assistive tech
- replace ad-hoc sr-only spans with VisuallyHidden and ensure decorative SVG icons are properly hidden from screen readers
- keep brand imagery decorative by pairing the hidden text label with empty alt text

## Testing
- yarn test

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68ddb9aefd688330891b7a2872847534