### PR TITLE
feat(web): respect reduced motion preference

### DIFF
--- a/apps/web/src/components/LanguageSwitcher.tsx
+++ b/apps/web/src/components/LanguageSwitcher.tsx
@@ -185,8 +185,8 @@ export function LanguageSwitcher({
 
   const triggerClassName =
     variant === 'compact'
-      ? 'inline-flex h-10 w-10 items-center justify-center rounded-md border border-border/60 bg-muted text-base text-foreground transition-colors hover:bg-muted/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
-      : 'inline-flex items-center gap-2 rounded-md border border-border/60 bg-muted px-3 py-1 text-sm font-medium text-foreground transition-colors hover:bg-muted/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background';
+      ? 'inline-flex h-10 w-10 items-center justify-center rounded-md border border-border/60 bg-muted text-base text-foreground transition-colors transition-base hover:bg-muted/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
+      : 'inline-flex items-center gap-2 rounded-md border border-border/60 bg-muted px-3 py-1 text-sm font-medium text-foreground transition-colors transition-base hover:bg-muted/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background';
 
   const getLanguageFlag = useCallback(
     (language: string) => LANGUAGE_FLAGS[language] ?? language.toUpperCase(),
@@ -264,7 +264,7 @@ export function LanguageSwitcher({
                   role="option"
                   {...optionProps}
                   aria-selected={isSelected}
-                  className={`flex w-full cursor-pointer items-center justify-between rounded px-2 py-2 text-left text-sm transition-colors ${
+                  className={`flex w-full cursor-pointer items-center justify-between rounded px-2 py-2 text-left text-sm transition-colors transition-base ${
                     isActive
                       ? 'bg-muted text-foreground'
                       : 'text-muted-foreground hover:bg-muted hover:text-foreground'

--- a/apps/web/src/components/Tabs.tsx
+++ b/apps/web/src/components/Tabs.tsx
@@ -39,7 +39,7 @@ type TabsProps = {
 };
 
 const defaultTabBaseClass =
-  'inline-flex items-center gap-2 rounded-t border border-b-0 border-gray-200 bg-gray-100 px-4 py-2 text-sm font-medium text-gray-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white';
+  'inline-flex items-center gap-2 rounded-t border border-b-0 border-gray-200 bg-gray-100 px-4 py-2 text-sm font-medium text-gray-600 transition-colors transition-base focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white';
 const defaultTabSelectedClass = 'bg-white text-gray-900';
 const defaultTabUnselectedClass = 'hover:text-gray-800';
 const defaultTabDisabledClass = 'cursor-not-allowed opacity-50';

--- a/apps/web/src/components/layout/AppBrandLink.tsx
+++ b/apps/web/src/components/layout/AppBrandLink.tsx
@@ -35,7 +35,7 @@ export function AppBrandLink({
   const brandText = t('app.brandInitials', { defaultValue: 'EBaL' });
 
   const baseClassName =
-    'inline-flex items-center gap-2 text-foreground transition-colors hover:text-muted-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background';
+    'inline-flex items-center gap-2 text-foreground transition-colors transition-base hover:text-muted-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background';
   const mergedClassName = mergeClassNames(baseClassName, className);
   const mergedImageClassName = mergeClassNames('h-9 w-auto', imageClassName);
   const mergedTextClassName = mergeClassNames(

--- a/apps/web/src/components/layout/AppHeader.tsx
+++ b/apps/web/src/components/layout/AppHeader.tsx
@@ -139,7 +139,7 @@ export function AppHeader({
           {hasNavigation ? (
             <button
               type="button"
-              className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-border/60 bg-muted text-foreground transition hover:bg-muted/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background lg:hidden"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-border/60 bg-muted text-foreground transition transition-base hover:bg-muted/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background lg:hidden"
               aria-controls={MOBILE_NAVIGATION_ID}
               aria-expanded={isNavigationOpen}
               aria-label={
@@ -190,7 +190,7 @@ export function AppHeader({
                   value: accountLabelValue,
                   defaultValue: accountLabelValue,
                 })}
-                className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-border/60 bg-muted text-foreground transition hover:bg-muted/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-border/60 bg-muted text-foreground transition transition-base hover:bg-muted/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                 onClick={accountMenu.toggle}
               >
                 <VisuallyHidden>{accountLabelValue}</VisuallyHidden>
@@ -260,7 +260,7 @@ export function AppHeader({
                           type="button"
                           role="menuitem"
                           {...optionProps}
-                          className={`block w-full px-4 py-2 text-left text-sm transition-colors ${toneClassName}`.trim()}
+                          className={`block w-full px-4 py-2 text-left text-sm transition-colors transition-base ${toneClassName}`.trim()}
                         >
                           {item.text}
                         </button>

--- a/apps/web/src/components/layout/AppSideNav.tsx
+++ b/apps/web/src/components/layout/AppSideNav.tsx
@@ -15,7 +15,7 @@ type AppSideNavProps = {
 
 const navLinkClassName = ({ isActive }: { isActive: boolean }) =>
   [
-    'flex w-full items-center rounded-md border border-transparent px-3 py-2 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+    'flex w-full items-center rounded-md border border-transparent px-3 py-2 text-sm font-medium transition-colors transition-base focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
     isActive
       ? 'bg-primary text-primary-foreground shadow-sm'
       : 'text-muted-foreground hover:bg-muted hover:text-foreground',
@@ -249,7 +249,7 @@ export function AppSideNav({
                 <button
                   ref={closeButtonRef}
                   type="button"
-                  className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border/60 bg-muted text-foreground transition hover:bg-muted/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                  className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border/60 bg-muted text-foreground transition transition-base hover:bg-muted/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                   aria-label={t('nav.closeMenu')}
                   onClick={onClose}
                 >

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -24,6 +24,13 @@
     --input: 214.3 31.8% 91.4%;
     --ring: 221.2 83.2% 53.3%;
     --radius: 0.75rem;
+    --motion-transition-duration: 150ms;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    :root {
+      --motion-transition-duration: 0ms;
+    }
   }
 
   * {
@@ -32,6 +39,12 @@
 
   body {
     @apply bg-background text-foreground;
+  }
+}
+
+@layer utilities {
+  .transition-base {
+    transition-duration: var(--motion-transition-duration, 150ms);
   }
 }
 


### PR DESCRIPTION
## Summary
- add a transition duration theme token that responds to the prefers-reduced-motion media query
- expose a reusable `transition-base` utility and apply it to shared navigation components to disable non-essential animation when reduced motion is requested

## Testing
- yarn build

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68ddbc7a64ac833093fbcd4acde65ee8