### PR TITLE
ci: deploy docs to GitHub Pages

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -1,0 +1,75 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: yarn
+          cache-dependency-path: docs/yarn.lock
+
+      - name: Install dependencies
+        working-directory: ./docs
+        run: yarn --frozen-lockfile || yarn
+
+      - name: Determine Astro base and site
+        run: |
+          owner="${GITHUB_REPOSITORY_OWNER}"
+          repo="${GITHUB_REPOSITORY#${owner}/}"
+          if [[ "${repo}" == "${owner}.github.io" ]]; then
+            base="/"
+            site="https://${owner}.github.io"
+          else
+            base="/${repo}"
+            site="https://${owner}.github.io/${repo}"
+          fi
+          echo "ASTRO_BASE=${base}" >> "$GITHUB_ENV"
+          echo "ASTRO_SITE=${site}" >> "$GITHUB_ENV"
+          echo "Configured ASTRO_BASE=${base} and ASTRO_SITE=${site}"
+
+      - name: Build docs
+        working-directory: ./docs
+        run: yarn build
+
+      - name: Disable Jekyll processing
+        run: touch docs/dist/.nojekyll
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+# Documentation Site
+
+## Publishing to GitHub Pages
+
+- **Branch:** `main`
+- **Workflow:** `.github/workflows/docs-pages.yml`
+- **Base/Site configuration:** The deployment workflow inspects the repository name and exports `ASTRO_BASE` and `ASTRO_SITE` before building. Repositories named `<org>.github.io` deploy with `ASTRO_BASE=/` and `ASTRO_SITE=https://<org>.github.io`. All other repositories deploy with `ASTRO_BASE=/<repo>` and `ASTRO_SITE=https://<org>.github.io/<repo>`.
+- **Custom domains:** Place your desired hostname in `docs/public/CNAME` so it is copied into the final `dist` output.
+
+### Local preview
+
+- `yarn dev` — runs the docs locally at `http://localhost:4321` without applying the production base path.
+- `ASTRO_BASE=/myrepo ASTRO_SITE=https://<org>.github.io/myrepo yarn build && yarn preview` — emulates the production build locally with a custom base/site prior to serving the static output.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -2,9 +2,12 @@ import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import starlightConfig from './starlight.config.mjs';
 
+const site = process.env.ASTRO_SITE || 'http://localhost:4321';
+const base = process.env.ASTRO_BASE || '/';
+
 // https://docs.astro.build/en/reference/configuration-reference/
 export default defineConfig({
-  site: 'https://example.com',
-  base: '/',
+  site,
+  base,
   integrations: [starlight(starlightConfig)]
 });


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that builds the `/docs` Astro site and deploys to GitHub Pages
- configure the Astro config to read base and site from deployment environment variables
- document how the GitHub Pages deployment works and how to emulate the production build locally

## Testing
- not run

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [ ] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [x] Feature flags respected (`ebal.*`)
- [x] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68e179628e048330b78940c019881591