### PR TITLE
docs: integrate legacy markdown into starlight site

### DIFF
--- a/docs/src/content/docs/getting-started/docs-site.md
+++ b/docs/src/content/docs/getting-started/docs-site.md
@@ -1,3 +1,11 @@
+---
+title: "Ebal v2 Documentation Site"
+description: "Install dependencies and run the Astro + Starlight documentation locally."
+sidebar:
+  label: "Docs site"
+  order: 10
+---
+
 # Ebal v2 Documentation Site
 
 This directory hosts the Astro + Starlight documentation site for Every Breath And Life (Ebal) v2. The site is file-system driven, so the sidebar automatically reflects the structure under `src/content/docs`.

--- a/docs/src/content/docs/how-to/production-deployment.md
+++ b/docs/src/content/docs/how-to/production-deployment.md
@@ -1,3 +1,10 @@
+---
+title: "Production Deployment Guide"
+description: "Deploy the EBAL web and API containers to production environments."
+sidebar:
+  label: "Deploy to production"
+---
+
 # Production Deployment Guide
 
 This guide describes how to deploy the Every Breath And Life (EBAL) application to production environments using the published Docker images for the web front-end and API. Follow the platform-specific instructions that match your target host.

--- a/docs/src/content/docs/manuals/authentication.md
+++ b/docs/src/content/docs/manuals/authentication.md
@@ -1,3 +1,10 @@
+---
+title: "Authentication & Authorization"
+description: "Configure security, understand role capabilities, and validate session flows."
+sidebar:
+  label: "Authentication"
+---
+
 # Authentication & Authorization
 
 This document covers how authentication is configured, which roles can access specific APIs, and how to verify session flows end-to-end.

--- a/docs/src/content/docs/reference/a11y/baseline.md
+++ b/docs/src/content/docs/reference/a11y/baseline.md
@@ -1,3 +1,10 @@
+---
+title: "Accessibility Linting Baseline"
+description: "Understand the shared JSX a11y lint rules and how to run the checks locally."
+sidebar:
+  label: "Linting baseline"
+---
+
 # Accessibility linting baseline
 
 We use [`eslint-plugin-jsx-a11y`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y) to enforce web accessibility affordances in React code. The shared ESLint preset (`packages/config/eslint.cjs`) now extends `plugin:jsx-a11y/strict`, which surfaces high-impact issues without requiring component refactors.

--- a/docs/src/content/docs/reference/a11y/checklist.md
+++ b/docs/src/content/docs/reference/a11y/checklist.md
@@ -1,3 +1,10 @@
+---
+title: "Accessibility Checklists"
+description: "Quick reference to review critical accessibility behaviors before shipping."
+sidebar:
+  label: "Checklists"
+---
+
 # Accessibility Checklists
 
 Use these quick-reference checklists during reviews to cover critical accessibility behaviors before a feature ships.

--- a/docs/src/content/docs/reference/a11y/colors.md
+++ b/docs/src/content/docs/reference/a11y/colors.md
@@ -1,3 +1,10 @@
+---
+title: "Color Contrast Guard"
+description: "Verify theme token pairings meet WCAG contrast requirements during development."
+sidebar:
+  label: "Color contrast"
+---
+
 # Color contrast guard
 
 Our design tokens rely on paired foreground/background colors. During development we automatically verify that the pairings satisfy WCAG 2.1 AA contrast for normal text.

--- a/docs/src/content/docs/reference/administering-users.md
+++ b/docs/src/content/docs/reference/administering-users.md
@@ -1,3 +1,10 @@
+---
+title: "Administering Users"
+description: "Manage accounts through the admin API endpoints without touching the database."
+sidebar:
+  label: "Admin users"
+---
+
 # Administering Users
 
 The `/api/v1/admin/users` endpoints allow administrators to manage accounts without touching the database directly. All requests require a bearer token with the `ADMIN` role and use the JSON models generated from `spec/openapi.yaml`.

--- a/docs/src/content/docs/reference/hardcoded-strings-migration-checklist.md
+++ b/docs/src/content/docs/reference/hardcoded-strings-migration-checklist.md
@@ -1,3 +1,10 @@
+---
+title: "Hardcoded Strings Migration Checklist"
+description: "Copy-ready PR template to track progress while replacing hardcoded UI strings."
+sidebar:
+  label: "i18n checklist"
+---
+
 # Hardcoded Strings Migration Checklist PR Template
 
 Use this template in pull requests that track removing hardcoded strings from the user interface. Copy the Markdown block below into the PR description and update the checkbox status as features are completed.

--- a/docs/src/content/docs/reference/web-i18n-design.md
+++ b/docs/src/content/docs/reference/web-i18n-design.md
@@ -1,3 +1,10 @@
+---
+title: "Web Internationalization Design"
+description: "Architecture and migration plan for bringing i18n to the React front-end."
+sidebar:
+  label: "Web i18n design"
+---
+
 # Web Internationalization Design Doc
 
 ## Overview

--- a/docs/starlight.config.mjs
+++ b/docs/starlight.config.mjs
@@ -8,6 +8,10 @@ export default {
   customCss: ['./src/styles/global.css'],
   sidebar: [
     {
+      label: 'Getting Started',
+      autogenerate: { directory: 'getting-started' }
+    },
+    {
       label: 'Manuals',
       autogenerate: { directory: 'manuals' }
     },


### PR DESCRIPTION
## Summary
- move existing Markdown content into the Starlight content tree and add frontmatter for sidebar metadata
- organize docs into getting started, manuals, how-to, and reference sections for clearer navigation
- update the Starlight sidebar config to include the new getting started section

## Testing
- `yarn dev`

## PR Checklist (copy and update)
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [x] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68e046dc87c88330983117d9beefafe5