### PR TITLE
fix: improve list page accessibility quick wins

### DIFF
--- a/apps/web/src/locales/en/groups.json
+++ b/apps/web/src/locales/en/groups.json
@@ -6,6 +6,7 @@
     "new": "New Group"
   },
   "list": {
+    "searchLabel": "Search groups",
     "searchPlaceholder": "Search by name...",
     "empty": "No groups found",
     "deleteConfirm": "Are you sure you want to delete this group? This action cannot be undone."

--- a/apps/web/src/locales/en/members.json
+++ b/apps/web/src/locales/en/members.json
@@ -36,6 +36,7 @@
     "new": "New Member"
   },
   "list": {
+    "searchLabel": "Search members",
     "searchPlaceholder": "Search by name...",
     "empty": "No members found",
     "deleteConfirm": "Are you sure you want to delete this member? This action cannot be undone."

--- a/apps/web/src/locales/en/songSets.json
+++ b/apps/web/src/locales/en/songSets.json
@@ -18,6 +18,7 @@
     "nameLabel": "Name"
   },
   "list": {
+    "searchLabel": "Search song sets",
     "searchPlaceholder": "Search by name...",
     "empty": "No song sets found"
   },

--- a/apps/web/src/locales/en/songs.json
+++ b/apps/web/src/locales/en/songs.json
@@ -50,6 +50,7 @@
     "editTitle": "Edit Song"
   },
   "list": {
+    "searchLabel": "Search songs",
     "searchPlaceholder": "Search by title...",
     "empty": "No songs found",
     "deleteConfirm": "Are you sure you want to delete this song? This action cannot be undone."

--- a/apps/web/src/locales/es/groups.json
+++ b/apps/web/src/locales/es/groups.json
@@ -6,6 +6,7 @@
     "new": "Nuevo grupo"
   },
   "list": {
+    "searchLabel": "Buscar grupos",
     "searchPlaceholder": "Buscar por nombre...",
     "empty": "No se encontraron grupos",
     "deleteConfirm": "¿Estás seguro de que deseas eliminar este grupo? Esta acción no se puede deshacer."

--- a/apps/web/src/locales/es/members.json
+++ b/apps/web/src/locales/es/members.json
@@ -36,6 +36,7 @@
     "new": "Nuevo miembro"
   },
   "list": {
+    "searchLabel": "Buscar miembros",
     "searchPlaceholder": "Buscar por nombre...",
     "empty": "No se encontraron miembros",
     "deleteConfirm": "¿Estás seguro de que deseas eliminar este miembro? Esta acción no se puede deshacer."

--- a/apps/web/src/locales/es/songSets.json
+++ b/apps/web/src/locales/es/songSets.json
@@ -18,6 +18,7 @@
     "nameLabel": "Nombre"
   },
   "list": {
+    "searchLabel": "Buscar repertorios",
     "searchPlaceholder": "Buscar por nombre...",
     "empty": "No se encontraron conjuntos de canciones"
   },

--- a/apps/web/src/locales/es/songs.json
+++ b/apps/web/src/locales/es/songs.json
@@ -50,6 +50,7 @@
     "editTitle": "Editar canción"
   },
   "list": {
+    "searchLabel": "Buscar canciones",
     "searchPlaceholder": "Buscar por título...",
     "empty": "No se encontraron canciones",
     "deleteConfirm": "¿Estás seguro de que deseas eliminar esta canción? Esta acción no se puede deshacer."

--- a/apps/web/src/pages/groups/GroupsPage.tsx
+++ b/apps/web/src/pages/groups/GroupsPage.tsx
@@ -79,6 +79,13 @@ export default function GroupsPage() {
   ); // TODO: server-side search when API adds query parameter
 
   const createTitleId = useId();
+  const searchInputId = useId();
+  const searchLabel =
+    t('list.searchLabel', {
+      defaultValue: t('list.searchPlaceholder', {
+        defaultValue: tCommon('actions.search', { defaultValue: 'Search groups' }),
+      }),
+    }) || t('list.searchPlaceholder');
 
   return (
     <div className="p-4">
@@ -86,13 +93,18 @@ export default function GroupsPage() {
         {t('page.title')}
       </PageHeading>
       <div className="flex items-center gap-2 mb-4">
+        <label className="sr-only" htmlFor={searchInputId}>
+          {searchLabel}
+        </label>
         <input
+          id={searchInputId}
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder={t('list.searchPlaceholder')}
           className="border p-2 rounded w-full max-w-sm"
         />
         <button
+          type="button"
           onClick={() => setCreating(true)}
           className="px-4 py-2 bg-blue-500 text-white rounded"
         >
@@ -146,12 +158,14 @@ export default function GroupsPage() {
                         <div className="flex gap-2 justify-end">
                           <button
                             className="px-2 py-1 text-sm bg-gray-200 rounded"
+                            type="button"
                             onClick={() => setEditingId(g.id!)}
                           >
                             {tCommon('actions.edit')}
                           </button>
                           <button
                             className="px-2 py-1 text-sm bg-red-500 text-white rounded"
+                            type="button"
                             onClick={() => g.id && handleDelete(g.id)}
                           >
                             {tCommon('actions.delete')}
@@ -173,6 +187,7 @@ export default function GroupsPage() {
             <button
               className="px-3 py-1 border rounded disabled:opacity-50"
               disabled={pageParam === 0}
+              type="button"
               onClick={() => goToPage(Math.max(0, pageParam - 1))}
             >
               {tCommon('pagination.previous')}
@@ -190,6 +205,7 @@ export default function GroupsPage() {
                 data.totalPages !== undefined &&
                 data.number + 1 >= data.totalPages
               }
+              type="button"
               onClick={() => goToPage(pageParam + 1)}
             >
               {tCommon('pagination.next')}

--- a/apps/web/src/pages/members/MembersPage.tsx
+++ b/apps/web/src/pages/members/MembersPage.tsx
@@ -79,6 +79,13 @@ export default function MembersPage() {
 
   const createTitleId = useId();
   const editTitleId = useId();
+  const searchInputId = useId();
+  const searchLabel =
+    t('list.searchLabel', {
+      defaultValue: t('list.searchPlaceholder', {
+        defaultValue: tCommon('actions.search', { defaultValue: 'Search members' }),
+      }),
+    }) || t('list.searchPlaceholder');
 
   return (
     <div className="p-4">
@@ -95,13 +102,18 @@ export default function MembersPage() {
         </div>
       </div>
       <div className="flex items-center gap-2 mb-4">
+        <label className="sr-only" htmlFor={searchInputId}>
+          {searchLabel}
+        </label>
         <input
+          id={searchInputId}
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder={t('list.searchPlaceholder')}
           className="border p-2 rounded w-full max-w-sm"
         />
         <button
+          type="button"
           onClick={() => setCreating(true)}
           className="px-4 py-2 bg-blue-500 text-white rounded"
         >
@@ -140,12 +152,14 @@ export default function MembersPage() {
                         <div className="flex gap-2 justify-end">
                           <button
                             className="px-2 py-1 text-sm bg-gray-200 rounded"
+                            type="button"
                             onClick={() => setEditing(m)}
                           >
                             {tCommon('actions.edit')}
                           </button>
                           <button
                             className="px-2 py-1 text-sm bg-red-500 text-white rounded"
+                            type="button"
                             onClick={() => m.id && handleDelete(m.id)}
                           >
                             {tCommon('actions.delete')}
@@ -160,6 +174,7 @@ export default function MembersPage() {
                 <button
                   className="px-3 py-1 border rounded disabled:opacity-50"
                   disabled={pageParam === 0}
+                  type="button"
                   onClick={() => goToPage(Math.max(0, pageParam - 1))}
                 >
                   {tCommon('pagination.previous')}
@@ -177,6 +192,7 @@ export default function MembersPage() {
                     data.totalPages !== undefined &&
                     data.number + 1 >= data.totalPages
                   }
+                  type="button"
                   onClick={() => goToPage(pageParam + 1)}
                 >
                   {tCommon('pagination.next')}

--- a/apps/web/src/pages/services/ServicesPage.tsx
+++ b/apps/web/src/pages/services/ServicesPage.tsx
@@ -179,6 +179,7 @@ export default function ServicesPage() {
         />
         {canManageServices ? (
           <button
+            type="button"
             onClick={() => setCreating(true)}
             className="px-4 py-2 bg-blue-500 text-white rounded"
           >
@@ -234,12 +235,14 @@ export default function ServicesPage() {
                             <>
                               <button
                                 className="px-2 py-1 text-sm bg-gray-200 rounded"
+                                type="button"
                                 onClick={() => setEditing(s)}
                               >
                                 {tCommon('actions.edit')}
                               </button>
                               <button
                                 className="px-2 py-1 text-sm bg-red-500 text-white rounded"
+                                type="button"
                                 onClick={() => s.id && handleDelete(s.id)}
                               >
                                 {tCommon('actions.delete')}
@@ -256,6 +259,7 @@ export default function ServicesPage() {
                 <button
                   className="px-3 py-1 border rounded disabled:opacity-50"
                   disabled={pageParam === 0}
+                  type="button"
                   onClick={() => goToPage(Math.max(0, pageParam - 1))}
                 >
                   {tCommon('pagination.previous')}
@@ -273,6 +277,7 @@ export default function ServicesPage() {
                     data?.totalPages !== undefined &&
                     data.number + 1 >= data.totalPages
                   }
+                  type="button"
                   onClick={() => goToPage(pageParam + 1)}
                 >
                   {tCommon('pagination.next')}

--- a/apps/web/src/pages/sets/SongSetsPage.tsx
+++ b/apps/web/src/pages/sets/SongSetsPage.tsx
@@ -70,6 +70,13 @@ export default function SongSetsPage() {
   const [editing, setEditing] = useState<{ id: string; name: string } | null>(null);
   const createTitleId = useId();
   const editTitleId = useId();
+  const searchInputId = useId();
+  const searchLabel =
+    t('list.searchLabel', {
+      defaultValue: t('list.searchPlaceholder', {
+        defaultValue: tCommon('actions.search', { defaultValue: 'Search song sets' }),
+      }),
+    }) || t('list.searchPlaceholder');
 
   const handleCreate = (values: SetFormValues) => {
     createMut.mutate(values, {
@@ -117,13 +124,18 @@ export default function SongSetsPage() {
         {t('page.title')}
       </PageHeading>
       <div className="flex items-center gap-2 mb-4">
+        <label className="sr-only" htmlFor={searchInputId}>
+          {searchLabel}
+        </label>
         <input
+          id={searchInputId}
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder={t('list.searchPlaceholder')}
           className="border p-2 rounded w-full max-w-sm"
         />
         <button
+          type="button"
           onClick={() => setCreating(true)}
           className="px-4 py-2 bg-blue-500 text-white rounded"
         >
@@ -172,24 +184,26 @@ export default function SongSetsPage() {
                         <td className="p-2 align-top">{itemsCount ?? '—'}</td>
                         <td className="p-2 text-right align-top">
                           <div className="flex gap-2 justify-end">
-                            <Link
-                              to={setId}
-                              className="px-2 py-1 text-sm bg-gray-100 rounded hover:bg-gray-200"
-                            >
-                              {tCommon('actions.open')}
-                            </Link>
-                            <button
-                              className="px-2 py-1 text-sm bg-gray-200 rounded"
-                              onClick={() => setEditing({ id: setId, name: set.name ?? '' })}
-                            >
-                              {tCommon('actions.edit')}
-                            </button>
-                            <button
-                              className="px-2 py-1 text-sm bg-red-500 text-white rounded"
-                              onClick={() => handleDelete(setId)}
-                            >
-                              {tCommon('actions.delete')}
-                            </button>
+                          <Link
+                            to={setId}
+                            className="px-2 py-1 text-sm bg-gray-100 rounded hover:bg-gray-200"
+                          >
+                            {tCommon('actions.open')}
+                          </Link>
+                          <button
+                            className="px-2 py-1 text-sm bg-gray-200 rounded"
+                            type="button"
+                            onClick={() => setEditing({ id: setId, name: set.name ?? '' })}
+                          >
+                            {tCommon('actions.edit')}
+                          </button>
+                          <button
+                            className="px-2 py-1 text-sm bg-red-500 text-white rounded"
+                            type="button"
+                            onClick={() => handleDelete(setId)}
+                          >
+                            {tCommon('actions.delete')}
+                          </button>
                           </div>
                         </td>
                       </tr>
@@ -201,6 +215,7 @@ export default function SongSetsPage() {
                 <button
                   className="px-3 py-1 border rounded disabled:opacity-50"
                   disabled={pageParam === 0}
+                  type="button"
                   onClick={() => goToPage(pageParam - 1)}
                 >
                   {tCommon('pagination.previous')}
@@ -218,6 +233,7 @@ export default function SongSetsPage() {
                     data.totalPages !== undefined &&
                     data.number + 1 >= data.totalPages
                   }
+                  type="button"
                   onClick={() => goToPage(pageParam + 1)}
                 >
                   {tCommon('pagination.next')}

--- a/apps/web/src/pages/songs/SongsPage.tsx
+++ b/apps/web/src/pages/songs/SongsPage.tsx
@@ -61,6 +61,13 @@ export default function SongsPage() {
   const [editing, setEditing] = useState<Song | null>(null);
   const createTitleId = useId();
   const editTitleId = useId();
+  const searchInputId = useId();
+  const searchLabel =
+    t('list.searchLabel', {
+      defaultValue: t('list.searchPlaceholder', {
+        defaultValue: tCommon('actions.search', { defaultValue: 'Search' }),
+      }),
+    }) || t('list.searchPlaceholder');
 
   const canManageSongs = hasRole('ADMIN') || hasRole('PLANNER');
 
@@ -98,7 +105,11 @@ export default function SongsPage() {
         {t('page.title')}
       </PageHeading>
       <div className="flex items-center gap-2 mb-4">
+        <label className="sr-only" htmlFor={searchInputId}>
+          {searchLabel}
+        </label>
         <input
+          id={searchInputId}
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder={t('list.searchPlaceholder')}
@@ -106,6 +117,7 @@ export default function SongsPage() {
         />
         {canManageSongs && (
           <button
+            type="button"
             onClick={() => setCreating(true)}
             className="px-4 py-2 bg-blue-500 text-white rounded"
           >
@@ -118,6 +130,7 @@ export default function SongsPage() {
           {tags.map((t) => (
             <button
               key={t}
+              type="button"
               onClick={() => {
                 const params = new URLSearchParams(searchParams);
                 if (tagParam === t) params.delete('tag');
@@ -176,17 +189,19 @@ export default function SongsPage() {
                       {canManageSongs && (
                         <td className="p-2 text-right">
                           <div className="flex gap-2 justify-end">
-                            <button
-                              className="px-2 py-1 text-sm bg-gray-200 rounded"
-                              onClick={() => setEditing(s)}
-                            >
-                              {tCommon('actions.edit')}
-                            </button>
-                            <button
-                              className="px-2 py-1 text-sm bg-red-500 text-white rounded"
-                              onClick={() => s.id && handleDelete(s.id)}
-                            >
-                              {tCommon('actions.delete')}
+                          <button
+                            className="px-2 py-1 text-sm bg-gray-200 rounded"
+                            type="button"
+                            onClick={() => setEditing(s)}
+                          >
+                            {tCommon('actions.edit')}
+                          </button>
+                          <button
+                            className="px-2 py-1 text-sm bg-red-500 text-white rounded"
+                            type="button"
+                            onClick={() => s.id && handleDelete(s.id)}
+                          >
+                            {tCommon('actions.delete')}
                             </button>
                           </div>
                         </td>
@@ -199,6 +214,7 @@ export default function SongsPage() {
                 <button
                   className="px-3 py-1 border rounded disabled:opacity-50"
                   disabled={pageParam === 0}
+                  type="button"
                   onClick={() => goToPage(Math.max(0, pageParam - 1))}
                 >
                   {tCommon('pagination.previous')}
@@ -216,6 +232,7 @@ export default function SongsPage() {
                     data.totalPages !== undefined &&
                     data.number + 1 >= data.totalPages
                   }
+                  type="button"
                   onClick={() => goToPage(pageParam + 1)}
                 >
                   {tCommon('pagination.next')}


### PR DESCRIPTION
## Summary
- add missing search field labels and explicit button types across list views to improve keyboard and screen reader support
- localize the new search labels in both English and Spanish resource files

## Testing
- yarn lint

## PR Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68deba0b81d48330be8a024f6275b9de