### PR TITLE
docs: add manuals for members, songs, services, and sets

### DIFF
--- a/docs/src/content/docs/manuals/arrangement-editor.mdx
+++ b/docs/src/content/docs/manuals/arrangement-editor.mdx
@@ -1,0 +1,49 @@
+---
+title: "Arrangement Editor Manual"
+description: "Craft accurate charts with live ChordPro previews and transposition tools."
+sidebar:
+  group: Manuals
+  label: "Arrangement Editor"
+  order: 3
+---
+
+# Arrangement Editor
+
+## Overview
+The Arrangement Editor is where you capture the musical specifics for each song version. It pairs a structured form for key, tempo, and meter with a live ChordPro preview that mirrors what musicians will see in services, sets, and printouts.
+
+## Prerequisites
+- Admin or Planner role with access to song management.
+- A song selected so you can create or edit its arrangements.
+
+## Step-by-step
+1. **Set the musical key.** Enter the base key (e.g., `G`) to define the arrangement’s starting point.
+2. **Add tempo and meter.** Optionally include BPM (30–300) and a meter such as `4/4` or `6/8` to inform rehearsal pacing.
+3. **Paste ChordPro lyrics.** Use the lyrics textarea for chords like `[G]` inline with lyrics. The editor normalizes line endings automatically.
+4. **Check the preview.** Watch the right-hand pane as you type to confirm chords align above lyrics or inline based on your layout selection.
+5. **Use transpose controls.** Test different keys with the **Transpose Up/Down** buttons; the preview updates instantly without altering the stored chart.
+6. **Switch sharps/flats.** Toggle between enharmonic spellings to suit your team’s preference, especially when testing transpositions.
+7. **Adjust layout.** Choose **Above** to show chords above lyrics (default) or **Inline** to embed them directly in the text.
+8. **Save the arrangement.** Submit the form to make the arrangement available in services, song sets, and plan exports.
+
+![Screenshot: Arrangement editor](../images/arrangement-editor-step-1.png)
+
+## Examples
+- **Simple verse with directive:**
+  ```chordpro
+  {title: Great Is Thy Faithfulness}
+  {comment: Verse 1}
+  [C]Great is Thy [F]faithfulness, [C]O God my [G]Father
+  ```
+- **Preview testing:** Transpose the chart up two semitones to verify Bb instruments still read comfortable shapes.
+
+## Tips & Best Practices
+- Keep one arrangement per distinct key or instrumentation so transposition history stays clear.
+- Use `{comment:}` blocks for band cues and `{title:}` for section headers; the preview renders both.
+- Remember that transpose and sharp/flat toggles are for preview only—stored data remains in the key you set.
+- If you copy lyrics from another source, double-check spacing; empty lines show as intentional breaks in the preview.
+
+## Related
+- [Songs & Arrangements Manual](./songs-arrangements)
+- [Song Sets Manual](./song-sets)
+- [Services Manual](./services)

--- a/docs/src/content/docs/manuals/members-groups.mdx
+++ b/docs/src/content/docs/manuals/members-groups.mdx
@@ -1,0 +1,43 @@
+---
+title: "Members & Groups Manual"
+description: "Keep your roster organized and align people into serving teams."
+sidebar:
+  group: Manuals
+  label: "Members & Groups"
+  order: 1
+---
+
+# Members & Groups
+
+## Overview
+The Members and Groups areas help you manage everyone involved in worship ministry and assign them to the teams they serve with. Use these pages to keep contact details current, track instruments, and curate focused groups for scheduling.
+
+## Prerequisites
+- Admin or Planner role to create, edit, or delete members and groups.
+- Member records for each person you intend to assign to a group.
+
+## Step-by-step
+1. **Review the member list.** Use the search bar to filter by name or instrument, then page through results if you manage a large roster.
+2. **Add a new member.** Select **New Member**, fill in display name, instruments (comma-separated), optional contact info, and birthday fields, then save to create the profile.
+3. **Update or remove members.** Open the context actions beside any member to edit their details or permanently delete the record (after confirming the prompt).
+4. **Create a group.** From the Groups page, choose **New Group**, name the team (e.g., "Vocalists"), and save.
+5. **Assign people to a group.** Open a group, search for a member using the typeahead picker, click **Add**, and repeat for each participant. Remove members with the **Remove** button when they roll off a team.
+6. **Keep rosters current.** Edit group names inline, or adjust member information at any time. Changes sync automatically to the rest of the app.
+
+![Screenshot: Members list](../images/members-groups-step-1.png)
+![Screenshot: Group detail](../images/members-groups-step-2.png)
+
+## Examples
+- **Roster hygiene:** Add instruments like `Vocals, Acoustic Guitar` so planners can filter quickly.
+- **Group assignments:** Create separate groups such as "Band", "Vocals", and "Tech" to drive service planning.
+
+## Tips & Best Practices
+- Use consistent instrument names (e.g., "Electric Guitar" instead of variations) to make search predictable.
+- Capture email and phone details so reminders can go out from one place.
+- Enter birthday month/day to plan celebrations or schedule around key dates.
+- Periodically audit groups to remove inactive members and keep rehearsal communications accurate.
+
+## Related
+- [Services Manual](./services)
+- [Song Sets Manual](./song-sets)
+- [Songs & Arrangements Manual](./songs-arrangements)

--- a/docs/src/content/docs/manuals/services.mdx
+++ b/docs/src/content/docs/manuals/services.mdx
@@ -1,0 +1,49 @@
+---
+title: "Services Manual"
+description: "Plan each gathering from outline to printable run sheet."
+sidebar:
+  group: Manuals
+  label: "Services"
+  order: 4
+---
+
+# Services
+
+## Overview
+The Services workspace lets you map out an entire worship gathering. Build a plan by adding songs, readings, and notes, drag items into a meaningful flow, and generate both shareable and print-friendly views for your team.
+
+## Prerequisites
+- Admin or Planner role to create and modify services.
+- Songs and arrangements already in your catalog for music items.
+
+## Step-by-step
+1. **Create the service.** From the Services list, click **New Service**, set the start date/time and optional location, then save.
+2. **Filter the schedule.** Use search and date filters to find existing services quickly.
+3. **Open the plan builder.** Select a service to reach the detail page, then use the left column to add plan items.
+4. **Add items.** Choose the item type:
+   - **Song:** Pick a song, select an arrangement, review the key summary preview, and add optional notes.
+   - **Reading or Note:** Enter free-form notes (Scripture references, transitions, announcements).
+5. **Organize the flow.** Drag the handle on each item to reorder. Changes save automatically in the background.
+6. **Edit notes in place.** Update any item’s notes field; blur the textarea to persist your changes.
+7. **Manage the service.** Use the action buttons to edit service metadata, remove items, or delete the service when it’s no longer needed.
+8. **Share the plan.** Click **Plan View** to open a read-only page (URL includes a `share` token) that leaders can distribute.
+9. **Print the run sheet.** Select **Print** for a formatting-optimized layout and trigger your browser’s print dialog.
+
+![Screenshot: Service plan builder](../images/services-step-1.png)
+![Screenshot: Printable service plan](../images/services-step-2.png)
+
+## Examples
+- Draft a Sunday gathering with songs, a Scripture reading, a communion note, and benediction instructions in separate plan items.
+- Share the plan link with volunteers so they can view the order without logging in (the share token controls access).
+
+## Tips & Best Practices
+- Add notes describing transitions (e.g., "Acoustic vamp into prayer") so everyone knows what happens between songs.
+- The song preview shows key, tempo, and meter pulled from the arrangement—use it to verify you picked the right version.
+- Keep drag-and-drop tidy by collapsing sections you’re done editing before moving on to the next block.
+- Use the plan’s print view during rehearsal to capture last-minute annotations directly on paper.
+
+## Related
+- [Songs & Arrangements Manual](./songs-arrangements)
+- [Arrangement Editor Manual](./arrangement-editor)
+- [Song Sets Manual](./song-sets)
+- [Members & Groups Manual](./members-groups)

--- a/docs/src/content/docs/manuals/song-sets.mdx
+++ b/docs/src/content/docs/manuals/song-sets.mdx
@@ -1,0 +1,45 @@
+---
+title: "Song Sets Manual"
+description: "Assemble reusable song sequences with key-aware previews."
+sidebar:
+  group: Manuals
+  label: "Song Sets"
+  order: 5
+---
+
+# Song Sets
+
+## Overview
+Song Sets let you bundle arrangements into reusable sequences for nights of worship, youth services, or recurring gatherings. Each item tracks transpose and capo adjustments, so you can drop the set into a service with confidence.
+
+## Prerequisites
+- Admin or Planner role to manage song sets.
+- Songs and arrangements prepared in the catalog.
+
+## Step-by-step
+1. **Create a set.** From the Song Sets list, click **New Set**, name it (e.g., “Youth Night Opener”), and save.
+2. **Open the set builder.** Select the set to view its detail page with add-and-arrange tools.
+3. **Pick a song.** Use the song search input to find the title you want.
+4. **Choose an arrangement.** Select the specific arrangement; a preview line shows song title, key, tempo, and meter.
+5. **Set transpose and capo.** Enter semitone shifts (−6 to +6) and capo position (0–7). The key summary updates to reflect sounding and shape keys.
+6. **Add the item.** Click **Add to set** to append it to the list in order.
+7. **Reorder items.** Drag the handle beside any item to rearrange the set; changes persist immediately.
+8. **Tweak existing items.** Adjust transpose/capo sliders or remove songs inline. Toggle the flats/sharps control at the top to view keys the way your team prefers.
+9. **Edit set details.** Rename the set from the action menu if its focus changes over time.
+
+![Screenshot: Song set builder](../images/song-sets-step-1.png)
+
+## Examples
+- **Label preview:** An item might display “Living Hope — Key E • 72 BPM • 4/4” with a key summary “Key E → F (+1), Capo 2 (shapes in D).”
+- **Seasonal reuse:** Build an “Advent Morning” set once, then add it to multiple December services without reconfiguring keys.
+
+## Tips & Best Practices
+- Use the flats toggle when planning for horn sections; they can confirm enharmonic spellings instantly.
+- Keep transpose adjustments within comfortable ranges (the editor clamps at ±6 semitones to help).
+- Leverage sets as starting points for services—copy the song order, then add readings or notes per service.
+- Remove unused items promptly so the arrangement cache stays focused on the charts you actually use.
+
+## Related
+- [Songs & Arrangements Manual](./songs-arrangements)
+- [Arrangement Editor Manual](./arrangement-editor)
+- [Services Manual](./services)

--- a/docs/src/content/docs/manuals/songs-arrangements.mdx
+++ b/docs/src/content/docs/manuals/songs-arrangements.mdx
@@ -1,0 +1,43 @@
+---
+title: "Songs & Arrangements Manual"
+description: "Build a reliable worship song catalog and keep arrangements in sync."
+sidebar:
+  group: Manuals
+  label: "Songs & Arrangements"
+  order: 2
+---
+
+# Songs & Arrangements
+
+## Overview
+Use the Songs area to curate your ministry songbook, record authorship and CCLI details, and manage multiple arrangements per song. Arrangements store key musical data—keys, tempo, meter, and ChordPro lyrics—so the whole team stays aligned.
+
+## Prerequisites
+- Admin or Planner role to add or edit songs and arrangements.
+- At least one arrangement per song before it can be scheduled in services or sets.
+
+## Step-by-step
+1. **Search your catalog.** Filter by title or apply a tag chip to narrow the list. Click a song title to open its detail page.
+2. **Add a song.** Select **New Song**, supply the title, optional CCLI number, author, default key, and comma-separated tags, then save.
+3. **Edit or delete songs.** Use the actions beside each row to update details or remove a song you no longer use.
+4. **Review arrangements.** On a song’s detail page, view existing arrangements in table form, including key, BPM, and meter.
+5. **Create an arrangement.** Choose **Add Arrangement**, then use the editor to set the musical key, tempo, meter, and paste your ChordPro lyrics. Save when the preview looks correct.
+6. **Update or remove arrangements.** Open the action buttons in the arrangement list to tweak details or delete the entry entirely.
+
+![Screenshot: Songs table](../images/songs-arrangements-step-1.png)
+![Screenshot: Song detail](../images/songs-arrangements-step-2.png)
+
+## Examples
+- Use tags such as `Advent`, `Upbeat`, or `Communion` to build quick thematic filters.
+- Track CCLI numbers so reporting can happen directly from the catalog.
+
+## Tips & Best Practices
+- Keep default keys accurate; downstream tools (sets, services) use them when suggesting transpositions.
+- Maintain one arrangement per key or instrumentation rather than overwriting a single file—this preserves history.
+- When editing, note that lyrics accept full ChordPro syntax, including `{comment:}` and `{title:}` directives.
+- Delete arrangements cautiously; services or sets referencing them will lose access to the chart.
+
+## Related
+- [Arrangement Editor Manual](./arrangement-editor)
+- [Services Manual](./services)
+- [Song Sets Manual](./song-sets)


### PR DESCRIPTION
## Summary
- add a Members & Groups manual that covers roster management and team assignments
- document songs, arrangements, and the dedicated arrangement editor for worship leaders
- write new manuals for services and song sets, including drag-and-drop planning and key management tips

## Testing
- n/a (docs only)

- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [x] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68e054b40d0c8330b2865fdf2d5ebe9a