### PR TITLE
docs: unify es translation placeholder

### DIFF
--- a/docs/src/content/docs/es/getting-started/docs-site.md
+++ b/docs/src/content/docs/es/getting-started/docs-site.md
@@ -5,7 +5,7 @@ sidebar:
   label: "Sitio de docs"
   order: 10
 ---
-> TODO: Traducir el contenido restante al español.
+> TODO: translate body
 
 # Ebal v2 Documentation Site
 

--- a/docs/src/content/docs/es/how-to/create-setlist.mdx
+++ b/docs/src/content/docs/es/how-to/create-setlist.mdx
@@ -2,7 +2,7 @@
 title: Crear una lista de canciones
 description: Arma una lista de adoración con canciones y arreglos.
 ---
-> TODO: Traducir el contenido restante al español.
+> TODO: translate body
 
 
 1. Navigate to the upcoming service in the dashboard.

--- a/docs/src/content/docs/es/how-to/production-deployment.md
+++ b/docs/src/content/docs/es/how-to/production-deployment.md
@@ -4,7 +4,7 @@ description: "Despliega los contenedores web y API de EBAL en entornos de produc
 sidebar:
   label: "Desplegar a producción"
 ---
-> TODO: Traducir el contenido restante al español.
+> TODO: translate body
 
 # Production Deployment Guide
 

--- a/docs/src/content/docs/es/index.mdx
+++ b/docs/src/content/docs/es/index.mdx
@@ -2,7 +2,7 @@
 title: Bienvenido a la documentación de Ebal v2
 description: Oriéntate con la herramienta de planificación de adoración.
 ---
-> TODO: Traducir el contenido restante al español.
+> TODO: translate body
 
 # Ebal v2 Documentation
 

--- a/docs/src/content/docs/es/manuals/arrangement-editor.mdx
+++ b/docs/src/content/docs/es/manuals/arrangement-editor.mdx
@@ -6,7 +6,7 @@ sidebar:
   label: "Editor de arreglos"
   order: 3
 ---
-> TODO: Traducir el contenido restante al español.
+> TODO: translate body
 
 # Arrangement Editor
 

--- a/docs/src/content/docs/es/manuals/authentication.md
+++ b/docs/src/content/docs/es/manuals/authentication.md
@@ -4,7 +4,7 @@ description: "Configura la seguridad, comprende las capacidades de los roles y v
 sidebar:
   label: "Autenticación"
 ---
-> TODO: Traducir el contenido restante al español.
+> TODO: translate body
 
 # Authentication & Authorization
 

--- a/docs/src/content/docs/es/manuals/members-groups.mdx
+++ b/docs/src/content/docs/es/manuals/members-groups.mdx
@@ -6,7 +6,7 @@ sidebar:
   label: "Miembros y grupos"
   order: 1
 ---
-> TODO: Traducir el contenido restante al español.
+> TODO: translate body
 
 # Members & Groups
 

--- a/docs/src/content/docs/es/manuals/service-planning.mdx
+++ b/docs/src/content/docs/es/manuals/service-planning.mdx
@@ -2,7 +2,7 @@
 title: Manual de planificación de servicios
 description: Traza los servicios de adoración desde el primer borrador hasta la hoja final.
 ---
-> TODO: Traducir el contenido restante al español.
+> TODO: translate body
 
 This section will grow to cover end-to-end planning workflows, from song discovery through final service run sheets.
 

--- a/docs/src/content/docs/es/manuals/services.mdx
+++ b/docs/src/content/docs/es/manuals/services.mdx
@@ -6,7 +6,7 @@ sidebar:
   label: "Servicios"
   order: 4
 ---
-> TODO: Traducir el contenido restante al español.
+> TODO: translate body
 
 # Services
 

--- a/docs/src/content/docs/es/manuals/song-sets.mdx
+++ b/docs/src/content/docs/es/manuals/song-sets.mdx
@@ -6,7 +6,7 @@ sidebar:
   label: "Conjuntos de canciones"
   order: 5
 ---
-> TODO: Traducir el contenido restante al español.
+> TODO: translate body
 
 # Song Sets
 

--- a/docs/src/content/docs/es/manuals/songs-arrangements.mdx
+++ b/docs/src/content/docs/es/manuals/songs-arrangements.mdx
@@ -6,7 +6,7 @@ sidebar:
   label: "Canciones y arreglos"
   order: 2
 ---
-> TODO: Traducir el contenido restante al español.
+> TODO: translate body
 
 # Songs & Arrangements
 

--- a/docs/src/content/docs/es/reference/a11y/baseline.md
+++ b/docs/src/content/docs/es/reference/a11y/baseline.md
@@ -4,7 +4,7 @@ description: "Comprende las reglas compartidas de linting JSX a11y y cómo ejecu
 sidebar:
   label: "Línea base de linting"
 ---
-> TODO: Traducir el contenido restante al español.
+> TODO: translate body
 
 # Accessibility linting baseline
 

--- a/docs/src/content/docs/es/reference/a11y/checklist.md
+++ b/docs/src/content/docs/es/reference/a11y/checklist.md
@@ -4,7 +4,7 @@ description: "Referencia rápida para revisar comportamientos críticos de acces
 sidebar:
   label: "Listas"
 ---
-> TODO: Traducir el contenido restante al español.
+> TODO: translate body
 
 # Accessibility Checklists
 

--- a/docs/src/content/docs/es/reference/a11y/colors.md
+++ b/docs/src/content/docs/es/reference/a11y/colors.md
@@ -4,7 +4,7 @@ description: "Verifica que las combinaciones de tokens del tema cumplan con los 
 sidebar:
   label: "Contraste de color"
 ---
-> TODO: Traducir el contenido restante al español.
+> TODO: translate body
 
 # Color contrast guard
 

--- a/docs/src/content/docs/es/reference/administering-users.md
+++ b/docs/src/content/docs/es/reference/administering-users.md
@@ -4,7 +4,7 @@ description: "Gestiona cuentas a través de los endpoints de la API de administr
 sidebar:
   label: "Usuarios admin"
 ---
-> TODO: Traducir el contenido restante al español.
+> TODO: translate body
 
 # Administering Users
 

--- a/docs/src/content/docs/es/reference/domain-overview.mdx
+++ b/docs/src/content/docs/es/reference/domain-overview.mdx
@@ -2,7 +2,7 @@
 title: Panorama del dominio
 description: Describe cómo Ebal modela miembros, canciones, arreglos y servicios.
 ---
-> TODO: Traducir el contenido restante al español.
+> TODO: translate body
 
 Ebal v2 models core worship planning entities such as members, groups, songs, arrangements, and service plans. Understanding these relationships helps administrators keep data clean and unlock reporting.
 

--- a/docs/src/content/docs/es/reference/hardcoded-strings-migration-checklist.md
+++ b/docs/src/content/docs/es/reference/hardcoded-strings-migration-checklist.md
@@ -4,7 +4,7 @@ description: "Plantilla lista para PR que rastrea el progreso mientras reemplaza
 sidebar:
   label: "Lista i18n"
 ---
-> TODO: Traducir el contenido restante al español.
+> TODO: translate body
 
 # Hardcoded Strings Migration Checklist PR Template
 

--- a/docs/src/content/docs/es/reference/web-i18n-design.md
+++ b/docs/src/content/docs/es/reference/web-i18n-design.md
@@ -4,7 +4,7 @@ description: "Arquitectura y plan de migración para llevar i18n al front-end de
 sidebar:
   label: "Diseño web i18n"
 ---
-> TODO: Traducir el contenido restante al español.
+> TODO: translate body
 
 # Web Internationalization Design Doc
 


### PR DESCRIPTION
## Summary
- Standardized the Spanish locale documentation placeholders to use the `> TODO: translate body` stub across all mirrored Markdown pages.

## Testing
- not run

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68e172979c60833096f82b982db026e5