### PR TITLE
feat: add ballooncraft openapi spec

### DIFF
--- a/openapi/ballooncraft.yaml
+++ b/openapi/ballooncraft.yaml
@@ -8,11 +8,11 @@ info:
     name: MIT
     url: https://opensource.org/license/mit/
 servers:
-  - url: https://api.ballooncraft.dev
+  - url: https://craft.giftballoons.gt
     description: Production server
 security: []
 paths:
-  /health:
+  /api/v1/health:
     get:
       summary: Check API health
       operationId: getHealth
@@ -33,7 +33,7 @@ paths:
           description: Invalid health check request.
         '503':
           description: Service is unavailable.
-  /designs:
+  /api/v1/designs:
     post:
       summary: Submit a new balloon design request
       operationId: submitDesign
@@ -72,7 +72,7 @@ paths:
                 format: uri
         '400':
           description: Invalid design submission.
-  /designs/{id}:
+  /api/v1/designs/{id}:
     get:
       summary: Retrieve a design request status
       operationId: getDesign


### PR DESCRIPTION
## Summary
- seed the Ballooncraft OpenAPI description with health and design endpoints
- define reusable components for design status, palette references, and template references

## Testing
- npx @redocly/cli lint openapi/ballooncraft.yaml

## Checklist
- [ ] Lints & tests pass: API (`mvn verify`), Web (`yarn build && tsc -p .`)
- [ ] DB: New Flyway migration added (if schema changed)
- [x] API: OpenAPI spec updated; generated new sources
- [ ] Web: Loading/error states; basic a11y; responsive layout
- [ ] Feature flags respected (`ebal.*`)
- [ ] Docs updated (`README.md` or `/docs/*`)


------
https://chatgpt.com/codex/tasks/task_e_68e56cba2e6c8330b6e9ba45496e97b9